### PR TITLE
Add CLI main entry point in cli.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Add direct CLI entry point in `cli/cli.py` (gorarakelyan)
 - Add disk space usage tracking (gorarakelyan)
 - Add profiler support for Keras (gorarakelyan)
 - Add TensorFlow graph nodes profiler (gorarakelyan)

--- a/aim/cli/cli.py
+++ b/aim/cli/cli.py
@@ -34,3 +34,7 @@ cli_entry_point.add_command(commit_commands.commit, COMMIT_NAME)
 cli_entry_point.add_command(reset_commands.reset, RESET_NAME)
 cli_entry_point.add_command(version_commands.version, VERSION_NAME)
 cli_entry_point.add_command(view_commands.view, VIEW_NAME)
+
+
+if __name__ == '__main__':
+    cli_entry_point()


### PR DESCRIPTION
Access aim command line interface by running:
`python aim/cli/cli.py --help`