### PR TITLE
Fix linechart active point on zoom mode

### DIFF
--- a/aim/web/ui_v2/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui_v2/src/components/LineChart/LineChart.tsx
@@ -155,6 +155,7 @@ const LineChart = React.forwardRef(function LineChart(
         brushRef,
         plotBoxRef,
         plotNodeRef,
+        attributesNodeRef,
         visBoxRef,
         axesRef,
         attributesRef,
@@ -180,7 +181,15 @@ const LineChart = React.forwardRef(function LineChart(
         requestAnimationFrame(renderChart);
       }
     },
-    [],
+    [
+      data,
+      zoomMode,
+      displayOutliers,
+      highlightMode,
+      axesScaleType,
+      curveInterpolation,
+      zoomMode,
+    ],
   );
 
   useResizeObserver(resizeObserverCallback, parentRef);

--- a/aim/web/ui_v2/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui_v2/src/components/LineChart/LineChart.tsx
@@ -164,6 +164,7 @@ const LineChart = React.forwardRef(function LineChart(
         axesScaleType,
         min,
         max,
+        syncHoverState,
       });
     }
   }

--- a/aim/web/ui_v2/src/types/components/LineChart/LineChart.d.ts
+++ b/aim/web/ui_v2/src/types/components/LineChart/LineChart.d.ts
@@ -47,6 +47,6 @@ export interface IAttributesRef {
   updateScales?: (xScale: IGetAxisScale, yScale: IGetAxisScale) => void;
   setActiveLine?: (lineKey: string) => void;
   updateHoverAttributes?: (xValue: number) => void;
-  updateFocusedChart?: (props?: IUpdateFocusedChartProps) => void;
+  updateFocusedChart?: (params?: IUpdateFocusedChartProps) => void;
   clearHoverAttributes?: () => void;
 }

--- a/aim/web/ui_v2/src/types/components/LineChart/LineChart.d.ts
+++ b/aim/web/ui_v2/src/types/components/LineChart/LineChart.d.ts
@@ -31,6 +31,12 @@ export interface ILineChartProps {
   syncHoverState: (params: ISyncHoverStateParams) => void;
 }
 
+export interface IUpdateFocusedChartProps {
+  mousePos: [number, number];
+  focusedStateActive?: boolean;
+  force?: boolean;
+}
+
 export interface IAttributesRef {
   focusedState?: IFocusedState;
   activePoint?: IActivePoint;
@@ -41,6 +47,6 @@ export interface IAttributesRef {
   updateScales?: (xScale: IGetAxisScale, yScale: IGetAxisScale) => void;
   setActiveLine?: (lineKey: string) => void;
   updateHoverAttributes?: (xValue: number) => void;
-  updateFocusedChart?: (mousePos: [number, number]) => IActivePoint;
+  updateFocusedChart?: (props?: IUpdateFocusedChartProps) => void;
   clearHoverAttributes?: () => void;
 }

--- a/aim/web/ui_v2/src/types/utils/d3/drawBrush.d.ts
+++ b/aim/web/ui_v2/src/types/utils/d3/drawBrush.d.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IGetAxesScaleProps, IGetAxisScale } from './getAxisScale';
+import { ISyncHoverStateParams } from './drawHoverAttributes';
 
 export interface IDrawBrushProps extends IGetAxesScaleProps {
   plotBoxRef: React.MutableRefObject<>;
@@ -11,6 +12,7 @@ export interface IDrawBrushProps extends IGetAxesScaleProps {
   linesRef: React.MutableRefObject<>;
   linesNodeRef: React.MutableRefObject<>;
   svgNodeRef: React.MutableRefObject<>;
+  syncHoverState: (params: ISyncHoverStateParams) => void;
 }
 
 export interface IHandleBrushChange {

--- a/aim/web/ui_v2/src/types/utils/d3/drawBrush.d.ts
+++ b/aim/web/ui_v2/src/types/utils/d3/drawBrush.d.ts
@@ -5,6 +5,7 @@ import { ISyncHoverStateParams } from './drawHoverAttributes';
 export interface IDrawBrushProps extends IGetAxesScaleProps {
   plotBoxRef: React.MutableRefObject<>;
   plotNodeRef: React.MutableRefObject<>;
+  attributesNodeRef: React.MutableRefObject<>;
   brushRef: React.MutableRefObject<>;
   visBoxRef: React.MutableRefObject<>;
   axesRef: React.MutableRefObject<>;

--- a/aim/web/ui_v2/src/utils/d3/drawBrush.ts
+++ b/aim/web/ui_v2/src/utils/d3/drawBrush.ts
@@ -19,6 +19,7 @@ function drawBrush(props: IDrawBrushProps): void {
     axesScaleType,
     min,
     max,
+    syncHoverState,
   } = props;
 
   const brush = d3
@@ -106,7 +107,32 @@ function drawBrush(props: IDrawBrushProps): void {
     axesRef.current.updateXAxis(brushRef.current.xScale);
     axesRef.current.updateYAxis(brushRef.current.yScale);
 
-    attributesRef.current.updateFocusedChart(mousePos);
+    let updateMousePos = mousePos;
+
+    if (attributesRef.current.focusedState.active) {
+      updateMousePos = [
+        attributesRef.current.xScale(attributesRef.current.focusedState.xValue),
+        attributesRef.current.yScale(attributesRef.current.focusedState.yValue),
+      ];
+    } else if (
+      attributesRef.current.activePoint?.xValue &&
+      attributesRef.current.activePoint.yValue
+    ) {
+      updateMousePos = [
+        attributesRef.current.xScale(attributesRef.current.activePoint.xValue),
+        attributesRef.current.yScale(attributesRef.current.activePoint.yValue),
+      ];
+    }
+
+    const activePoint =
+      attributesRef.current.updateFocusedChart(updateMousePos);
+
+    if (typeof syncHoverState === 'function') {
+      syncHoverState({
+        activePoint,
+        focusedStateActive: attributesRef.current.focusedState.active,
+      });
+    }
 
     linesNodeRef.current
       .selectAll('.Line')

--- a/aim/web/ui_v2/src/utils/d3/drawBrush.ts
+++ b/aim/web/ui_v2/src/utils/d3/drawBrush.ts
@@ -4,12 +4,14 @@ import { IDrawBrushProps, IHandleBrushChange } from 'types/utils/d3/drawBrush';
 import getAxisScale from './getAxisScale';
 import lineGenerator from './lineGenerator';
 import { IGetAxisScale } from '../../types/utils/d3/getAxisScale';
+import { CircleEnum } from './index';
 
 function drawBrush(props: IDrawBrushProps): void {
   const {
     brushRef,
     plotBoxRef,
     plotNodeRef,
+    attributesNodeRef,
     visBoxRef,
     axesRef,
     attributesRef,
@@ -107,32 +109,7 @@ function drawBrush(props: IDrawBrushProps): void {
     axesRef.current.updateXAxis(brushRef.current.xScale);
     axesRef.current.updateYAxis(brushRef.current.yScale);
 
-    let updateMousePos = mousePos;
-
-    if (attributesRef.current.focusedState.active) {
-      updateMousePos = [
-        attributesRef.current.xScale(attributesRef.current.focusedState.xValue),
-        attributesRef.current.yScale(attributesRef.current.focusedState.yValue),
-      ];
-    } else if (
-      attributesRef.current.activePoint?.xValue &&
-      attributesRef.current.activePoint.yValue
-    ) {
-      updateMousePos = [
-        attributesRef.current.xScale(attributesRef.current.activePoint.xValue),
-        attributesRef.current.yScale(attributesRef.current.activePoint.yValue),
-      ];
-    }
-
-    const activePoint =
-      attributesRef.current.updateFocusedChart(updateMousePos);
-
-    if (typeof syncHoverState === 'function') {
-      syncHoverState({
-        activePoint,
-        focusedStateActive: attributesRef.current.focusedState.active,
-      });
-    }
+    attributesRef.current.updateFocusedChart();
 
     linesNodeRef.current
       .selectAll('.Line')
@@ -166,7 +143,7 @@ function drawBrush(props: IDrawBrushProps): void {
     linesRef.current.updateLinesScales(xScale, yScale);
 
     attributesRef.current.updateScales(xScale, yScale);
-    attributesRef.current.updateFocusedChart(d3.pointer(event));
+    attributesRef.current.updateFocusedChart();
   }
 }
 

--- a/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
@@ -321,6 +321,20 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
       .on('click', handlePointClick);
   }
 
+  function drawLinesHighlightMode(): void {
+    linesNodeRef.current.classed(
+      'highlight',
+      highlightMode !== HighlightEnum.Off,
+    );
+  }
+
+  function drawCirclesHighlightMode(): void {
+    attributesNodeRef.current.classed(
+      'highlight',
+      highlightMode !== HighlightEnum.Off,
+    );
+  }
+
   function getActivePoint(circle: INearestCircle): IActivePoint {
     return {
       key: circle.key,
@@ -340,14 +354,8 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
     const mouseX = x < xMin ? xMin : x > xMax ? xMax : x;
     const nearestCircles = getNearestCircles(mouseX);
 
-    linesNodeRef.current.classed(
-      'highlight',
-      highlightMode !== HighlightEnum.Off,
-    );
-    attributesNodeRef.current.classed(
-      'highlight',
-      highlightMode !== HighlightEnum.Off,
-    );
+    drawLinesHighlightMode();
+    drawCirclesHighlightMode();
 
     clearHorizontalAxisLine();
     clearYAxisLabel();
@@ -388,10 +396,7 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
   ): IActivePoint {
     // hover Line Changed case
     if (force || circle.key !== attributesRef.current.lineKey) {
-      linesNodeRef.current.classed(
-        'highlight',
-        highlightMode !== HighlightEnum.Off,
-      );
+      drawLinesHighlightMode();
       clearActiveLine(attributesRef.current.lineKey);
       drawActiveLine(circle.key);
     }
@@ -403,16 +408,17 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
       circle.x !== attributesRef.current.activePoint?.xPos ||
       circle.y !== attributesRef.current.activePoint?.yPos
     ) {
-      attributesNodeRef.current.classed(
-        'highlight',
-        highlightMode !== HighlightEnum.Off,
-      );
+      drawCirclesHighlightMode();
       drawCircles(nearestCircles);
       drawVerticalAxisLine(circle.x);
       drawHorizontalAxisLine(circle.y);
       drawXAxisLabel(circle.x);
       drawYAxisLabel(circle.y);
       drawActiveCircle(circle.key);
+
+      if (attributesRef.current.focusedState?.active) {
+        drawFocusedCircle(circle.key);
+      }
     }
 
     const activePoint = getActivePoint(circle);
@@ -482,7 +488,6 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
       circle.y + margin.top,
     ];
     const activePoint = updateFocusedChart(mousePos);
-    drawFocusedCircle(activePoint.key);
 
     if (typeof syncHoverState === 'function') {
       syncHoverState({
@@ -559,10 +564,6 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
       ];
       if (isMouseInVisArea(mousePos[0], mousePos[1])) {
         const activePoint = updateFocusedChart(mousePos, true);
-
-        if (focusedState.active) {
-          drawFocusedCircle(activePoint.key);
-        }
 
         if (typeof syncHoverState === 'function') {
           syncHoverState({

--- a/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
@@ -422,12 +422,12 @@ function drawHoverAttributes(props: IDrawHoverAttributesProps): void {
     return activePoint;
   }
 
-  function updateFocusedChart(props?: IUpdateFocusedChartProps): void {
+  function updateFocusedChart(params?: IUpdateFocusedChartProps): void {
     const {
       mousePos,
       focusedStateActive = attributesRef.current.focusedState?.active || false,
       force = false,
-    } = props || {};
+    } = params || {};
     const { xScale, yScale, focusedState, xStep } = attributesRef.current;
 
     let mousePosition: [number, number] | [] = [];


### PR DESCRIPTION
Fix: 
 - Brush `active` or `focused` point location on zoom
 
Add: 
 - `updateFocusedChart` function can call with an existing `active` or `focused` point(can call without receiving mouse position)