### PR TITLE
tags/experiments API improvements

### DIFF
--- a/aim/storage/structured/sql_engine/utils.py
+++ b/aim/storage/structured/sql_engine/utils.py
@@ -59,8 +59,10 @@ class ModelMappedCollection(Collection[T]):
         return ret
 
     def __len__(self):
-        self._create_cache()
-        return len(self._cache)
+        if self._cache is not None:
+            return len(self._cache)
+        else:
+            return self.query.count()
 
     def __contains__(self, item: Union[T, str]) -> bool:
         self._create_cache()

--- a/aim/web/api/projects/views.py
+++ b/aim/web/api/projects/views.py
@@ -56,7 +56,7 @@ async def project_activity_api(request: Request, factory=Depends(object_factory)
         num_runs += 1
 
     return {
-        'num_experiments': len(factory.experiments),
+        'num_experiments': len(factory.experiments()),
         'num_runs': num_runs,
         'activity_map': dict(activity_counter),
     }

--- a/aim/web/api/v2/views/experiments.py
+++ b/aim/web/api/v2/views/experiments.py
@@ -8,7 +8,7 @@ experiment_router = APIRouter()
 
 @experiment_router.get('/list/')
 async def get_experiments_list_api(factory=Depends(object_factory)):
-    response = [{'id': exp.uuid, 'name': exp.name} for exp in factory.experiments()]
+    response = [{'id': exp.uuid, 'name': exp.name, 'run_count': len(exp.runs)} for exp in factory.experiments()]
     return response
 
 
@@ -18,7 +18,8 @@ async def search_experiments_by_name_api(request: Request, factory=Depends(objec
     search_term = params.get('q') or ''
     search_term.strip()
 
-    response = [{'id': exp.uuid, 'name': exp.name} for exp in factory.search_experiments(search_term)]
+    response = [{'id': exp.uuid, 'name': exp.name, 'run_count': len(exp.runs)}
+                for exp in factory.search_experiments(search_term)]
     return response
 
 

--- a/aim/web/api/v2/views/tags.py
+++ b/aim/web/api/v2/views/tags.py
@@ -8,7 +8,8 @@ tag_router = APIRouter()
 
 @tag_router.get('/list/')
 async def get_tags_list_api(factory=Depends(object_factory)):
-    return [{'id': tag.uuid, 'name': tag.name} for tag in factory.tags()]
+    return [{'id': tag.uuid, 'name': tag.name, 'color': tag.color, 'run_count': len(tag.runs)}
+            for tag in factory.tags()]
 
 
 @tag_router.get('/search/')
@@ -17,7 +18,8 @@ async def search_tags_by_name_api(request: Request, factory=Depends(object_facto
     search_term = params.get('q') or ''
     search_term.strip()
 
-    response = [{'id': tag.uuid, 'name': tag.name} for tag in factory.search_tags(search_term)]
+    response = [{'id': tag.uuid, 'name': tag.name, 'color': tag.color, 'run_count': len(tag.runs)}
+                for tag in factory.search_tags(search_term)]
     return response
 
 
@@ -29,7 +31,8 @@ async def get_tag_api(tag_id: str, factory=Depends(object_factory)):
 
     response = {
         'id': tag.uuid,
-        'name': tag.name
+        'name': tag.name,
+        'color': tag.color,
     }
     return response
 
@@ -74,8 +77,12 @@ async def update_tag_properties_api(tag_id: str, request: Request, factory=Depen
         body = await request.json()
         tag_name = body.get('name') or ''
         tag_name = tag_name.strip()
+        tag_color = body.get('color') or ''
+        tag_color = tag_color.strip()
         if tag_name:
             tag.name = tag_name
+        if tag_color:
+            tag.color = tag_color
 
     return {
         'id': tag.uuid,


### PR DESCRIPTION
* Added run count per tag/experiment to APIs
* Added tag color set/get
* Optimized `ModelMappedColelction len()` method to return query.count() instead of caching all objects