### PR TITLE
[WIP] Add tensorflow 1.x integration to track wights & biases distributions via aim SDK.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,10 +110,13 @@ aim.sublime-*
 .DS_Store
 .idea
 .vim
+.vscode/
+
 
 data
 examples/.aim
 examples/.git
 
-.vscode/
 models/
+
+temp.py

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ aim.sublime-*
 data
 examples/.aim
 examples/.git
+
+.vscode/
+models/

--- a/aim/sdk/artifacts/distribution.py
+++ b/aim/sdk/artifacts/distribution.py
@@ -143,7 +143,7 @@ class WeightsDistribution(ModelDistribution):
                 ]
                 else:
                     raise ValueError(f"Couldn't trak the {param_id} for {layer_name}")
-            return layers
+        return layers
 
 
 class GradientsDistribution(ModelDistribution):

--- a/aim/sdk/artifacts/distribution.py
+++ b/aim/sdk/artifacts/distribution.py
@@ -121,25 +121,29 @@ class WeightsDistribution(ModelDistribution):
                             bias_hist[1].tolist(),
                         ]
         else:
-            params = model
-            num_of_layers = int(len(params) / 2)
-            weights = model[num_of_layers: ]
-            biases = model[: num_of_layers]
-            for i in range(num_of_layers):
-                layer_name = f"Layer{i+1}"
-                weight_arr = weights[i]
-                weight_hist = np.histogram(weight_arr, 30)
-                layers[layer_name]['weight'] = [
+            weight_id = "kernel"
+            bias_id = "bias"
+            for tr_var, param in model:
+                if "/" not in tr_var.name:
+                    continue
+                layer_name, param_id = tr_var.name.split("/")
+                if layer_name not in layers:
+                    layers[layer_name] = {}
+                if weight_id in param_id:
+                    weight_hist = np.histogram(param, 30)
+                    layers[layer_name]["weight"] = [
                     weight_hist[0].tolist(),
                     weight_hist[1].tolist(),
                 ]
-                bias_arr = biases[i]
-                bias_hist = np.histogram(bias_arr, 30)
-                layers[layer_name]['bias'] = [
+                elif bias_id in param_id:
+                    bias_hist = np.histogram(param, 30)
+                    layers[layer_name]['bias'] = [
                     bias_hist[0].tolist(),
                     bias_hist[1].tolist(),
                 ]
-        return layers
+                else:
+                    raise ValueError(f"Couldn't trak the {param_id} for {layer_name}")
+            return layers
 
 
 class GradientsDistribution(ModelDistribution):

--- a/aim/sdk/artifacts/distribution.py
+++ b/aim/sdk/artifacts/distribution.py
@@ -120,7 +120,25 @@ class WeightsDistribution(ModelDistribution):
                             bias_hist[0].tolist(),
                             bias_hist[1].tolist(),
                         ]
-
+        else:
+            params = model
+            num_of_layers = int(len(params) / 2)
+            weights = model[num_of_layers: ]
+            biases = model[: num_of_layers]
+            for i in range(num_of_layers):
+                layer_name = f"Layer{i+1}"
+                weight_arr = weights[i]
+                weight_hist = np.histogram(weight_arr, 30)
+                layers[layer_name]['weight'] = [
+                    weight_hist[0].tolist(),
+                    weight_hist[1].tolist(),
+                ]
+                bias_arr = biases[i]
+                bias_hist = np.histogram(bias_arr, 30)
+                layers[layer_name]['bias'] = [
+                    bias_hist[0].tolist(),
+                    bias_hist[1].tolist(),
+                ]
         return layers
 
 

--- a/aim/sdk/artifacts/utils.py
+++ b/aim/sdk/artifacts/utils.py
@@ -1,5 +1,61 @@
+import numpy as np
+
+
 def get_pt_tensor(t):
     if hasattr(t, 'is_cuda') and t.is_cuda:
         return t.cpu()
 
     return t
+
+
+class TfUtils:
+
+    #FIXME:  statics as properties, and __init__(sess)
+    
+    @staticmethod    
+    def get_tf_t_vars(sess):
+        """Returns all trainable variables in the tf.session"""
+        return sess.graph.get_collection("trainable_variables")
+    
+    @staticmethod
+    def get_tf_t_vals(sess):
+        """Returns all trainable values (parameters) in the tf.session"""
+        return sess.run(
+            TfUtils.get_tf_t_vars(sess)
+            )
+
+    @staticmethod
+    def _is_op_defined(t_vars) -> bool:
+        """Checks whether trainable variables are tf.Variables"""
+        return all(t_var.name.startswith("Variable") for t_var in t_vars)
+    
+    @staticmethod
+    def get_vals_hist(t_vals, num_bin):
+        """Creates and returns hist"""
+        t_vals_hist = np.histogram(t_vals, num_bin)
+        return [ t_vals_hist[0].tolist(),
+                 t_vals_hist[1].tolist(),
+                 ]
+
+    @staticmethod
+    def get_layers(t_vars):
+        """Return the names of layers in net."""
+        if TfUtils._is_op_defined(t_vars):
+            return [t_var.name for t_var in t_vars][: len(t_vars) // 2 ]
+        return np.unique([t_var.name.split("/")[0] for t_var in t_vars if "/" in t_var.name])
+
+    @staticmethod
+    def get_weights(t_vars, sess):
+        """Given the seesion and trainable variables, returns weights"""
+        if TfUtils._is_op_defined(t_vars):
+            num_of_layers = len(TfUtils.get_layers(t_vars))
+            return [sess.run(t_var) for t_var in t_vars[ : num_of_layers]]
+        return [sess.run(t_var) for t_var in t_vars if "kernel" in t_var.name]
+
+    @staticmethod
+    def get_biases(t_vars, sess):
+        """Given the seesion and trainable variables, returns biases"""
+        if TfUtils._is_op_defined(t_vars):
+            num_of_layers = len(TfUtils.get_layers(t_vars))
+            return [sess.run(t_var) for t_var in t_vars[num_of_layers : ]]
+        return [sess.run(t_var) for t_var in t_vars if "bias" in t_var.name]

--- a/examples/retrieve_metrics.py
+++ b/examples/retrieve_metrics.py
@@ -27,3 +27,4 @@ for r in storage.read_records('accuracy', slice(None, None)):
     print('accuracy', base_pb, metric_pb)
 
 storage.close()
+

--- a/examples/tf_track_distribution.py
+++ b/examples/tf_track_distribution.py
@@ -3,6 +3,7 @@ from aim import track
 
 import tensorflow as tf
 
+
 # Import MNIST data
 from tensorflow.examples.tutorials.mnist import input_data
 mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
@@ -22,32 +23,23 @@ num_classes = 10 # MNIST total classes (0-9 digits)
 X = tf.placeholder("float", [None, num_input])
 Y = tf.placeholder("float", [None, num_classes])
 
-# Store layers weight & bias
-weights = {
-    'h1': tf.Variable(tf.random_normal([num_input, n_hidden_1])),
-    'h2': tf.Variable(tf.random_normal([n_hidden_1, n_hidden_2])),
-    'out': tf.Variable(tf.random_normal([n_hidden_2, num_classes]))
-}
-biases = {
-    'b1': tf.Variable(tf.random_normal([n_hidden_1])),
-    'b2': tf.Variable(tf.random_normal([n_hidden_2])),
-    'out': tf.Variable(tf.random_normal([num_classes]))
-}
+# Need only if layers are created NOT BY tf.layers object
+# weights = tf.Variable(tf.random_normal([num_input, n_hidden_1]))
+# biases = tf.Variable(tf.random_normal([n_hidden_1]))
 
 
-# Create model
 def neural_net(x):
-    # Hidden fully connected layer with 256 neurons
-    layer_1 = tf.add(tf.matmul(x, weights['h1']), biases['b1'])
+    # Input Layer
+    input_layer = tf.layers.dense(inputs=x, units=num_input)
 
-    # Hidden fully connected layer with 256 neurons
-    layer_2 = tf.add(tf.matmul(layer_1, weights['h2']), biases['b2'])
+    # Hidden fully connected layer with 256 neurons  # can have `name` parameter
+    hidden_1 = tf.layers.dense(inputs=input_layer, units=n_hidden_1, activation=tf.nn.relu)
+    hidden_2 = tf.layers.dense(inputs=hidden_1, units=n_hidden_2, activation=tf.nn.relu)
 
     # Output fully connected layer with a neuron for each class
-    out_layer = tf.matmul(layer_2, weights['out']) + biases['out']
+    out_layer = tf.layers.dense(inputs=hidden_2, units=num_classes)
 
     return out_layer
-
 
 logits = neural_net(X)
 
@@ -78,16 +70,13 @@ with tf.Session() as sess:
                 loss, acc = sess.run([loss_op, accuracy], feed_dict={X: batch_x,
                                                                      Y: batch_y,
                                                                      })
-                params = tf.trainable_variables()
-                param_vals = sess.run(params)
-                track(aim.weights, param_vals)
+                t_vars = tf.trainable_variables()
+                params = sess.run(t_vars)
+                track(aim.weights, zip(t_vars, params))
                 print("Step " + str(step) + ", Epoch " + str(e+1) +
                       ", Minibatch Loss= " +
                       "{:.4f}".format(loss) + ", Training Accuracy= " +
                       "{:.3f}".format(acc))
-    # Final 
-    vars_ = tf.trainable_variables()
-    vars_vals = sess.run(vars_)
     print("Optimization Finished!")
 
     # Calculate accuracy for MNIST test images
@@ -96,5 +85,3 @@ with tf.Session() as sess:
                                       Y: mnist.test.labels}))
 
 
-# for i in range(len(param_vals)):
-#     print(param_vals[i].shape)

--- a/examples/tf_track_distribution.py
+++ b/examples/tf_track_distribution.py
@@ -1,0 +1,100 @@
+import aim
+from aim import track
+
+import tensorflow as tf
+
+# Import MNIST data
+from tensorflow.examples.tutorials.mnist import input_data
+mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
+
+learning_rate = 0.1
+num_steps = 500
+batch_size = 128
+display_step = 100
+
+# Network Parameters
+n_hidden_1 = 256 # 1st layer number of neurons
+n_hidden_2 = 256 # 2nd layer number of neurons
+num_input = 784 # MNIST data input (img shape: 28*28)
+num_classes = 10 # MNIST total classes (0-9 digits)
+
+# tf Graph input
+X = tf.placeholder("float", [None, num_input])
+Y = tf.placeholder("float", [None, num_classes])
+
+# Store layers weight & bias
+weights = {
+    'h1': tf.Variable(tf.random_normal([num_input, n_hidden_1])),
+    'h2': tf.Variable(tf.random_normal([n_hidden_1, n_hidden_2])),
+    'out': tf.Variable(tf.random_normal([n_hidden_2, num_classes]))
+}
+biases = {
+    'b1': tf.Variable(tf.random_normal([n_hidden_1])),
+    'b2': tf.Variable(tf.random_normal([n_hidden_2])),
+    'out': tf.Variable(tf.random_normal([num_classes]))
+}
+
+
+# Create model
+def neural_net(x):
+    # Hidden fully connected layer with 256 neurons
+    layer_1 = tf.add(tf.matmul(x, weights['h1']), biases['b1'])
+
+    # Hidden fully connected layer with 256 neurons
+    layer_2 = tf.add(tf.matmul(layer_1, weights['h2']), biases['b2'])
+
+    # Output fully connected layer with a neuron for each class
+    out_layer = tf.matmul(layer_2, weights['out']) + biases['out']
+
+    return out_layer
+
+
+logits = neural_net(X)
+
+# Define loss and optimizer
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+    logits=logits, labels=Y))
+optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
+train_op = optimizer.minimize(loss_op)
+
+# Evaluate model (with test logits, for dropout to be disabled)
+correct_pred = tf.equal(tf.argmax(logits, 1), tf.argmax(Y, 1))
+accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))
+
+# Initialize the variables (i.e. assign their default value)
+init = tf.global_variables_initializer()
+
+with tf.Session() as sess:
+    # Run the initializer
+    sess.run(init)
+
+    for e in range(10):
+        for step in range(1, num_steps+1):
+            batch_x, batch_y = mnist.train.next_batch(batch_size)
+            # Run optimization op (backprop)
+            sess.run(train_op, feed_dict={X: batch_x, Y: batch_y})
+            if step % display_step == 0 or step == 1:
+                # Calculate batch loss and accuracy
+                loss, acc = sess.run([loss_op, accuracy], feed_dict={X: batch_x,
+                                                                     Y: batch_y,
+                                                                     })
+                params = tf.trainable_variables()
+                param_vals = sess.run(params)
+                track(aim.weights, param_vals)
+                print("Step " + str(step) + ", Epoch " + str(e+1) +
+                      ", Minibatch Loss= " +
+                      "{:.4f}".format(loss) + ", Training Accuracy= " +
+                      "{:.3f}".format(acc))
+    # Final 
+    vars_ = tf.trainable_variables()
+    vars_vals = sess.run(vars_)
+    print("Optimization Finished!")
+
+    # Calculate accuracy for MNIST test images
+    print("Testing Accuracy:", \
+        sess.run(accuracy, feed_dict={X: mnist.test.images,
+                                      Y: mnist.test.labels}))
+
+
+# for i in range(len(param_vals)):
+#     print(param_vals[i].shape)


### PR DESCRIPTION
Following the pattern of names and logic in the `examples` package, `tf_track_distribution.py` is added. Also, corresponding changes are made in the `aim/sdk/artefacts/distribution` module. For now, we will just assume, that if the NN module is not derived from `pytorch`, then it is created by `tensorflow`. For complete tracking, layer names should be added too. 

**PR UPDATE 2**
Layer names are track via low API `tf.layers`. It works for any model, which layers are instantiated by `tf.layers`. 
 
Next steps:
[+] - Track graph operation names
[+]- Track graph trainable variables' values
[  ] - Add condition checking if model is built in tensorflow


**PR UPDATE 3**
`track(<artefact>, session)` is applied. API takes  tf.Session as input, and tracks weights and biases for both ops and layers. 

Next steps:
1. Notify users about  layer name default generation (as in `tf`), if they didn't name their variables, or didn't enscope the variables or operations.