### PR TITLE
Change output of aim auth command to only contain key in stdout

### DIFF
--- a/aim/cli/auth/commands.py
+++ b/aim/cli/auth/commands.py
@@ -13,6 +13,6 @@ def auth(address):
     public_key = keys['public_key']
 
     click.echo(click.style('Your public key for {}'.format(address),
-                           fg='yellow'))
+                           fg='yellow'), err=True)
     click.echo(public_key)
     click.echo()


### PR DESCRIPTION
* Print any additional information to stderr so stout can be piped to
other commnds
* This change makes easy to copy the key to paste-buffer using tools
like `pbcopy` or `xclip`

Examples of usage:

```
aim auth -a <url> | pbcopy # for macOS
aim auth -a <url> |  xclip -selection clipboard # for Linux with X11
``` 


