### PR TITLE
Hoist context table state to the parent container

### DIFF
--- a/aim/web/ui/src/components/hub/ContextTable/ContextTable.js
+++ b/aim/web/ui/src/components/hub/ContextTable/ContextTable.js
@@ -5,51 +5,18 @@ import PropTypes from 'prop-types';
 
 import UI from '../../../ui';
 import { classNames } from '../../../utils';
-import BarFilter from './components/BarFilter/BarFilter';
 import BarRowHeightSelect from './components/BarRowHeightSelect/BarRowHeightSelect';
 import BarViewModes from '../BarViewModes/BarViewModes';
-import { setItem, getItem } from '../../../services/storage';
-import {
-  CONTEXT_TABLE_CONFIG,
-  TABLE_COLUMNS,
-  TABLE_COLUMNS_WIDTHS,
-} from '../../../config';
 import BarSort from './components/BarSort/BarSort';
 import BarReorder from './components/BarReorder/BarReorder';
 import BarRowVisualization from './components/BarRowVisualization/BarRowVisualization';
-import { ContextTableModel } from './models/ContextTableModel';
 
 function ContextTable(props) {
-  const storageKey = CONTEXT_TABLE_CONFIG.replace('{name}', props.name);
-  let storageVal;
-  try {
-    storageVal = getItem(storageKey);
-    storageVal = JSON.parse(storageVal);
-  } catch (e) {
-    storageVal = {};
-  }
-
   let contextTableContainerRef = useRef();
   let contextTableRef = useRef();
 
-  let [excludedFields, setExcludedFields] = useState(
-    storageVal?.excludedFields ?? [],
-  );
-  let [rowHeightMode, setRowHeightMode] = useState(
-    storageVal?.rowHeightMode ?? 'medium',
-  );
-  let [columnsOrder, setColumnsOrder] = useState({
-    left: [],
-    middle: [],
-    right: [],
-  });
-  let [columnsWidth, setColumnsWidth] = useState(
-    JSON.parse(getItem(TABLE_COLUMNS_WIDTHS))?.[props.name] ?? {},
-  );
-
   function updateColumns(columns, reset = false) {
     let order;
-    const tableColumns = JSON.parse(getItem(TABLE_COLUMNS)) ?? {};
     if (reset) {
       order = {
         left: [],
@@ -68,126 +35,23 @@ function ContextTable(props) {
     } else {
       order = columns;
     }
-    tableColumns[props.name] = order;
-    setColumnsOrder(order);
-    setItem(TABLE_COLUMNS, JSON.stringify(tableColumns));
+    props.setColumnsOrder(order);
   }
 
-  function updateColumnsWidth(colKey, width, reset = false) {
-    const tableColumnsWidths = JSON.parse(getItem(TABLE_COLUMNS_WIDTHS)) ?? {};
-    let columnsWidthClone;
+  function updateColumnsWidths(colKey, width, reset = false) {
+    let columnsWidthsClone;
     if (reset) {
-      columnsWidthClone = _.omit(columnsWidth, [colKey]);
+      columnsWidthsClone = _.omit(props.columnsWidths, [colKey]);
     } else {
-      columnsWidthClone = _.clone(columnsWidth);
-      columnsWidthClone[colKey] = width;
+      columnsWidthsClone = _.clone(props.columnsWidths);
+      columnsWidthsClone[colKey] = width;
     }
-    tableColumnsWidths[props.name] = columnsWidthClone;
-    setItem(TABLE_COLUMNS_WIDTHS, JSON.stringify(tableColumnsWidths));
-    setColumnsWidth(columnsWidthClone);
+    props.setColumnsWidths(columnsWidthsClone);
   }
 
   const height =
     contextTableContainerRef.current?.getBoundingClientRect()?.height;
   const itemMaxHeight = !!height ? height - 50 : null;
-
-  useEffect(() => {
-    const subscription = ContextTableModel.subscribe(
-      ContextTableModel.events.SET_GROUPED_COLUMNS,
-      (data) => {
-        if (props.name === data.name) {
-          const columnsOrderClone = _.cloneDeep(columnsOrder);
-          data.columns.forEach((column) => {
-            if (columnsOrderClone.middle.includes(column)) {
-              columnsOrderClone.middle.splice(
-                columnsOrderClone.middle.indexOf(column),
-                1,
-              );
-              columnsOrderClone.middle.unshift(column);
-            }
-          });
-          updateColumns(columnsOrderClone);
-        }
-      },
-    );
-
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [columnsOrder]);
-
-  useEffect(() => {
-    setItem(
-      storageKey,
-      JSON.stringify({
-        rowHeightMode,
-        excludedFields,
-      }),
-    );
-  }, [rowHeightMode, excludedFields]);
-
-  useEffect(() => {
-    const tableColumns = JSON.parse(getItem(TABLE_COLUMNS))?.[props.name];
-    const order = {
-      left: [],
-      middle: [],
-      right: [],
-    };
-    props.columns.forEach((col) => {
-      if (!!tableColumns && tableColumns.left.includes(col.key)) {
-        order.left.push(col.key);
-      } else if (!!tableColumns && tableColumns.middle.includes(col.key)) {
-        order.middle.push(col.key);
-      } else if (!!tableColumns && tableColumns.right.includes(col.key)) {
-        order.right.push(col.key);
-      } else {
-        if (col.pin === 'left') {
-          order.left.push(col.key);
-        } else if (col.pin === 'right') {
-          order.right.push(col.key);
-        } else {
-          order.middle.push(col.key);
-        }
-      }
-    });
-    order.left.sort((a, b) => {
-      if (!!tableColumns) {
-        if (tableColumns.left.indexOf(b) === -1) {
-          return -1;
-        }
-        if (tableColumns.left.indexOf(a) === -1) {
-          return 1;
-        }
-        return tableColumns.left.indexOf(a) - tableColumns.left.indexOf(b);
-      }
-      return 0;
-    });
-    order.middle.sort((a, b) => {
-      if (!!tableColumns) {
-        if (tableColumns.middle.indexOf(b) === -1) {
-          return -1;
-        }
-        if (tableColumns.middle.indexOf(a) === -1) {
-          return 1;
-        }
-        return tableColumns.middle.indexOf(a) - tableColumns.middle.indexOf(b);
-      }
-      return 0;
-    });
-    order.right.sort((a, b) => {
-      if (!!tableColumns) {
-        if (tableColumns.right.indexOf(b) === -1) {
-          return -1;
-        }
-        if (tableColumns.right.indexOf(a) === -1) {
-          return 1;
-        }
-        return tableColumns.right.indexOf(a) - tableColumns.right.indexOf(b);
-      }
-      return 0;
-    });
-    setColumnsOrder(order);
-  }, [props.columns]);
 
   useEffect(() => {
     if (typeof props.getTableContainerElement === 'function') {
@@ -200,7 +64,7 @@ function ContextTable(props) {
       className={classNames({
         ContextTable: true,
         'ContextTable--displayBar': true,
-        [`ContextTable--${rowHeightMode}`]: true,
+        [`ContextTable--${props.rowHeightMode}`]: true,
       })}
       ref={contextTableContainerRef}
     >
@@ -225,10 +89,10 @@ function ContextTable(props) {
             /> */}
             <BarReorder
               columns={props.columns}
-              columnsOrder={columnsOrder}
+              columnsOrder={props.columnsOrder}
               updateColumns={updateColumns}
-              excludedFields={excludedFields}
-              setExcludedFields={setExcludedFields}
+              excludedFields={props.excludedFields}
+              setExcludedFields={props.setExcludedFields}
               alwaysVisibleColumns={props.alwaysVisibleColumns}
               getParamsWithSameValue={props.getParamsWithSameValue}
             />
@@ -247,8 +111,8 @@ function ContextTable(props) {
               />
             )}
             <BarRowHeightSelect
-              rowHeightMode={rowHeightMode}
-              setRowHeightMode={setRowHeightMode}
+              rowHeightMode={props.rowHeightMode}
+              setRowHeightMode={props.setRowHeightMode}
             />
           </div>
           <div className='ContextTableBar__items ContextTableBar__items--right' />
@@ -257,19 +121,19 @@ function ContextTable(props) {
       <div
         className={classNames({
           ContextTable__table: true,
-          [rowHeightMode]: true,
+          [props.rowHeightMode]: true,
         })}
         ref={contextTableRef}
       >
         <UI.Table
-          excludedFields={excludedFields}
-          setExcludedFields={setExcludedFields}
+          excludedFields={props.excludedFields}
+          setExcludedFields={props.setExcludedFields}
           alwaysVisibleColumns={props.alwaysVisibleColumns}
-          rowHeightMode={rowHeightMode}
-          columnsOrder={columnsOrder}
+          rowHeightMode={props.rowHeightMode}
+          columnsOrder={props.columnsOrder}
           updateColumns={updateColumns}
-          columnsWidth={columnsWidth}
-          updateColumnsWidth={updateColumnsWidth}
+          columnsWidths={props.columnsWidths}
+          updateColumnsWidths={updateColumnsWidths}
           sortFields={props.sortFields}
           setSortFields={props.setSortFields}
           {...props}
@@ -302,6 +166,14 @@ ContextTable.propTypes = {
   alwaysVisibleColumns: PropTypes.array,
   hiddenMetrics: PropTypes.array,
   setHiddenMetrics: PropTypes.func,
+  rowHeightMode: PropTypes.string,
+  setRowHeightMode: PropTypes.func,
+  excludedFields: PropTypes.array,
+  setExcludedFields: PropTypes.func,
+  columnsOrder: PropTypes.object,
+  setColumnsOrder: PropTypes.func,
+  columnsWidths: PropTypes.object,
+  setColumnsWidths: PropTypes.func,
   getParamsWithSameValue: PropTypes.func,
   getTableContainerElement: PropTypes.func,
 };

--- a/aim/web/ui/src/components/hub/ContextTable/ContextTable.js
+++ b/aim/web/ui/src/components/hub/ContextTable/ContextTable.js
@@ -1,6 +1,6 @@
 import './ContextTable.less';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import UI from '../../../ui';

--- a/aim/web/ui/src/screens/hub/HubMainScreen/HubMainScreen.js
+++ b/aim/web/ui/src/screens/hub/HubMainScreen/HubMainScreen.js
@@ -13,8 +13,6 @@ import { setItem, getItem } from '../../../services/storage';
 import {
   USER_LAST_SEARCH_QUERY,
   AIM_QL_VERSION,
-  EXPLORE_PANEL_FLEX_STYLE,
-  EXPLORE_PANEL_VIEW_MODE,
   USER_LAST_EXPLORE_CONFIG,
 } from '../../../config';
 import Panel from './components/Panel/Panel';
@@ -50,15 +48,14 @@ function HubMainScreen(props) {
     height: 0,
     width: 0,
     resizing: false,
-    panelFlex: getItem(EXPLORE_PANEL_FLEX_STYLE),
-    viewMode: getItem(EXPLORE_PANEL_VIEW_MODE) ?? 'resizable',
     searchError: null,
   });
 
-  let { runs, traceList, search, searchInput } =
+  let { runs, traceList, search, searchInput, screen } =
     HubMainScreenModel.useHubMainScreenState([
       HubMainScreenModel.events.SET_RUNS_STATE,
       HubMainScreenModel.events.SET_TRACE_LIST,
+      HubMainScreenModel.events.SET_SCREEN_STATE,
     ]);
 
   const {
@@ -69,6 +66,7 @@ function HubMainScreen(props) {
     setChartFocusedActiveState,
     setChartSettingsState,
     setTraceList,
+    setScreenState,
   } = HubMainScreenModel.emitters;
 
   const { traceToHash } = HubMainScreenModel.helpers;
@@ -120,10 +118,9 @@ function HubMainScreen(props) {
         projectWrapperRef.current.getHeaderHeight() -
         searchBarHeight;
       const flex = height / (state.height - searchBarHeight);
-      setState((s) => ({
-        ...s,
+      setScreenState({
         panelFlex: flex,
-      }));
+      });
     });
   }
 
@@ -508,16 +505,6 @@ function HubMainScreen(props) {
   }, [props.location]);
 
   useEffect(() => {
-    if (state.resizing === false) {
-      setItem(EXPLORE_PANEL_FLEX_STYLE, state.panelFlex);
-    }
-  }, [state.resizing]);
-
-  useEffect(() => {
-    setItem(EXPLORE_PANEL_VIEW_MODE, state.viewMode);
-  }, [state.viewMode]);
-
-  useEffect(() => {
     props.completeProgress();
     updateWindowDimensions();
     window.addEventListener('resize', updateWindowDimensions);
@@ -575,7 +562,7 @@ function HubMainScreen(props) {
       <div
         className={classNames({
           HubMainScreen__grid__body: true,
-          [`HubMainScreen__grid__body--${state.viewMode}`]: true,
+          [`HubMainScreen__grid__body--${screen.viewMode}`]: true,
         })}
         style={{
           height: `${state.height - searchBarHeight}px`,
@@ -595,17 +582,17 @@ function HubMainScreen(props) {
             </div>
           ) : (
             <div className='HubMainScreen__grid__body__blocks'>
-              {state.viewMode !== 'context' && (
+              {screen.viewMode !== 'context' && (
                 <div
                   className='HubMainScreen__grid__panel'
                   style={{
-                    flex: state.viewMode === 'panel' ? 1 : state.panelFlex,
+                    flex: screen.viewMode === 'panel' ? 1 : screen.panelFlex,
                   }}
                 >
                   <Panel
                     parentHeight={state.height}
                     parentWidth={state.width}
-                    mode={state.viewMode}
+                    mode={screen.viewMode}
                     indices={panelIndices}
                     resizing={state.resizing}
                   />
@@ -622,7 +609,7 @@ function HubMainScreen(props) {
                   )}
                 </div>
               )}
-              {state.viewMode === 'resizable' && (
+              {screen.viewMode === 'resizable' && (
                 <div
                   className='HubMainScreen__grid__resize__area'
                   onMouseDown={startResize}
@@ -641,34 +628,30 @@ function HubMainScreen(props) {
                 className={classNames({
                   HubMainScreen__grid__context: true,
                   'HubMainScreen__grid__context--minimize':
-                  state.viewMode === 'panel',
+                  screen.viewMode === 'panel',
                 })}
                 style={{
                   flex:
-                  state.viewMode === 'context'
+                  screen.viewMode === 'context'
                     ? 1
-                    : state.viewMode === 'panel'
+                    : screen.viewMode === 'panel'
                       ? 0
-                      : 1 - state.panelFlex,
+                      : 1 - screen.panelFlex,
                 }}
               >
-                {state.viewMode !== 'panel' ? (
+                {screen.viewMode !== 'panel' ? (
                   <ContextBox
-                    spacing={state.viewMode !== 'resizable'}
+                    spacing={screen.viewMode !== 'resizable'}
                     width={state.width - headerWidth - controlsWidth - 5}
                     resizing={state.resizing}
-                    viewMode={state.viewMode}
-                    setViewMode={(mode) =>
-                      setState((s) => ({ ...s, viewMode: mode }))
-                    }
+                    viewMode={screen.viewMode}
+                    setViewMode={(mode) => setScreenState({ viewMode: mode })}
                   />
                 ) : (
                   <div className='HubMainScreen__grid__context__bar'>
                     <BarViewModes
-                      viewMode={state.viewMode}
-                      setViewMode={(mode) =>
-                        setState((s) => ({ ...s, viewMode: mode }))
-                      }
+                      viewMode={screen.viewMode}
+                      setViewMode={(mode) => setScreenState({ viewMode: mode })}
                     />
                   </div>
                 )}

--- a/aim/web/ui/src/screens/hub/HubMainScreen/HubMainScreen.js
+++ b/aim/web/ui/src/screens/hub/HubMainScreen/HubMainScreen.js
@@ -13,8 +13,6 @@ import { setItem, getItem } from '../../../services/storage';
 import {
   USER_LAST_SEARCH_QUERY,
   AIM_QL_VERSION,
-  EXPLORE_PANEL_FLEX_STYLE,
-  EXPLORE_PANEL_VIEW_MODE,
   USER_LAST_EXPLORE_CONFIG,
 } from '../../../config';
 import Panel from './components/Panel/Panel';
@@ -49,15 +47,14 @@ function HubMainScreen(props) {
     height: 0,
     width: 0,
     resizing: false,
-    panelFlex: getItem(EXPLORE_PANEL_FLEX_STYLE),
-    viewMode: getItem(EXPLORE_PANEL_VIEW_MODE) ?? 'resizable',
     searchError: null,
   });
 
-  let { runs, traceList, search, searchInput } =
+  let { runs, traceList, search, searchInput, screen } =
     HubMainScreenModel.useHubMainScreenState([
       HubMainScreenModel.events.SET_RUNS_STATE,
       HubMainScreenModel.events.SET_TRACE_LIST,
+      HubMainScreenModel.events.SET_SCREEN_STATE,
     ]);
 
   const {
@@ -68,6 +65,7 @@ function HubMainScreen(props) {
     setChartFocusedActiveState,
     setChartSettingsState,
     setTraceList,
+    setScreenState,
   } = HubMainScreenModel.emitters;
 
   const projectWrapperRef = useRef();
@@ -117,10 +115,9 @@ function HubMainScreen(props) {
         projectWrapperRef.current.getHeaderHeight() -
         searchBarHeight;
       const flex = height / (state.height - searchBarHeight);
-      setState((s) => ({
-        ...s,
+      setScreenState({
         panelFlex: flex,
-      }));
+      });
     });
   }
 
@@ -346,16 +343,6 @@ function HubMainScreen(props) {
   }, [props.location]);
 
   useEffect(() => {
-    if (state.resizing === false) {
-      setItem(EXPLORE_PANEL_FLEX_STYLE, state.panelFlex);
-    }
-  }, [state.resizing]);
-
-  useEffect(() => {
-    setItem(EXPLORE_PANEL_VIEW_MODE, state.viewMode);
-  }, [state.viewMode]);
-
-  useEffect(() => {
     props.completeProgress();
     updateWindowDimensions();
     window.addEventListener('resize', updateWindowDimensions);
@@ -408,30 +395,30 @@ function HubMainScreen(props) {
       <div
         className={classNames({
           HubMainScreen__grid__body: true,
-          [`HubMainScreen__grid__body--${state.viewMode}`]: true,
+          [`HubMainScreen__grid__body--${screen.viewMode}`]: true,
         })}
         style={{
           height: `${state.height - searchBarHeight}px`,
         }}
       >
         <div className='HubMainScreen__grid__body__blocks'>
-          {state.viewMode !== 'context' && (
+          {screen.viewMode !== 'context' && (
             <div
               className='HubMainScreen__grid__panel'
               style={{
-                flex: state.viewMode === 'panel' ? 1 : state.panelFlex,
+                flex: screen.viewMode === 'panel' ? 1 : screen.panelFlex,
               }}
             >
               <Panel
                 parentHeight={state.height}
                 parentWidth={state.width}
-                mode={state.viewMode}
+                mode={screen.viewMode}
                 indices={panelIndices}
                 resizing={state.resizing}
               />
             </div>
           )}
-          {state.viewMode === 'resizable' && (
+          {screen.viewMode === 'resizable' && (
             <div
               className='HubMainScreen__grid__resize__area'
               onMouseDown={startResize}
@@ -450,34 +437,30 @@ function HubMainScreen(props) {
             className={classNames({
               HubMainScreen__grid__context: true,
               'HubMainScreen__grid__context--minimize':
-                state.viewMode === 'panel',
+                screen.viewMode === 'panel',
             })}
             style={{
               flex:
-                state.viewMode === 'context'
+                screen.viewMode === 'context'
                   ? 1
-                  : state.viewMode === 'panel'
+                  : screen.viewMode === 'panel'
                     ? 0
-                    : 1 - state.panelFlex,
+                    : 1 - screen.panelFlex,
             }}
           >
-            {state.viewMode !== 'panel' ? (
+            {screen.viewMode !== 'panel' ? (
               <ContextBox
-                spacing={state.viewMode !== 'resizable'}
+                spacing={screen.viewMode !== 'resizable'}
                 width={state.width - headerWidth - controlsWidth - 5}
                 resizing={state.resizing}
-                viewMode={state.viewMode}
-                setViewMode={(mode) =>
-                  setState((s) => ({ ...s, viewMode: mode }))
-                }
+                viewMode={screen.viewMode}
+                setViewMode={(mode) => setScreenState({ viewMode: mode })}
               />
             ) : (
               <div className='HubMainScreen__grid__context__bar'>
                 <BarViewModes
-                  viewMode={state.viewMode}
-                  setViewMode={(mode) =>
-                    setState((s) => ({ ...s, viewMode: mode }))
-                  }
+                  viewMode={screen.viewMode}
+                  setViewMode={(mode) => setScreenState({ viewMode: mode })}
                 />
               </div>
             )}

--- a/aim/web/ui/src/screens/hub/HubMainScreen/models/HubMainScreenModel.js
+++ b/aim/web/ui/src/screens/hub/HubMainScreen/models/HubMainScreenModel.js
@@ -894,7 +894,7 @@ function setScreenState(screenOptions) {
   }
 
   if (screenOptions.hasOwnProperty('viewMode')) {
-    setItem(EXPLORE_PANEL_FLEX_STYLE, screenOptions.viewMode);
+    setItem(EXPLORE_PANEL_VIEW_MODE, screenOptions.viewMode);
   }
 }
 

--- a/aim/web/ui/src/screens/hub/HubMainScreen/models/HubMainScreenModel.js
+++ b/aim/web/ui/src/screens/hub/HubMainScreen/models/HubMainScreenModel.js
@@ -10,6 +10,11 @@ import {
   EXPLORE_PANEL_HIDDEN_METRICS,
   EXPLORE_PANEL_SINGLE_ZOOM_MODE,
   EXPLORE_PANEL_CHART_TOOLTIP_OPTIONS,
+  EXPLORE_PANEL_VIEW_MODE,
+  EXPLORE_PANEL_FLEX_STYLE,
+  CONTEXT_TABLE_CONFIG,
+  TABLE_COLUMNS,
+  TABLE_COLUMNS_WIDTHS,
 } from '../../../../config';
 import { getItem, removeItem, setItem } from '../../../../services/storage';
 import { flattenObject, sortOnKeys } from '../../../../utils';
@@ -37,6 +42,11 @@ const events = {
   SET_SEED: 'SET_SEED',
   TOGGLE_PERSISTENCE: 'TOGGLE_PERSISTENCE',
   SET_COLOR_PALETTE: 'SET_COLOR_PALETTE',
+  SET_SCREEN_STATE: 'SET_SCREEN_STATE',
+  SET_TABLE_ROW_HEIGHT_MODE: 'SET_TABLE_ROW_HEIGHT_MODE',
+  SET_TABLE_EXCLUDED_FIELDS: 'SET_TABLE_EXCLUDED_FIELDS',
+  SET_TABLE_COLUMNS_ORDER: 'SET_TABLE_COLUMNS_ORDER',
+  SET_TABLE_COLUMNS_WIDTHS: 'SET_TABLE_COLUMNS_WIDTHS',
 };
 
 // State
@@ -142,6 +152,28 @@ const state = {
   colorPalette: !!getItem(EXPLORE_PANEL_COLOR_PALETTE)
     ? +getItem(EXPLORE_PANEL_COLOR_PALETTE)
     : 0,
+
+  // Screen state
+  screen: {
+    panelFlex: getItem(EXPLORE_PANEL_FLEX_STYLE),
+    viewMode: getItem(EXPLORE_PANEL_VIEW_MODE) ?? 'resizable',
+  },
+
+  // Context table state
+  table: {
+    rowHeightMode:
+      JSON.parse(getItem(CONTEXT_TABLE_CONFIG.replace('{name}', 'context')))
+        ?.rowHeightMode ?? 'medium',
+    excludedFields:
+      JSON.parse(getItem(CONTEXT_TABLE_CONFIG.replace('{name}', 'context')))
+        ?.excludedFields ?? [],
+    columnsOrder: JSON.parse(getItem(TABLE_COLUMNS))?.context ?? {
+      left: [],
+      middle: [],
+      right: [],
+    },
+    columnsWidths: JSON.parse(getItem(TABLE_COLUMNS_WIDTHS))?.context ?? {},
+  },
 };
 
 // initial controls
@@ -808,6 +840,83 @@ function setColorPalette(paletteIndex) {
   setItem(EXPLORE_PANEL_COLOR_PALETTE, paletteIndex);
 }
 
+function setScreenState(screenOptions) {
+  emit(events.SET_SCREEN_STATE, {
+    screen: {
+      ...getState().screen,
+      ...screenOptions,
+    },
+  });
+
+  if (screenOptions.hasOwnProperty('panelFlex')) {
+    setItem(EXPLORE_PANEL_FLEX_STYLE, screenOptions.panelFlex);
+  }
+
+  if (screenOptions.hasOwnProperty('viewMode')) {
+    setItem(EXPLORE_PANEL_FLEX_STYLE, screenOptions.viewMode);
+  }
+}
+
+function setRowHeightMode(mode) {
+  emit(events.SET_TABLE_ROW_HEIGHT_MODE, {
+    table: {
+      ...getState().table,
+      rowHeightMode: mode,
+    },
+  });
+
+  const storageKey = CONTEXT_TABLE_CONFIG.replace('{name}', 'context');
+  setItem(
+    storageKey,
+    JSON.stringify({
+      rowHeightMode: mode,
+      excludedFields: getState().table.excludedFields,
+    }),
+  );
+}
+
+function setExcludedFields(fields) {
+  emit(events.SET_TABLE_EXCLUDED_FIELDS, {
+    table: {
+      ...getState().table,
+      excludedFields: fields,
+    },
+  });
+
+  const storageKey = CONTEXT_TABLE_CONFIG.replace('{name}', 'context');
+  setItem(
+    storageKey,
+    JSON.stringify({
+      rowHeightMode: getState().table.rowHeightMode,
+      excludedFields: fields,
+    }),
+  );
+}
+
+function setColumnsOrder(columnsOrder) {
+  emit(events.SET_TABLE_COLUMNS_ORDER, {
+    table: {
+      ...getState().table,
+      columnsOrder,
+    },
+  });
+  const tableColumns = JSON.parse(getItem(TABLE_COLUMNS)) ?? {};
+  tableColumns.context = columnsOrder;
+  setItem(TABLE_COLUMNS, JSON.stringify(tableColumns));
+}
+
+function setColumnsWidths(columnsWidths) {
+  emit(events.SET_TABLE_COLUMNS_WIDTHS, {
+    table: {
+      ...getState().table,
+      columnsWidths,
+    },
+  });
+  const tableColumnsWidths = JSON.parse(getItem(TABLE_COLUMNS_WIDTHS)) ?? {};
+  tableColumnsWidths.context = columnsWidths;
+  setItem(TABLE_COLUMNS_WIDTHS, JSON.stringify(tableColumnsWidths));
+}
+
 // helpers
 
 function isExploreMetricsModeEnabled() {
@@ -1148,6 +1257,11 @@ export const HubMainScreenModel = {
     setSeed,
     togglePersistence,
     setColorPalette,
+    setScreenState,
+    setRowHeightMode,
+    setExcludedFields,
+    setColumnsOrder,
+    setColumnsWidths,
   },
   helpers: {
     isExploreMetricsModeEnabled,

--- a/aim/web/ui/src/ui/components/Table/Table.js
+++ b/aim/web/ui/src/ui/components/Table/Table.js
@@ -225,8 +225,8 @@ function Table(props) {
                 togglePin={togglePin}
                 pinnedTo='left'
                 firstColumn={index === 0}
-                width={props.columnsWidth[col.key]}
-                updateColumnWidth={props.updateColumnsWidth}
+                width={props.columnsWidths[col.key]}
+                updateColumnWidth={props.updateColumnsWidths}
                 headerMeta={props.headerMeta}
                 isAlwaysVisible={props.alwaysVisibleColumns.includes(col.key)}
                 hideColumn={() =>
@@ -269,8 +269,8 @@ function Table(props) {
               togglePin={togglePin}
               pinnedTo={null}
               firstColumn={index === 0 && leftPane.length === 0}
-              width={props.columnsWidth[col.key]}
-              updateColumnWidth={props.updateColumnsWidth}
+              width={props.columnsWidths[col.key]}
+              updateColumnWidth={props.updateColumnsWidths}
               headerMeta={props.headerMeta}
               isAlwaysVisible={props.alwaysVisibleColumns.includes(col.key)}
               hideColumn={() =>
@@ -324,8 +324,8 @@ function Table(props) {
                   leftPane.length === 0 &&
                   middlePane.length === 0
                 }
-                width={props.columnsWidth[col.key]}
-                updateColumnWidth={props.updateColumnsWidth}
+                width={props.columnsWidths[col.key]}
+                updateColumnWidth={props.updateColumnsWidths}
                 headerMeta={props.headerMeta}
                 isAlwaysVisible={props.alwaysVisibleColumns.includes(col.key)}
                 hideColumn={() =>


### PR DESCRIPTION
This adds an ability to easily manage `Explore Screen` state history for dashboard apps. 