### PR TITLE
Add keras 2.x integration to track wights & biases distributions of ML model via aim SDK.

### DIFF
--- a/aim/sdk/artifacts/distribution.py
+++ b/aim/sdk/artifacts/distribution.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Any
 
-from aim.engine.utils import is_pytorch_module, get_module
+from aim.engine.utils import is_pytorch_module, get_module, is_keras_model
 from aim.sdk.artifacts.artifact import Artifact
 from aim.sdk.artifacts.record import Record, RecordCollection
 from aim.sdk.artifacts.utils import get_pt_tensor
@@ -120,7 +120,27 @@ class WeightsDistribution(ModelDistribution):
                             bias_hist[0].tolist(),
                             bias_hist[1].tolist(),
                         ]
+        elif is_keras_model(model):
+            for i in range(len(model.layers)):
+                #Choose Layer Name
+                layer_name = model.layers[i].name # Example: "dense_1" (For the first dense layer)
+                layers[layer_name] = {}
 
+                weights, biases = model.layers[i].get_weights()
+                weights = np.array(weights)
+                biases = np.array(biases)
+                weight_hist = np.histogram(weights, 30) #30 is chosen based on pytorch integration
+                bias_hist = np.histogram(biases, 30)
+
+                layers[layer_name]['weight'] = [
+                    weight_hist[0].tolist(),
+                    weight_hist[1].tolist()
+                ]
+                layers[layer_name]['bias'] = [
+                    bias_hist[0].tolist(),
+                    bias_hist[1].tolist()
+                ]
+                
         return layers
 
 

--- a/aim/sdk/track.py
+++ b/aim/sdk/track.py
@@ -4,6 +4,7 @@ from aim.engine.aim_repo import AimRepo
 from aim.sdk.artifacts import *
 from aim.sdk.artifacts.artifact_writer import ArtifactWriter
 import aim.logger
+import keras
 
 
 repo = None
@@ -40,3 +41,19 @@ def track(artifact_name: str, *args, **kwargs):
     writer.save(repo, inst)
 
     return inst
+
+class TrackCallBack(keras.callbacks.Callback):
+
+  def __init__(self, k=1):
+      super(TrackCallBack, self).__init__()
+      self.k = k
+
+  def on_epoch_end(self, epoch, logs=None):
+    track(aim.weights, model)
+
+  def on_train_batch_end(self, batch, logs=None):
+    if self.k != 0 and batch % self.k == 0:
+        track(aim.weights, model)
+
+
+

--- a/examples/keras_track_distribution.py
+++ b/examples/keras_track_distribution.py
@@ -1,0 +1,56 @@
+import aim
+from aim import track
+
+import numpy as np
+import mnist
+from keras.models import Sequential
+from keras.layers import Dense
+from keras.utils import to_categorical
+
+"""
+Citation for Keras Example Model: victorzhou.com/blog/keras-neural-network-tutorial/
+"""
+
+train_images = mnist.train_images()
+train_labels = mnist.train_labels()
+test_images = mnist.test_images()
+test_labels = mnist.test_labels()
+
+# Normalize the images.
+train_images = (train_images / 255) - 0.5
+test_images = (test_images / 255) - 0.5
+
+# Flatten the images.
+train_images = train_images.reshape((-1, 784))
+test_images = test_images.reshape((-1, 784))
+
+# Build the model.
+model = Sequential([
+  Dense(64, activation='relu', input_shape=(784,)),
+  Dense(64, activation='relu'),
+  Dense(10, activation='softmax'),
+])
+
+# Compile the model.
+model.compile(
+  optimizer='adam',
+  loss='categorical_crossentropy',
+  metrics=['accuracy'],
+)
+
+# Train the model.
+model.fit(
+  train_images,
+  to_categorical(train_labels),
+  epochs=5,
+  batch_size=32,
+)
+
+# Evaluate the model.
+model.evaluate(
+  test_images,
+  to_categorical(test_labels)
+)
+
+weights, biases = model.layers[0].get_weights()
+track(aim.weights, model)

--- a/examples/keras_track_distribution.py
+++ b/examples/keras_track_distribution.py
@@ -1,6 +1,5 @@
 import aim
-from aim import track
-
+from aim import track, TrackCallBack
 import numpy as np
 import mnist
 import keras
@@ -12,9 +11,7 @@ from keras.utils import to_categorical
 Citation for Keras Example Model: victorzhou.com/blog/keras-neural-network-tutorial/
 """
 
-class TrackCallBack(keras.callbacks.Callback):
-  def on_epoch_end(self, epoch, logs=None):
-    track(aim.weights, model)
+
 
 train_images = mnist.train_images()
 train_labels = mnist.train_labels()
@@ -49,7 +46,7 @@ model.fit(
   to_categorical(train_labels),
   epochs=5,
   batch_size=32,
-  callbacks=[TrackCallBack()]
+  callbacks=[TrackCallBack(2)]
 )
 
 # Evaluate the model.

--- a/examples/keras_track_distribution.py
+++ b/examples/keras_track_distribution.py
@@ -3,6 +3,7 @@ from aim import track
 
 import numpy as np
 import mnist
+import keras
 from keras.models import Sequential
 from keras.layers import Dense
 from keras.utils import to_categorical
@@ -10,6 +11,10 @@ from keras.utils import to_categorical
 """
 Citation for Keras Example Model: victorzhou.com/blog/keras-neural-network-tutorial/
 """
+
+class TrackCallBack(keras.callbacks.Callback):
+  def on_epoch_end(self, epoch, logs=None):
+    track(aim.weights, model)
 
 train_images = mnist.train_images()
 train_labels = mnist.train_labels()
@@ -44,6 +49,7 @@ model.fit(
   to_categorical(train_labels),
   epochs=5,
   batch_size=32,
+  callbacks=[TrackCallBack()]
 )
 
 # Evaluate the model.
@@ -51,6 +57,3 @@ model.evaluate(
   test_images,
   to_categorical(test_labels)
 )
-
-weights, biases = model.layers[0].get_weights()
-track(aim.weights, model)


### PR DESCRIPTION
Edit 1: Integrated keras 2.x with aim using aim sdk by editing the get_layers method in aim/sdk/artifacts/distribution.py. I was able to access the weights and biases in the keras model and used the layers dictionary to hold the distribution.

Edit 2: Created examples/keras_track_distribution.py which runs an example MNIST Keras model and tracks the weights distribution at the end of the training.