### PR TITLE
Make changes to runs and tags endpoints:

### DIFF
--- a/aim/storage/types.py
+++ b/aim/storage/types.py
@@ -55,6 +55,12 @@ class SafeNone(metaclass=Singleton):
     def __eq__(self, other):
         return other is None or isinstance(other, SafeNone)
 
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration
+
 
 __all__ = [
     'NoneType',

--- a/aim/web/api/experiments/pydantic_models.py
+++ b/aim/web/api/experiments/pydantic_models.py
@@ -9,7 +9,7 @@ class ExperimentCreateIn(BaseModel):
 
 class ExperimentUpdateIn(BaseModel):
     name: Optional[str] = ''
-    archive: Optional[bool] = None
+    archived: Optional[bool] = False
 
 
 class ExperimentGetOut(BaseModel):
@@ -17,6 +17,7 @@ class ExperimentGetOut(BaseModel):
     name: str
     run_count: int
     archived: bool
+
 
 ExperimentListOut = List[ExperimentGetOut]
 

--- a/aim/web/api/experiments/pydantic_models.py
+++ b/aim/web/api/experiments/pydantic_models.py
@@ -9,7 +9,7 @@ class ExperimentCreateIn(BaseModel):
 
 class ExperimentUpdateIn(BaseModel):
     name: Optional[str] = ''
-    archived: Optional[bool] = False
+    archived: Optional[bool] = None
 
 
 class ExperimentGetOut(BaseModel):

--- a/aim/web/api/experiments/views.py
+++ b/aim/web/api/experiments/views.py
@@ -69,11 +69,11 @@ async def update_experiment_properties_api(exp_id: str, exp_in: ExperimentUpdate
 
         if exp_in.name:
             exp.name = exp_in.name.strip()
-        if exp_in.archive is not None:
-            if exp_in.archive and len(exp.runs) > 0:
+        if exp_in.archived is not None:
+            if exp_in.archived and len(exp.runs) > 0:
                 raise HTTPException(status_code=400,
                                     detail=f'Cannot archive experiment \'{exp_id}\'. Experiment has associated runs.')
-            exp.archived = exp_in.archive
+            exp.archived = exp_in.archived
 
     return {
         'id': exp.uuid,

--- a/aim/web/api/runs/pydantic_models.py
+++ b/aim/web/api/runs/pydantic_models.py
@@ -47,10 +47,32 @@ class TraceFullView(TraceAlignedView):
     timestamps: EncodedNumpyArray
 
 
+class PropsView(BaseModel):
+    class Tag(BaseModel):
+        id: UUID
+        name: str
+        color: str
+
+    class Experiment(BaseModel):
+        id: UUID
+        name: str
+
+    name: Optional[str] = None
+    experiment: Optional[Experiment] = None
+    tags: Optional[List[Tag]] = []
+    creation_time: float
+
+
 class MetricSearchRunView(BaseModel):
     params: dict
     traces: List[TraceFullView]
-    created_at: float = 0.1
+    props: PropsView
+
+
+class RunInfoOut(BaseModel):
+    params: dict
+    traces: List[TraceOverview]
+    props: PropsView
 
 
 RunMetricSearchApiOut = Dict[str, MetricSearchRunView]
@@ -59,7 +81,7 @@ RunMetricSearchApiOut = Dict[str, MetricSearchRunView]
 class RunSearchRunView(BaseModel):
     params: dict
     traces: List[TraceOverview]
-    created_at: float = 0.1
+    props: PropsView
 
 
 RunSearchApiOut = Dict[str, RunSearchRunView]
@@ -89,36 +111,13 @@ RunTracesBatchApiIn = List[TraceBase]
 class StructuredRunUpdateIn(BaseModel):
     name: Optional[str] = ''
     description: Optional[str] = ''
-    archived: Optional[bool] = None
+    archived: Optional[bool] = False
     experiment: Optional[str] = ''
 
 
 class StructuredRunUpdateOut(BaseModel):
     id: str
     status: str = 'OK'
-
-
-class StructuredRunBaseOut(BaseModel):
-    id: str
-    name: str
-
-
-StructuredRunListOut = List[StructuredRunBaseOut]
-
-
-class StructuredRunOut(StructuredRunBaseOut):
-    class Experiment(BaseModel):
-        experiment_id: UUID
-        name: str = ''
-
-    class Tag(BaseModel):
-        tag_id: UUID
-        name: str = ''
-
-    archived: bool = False
-    description: str = ''
-    experiment: Optional[Experiment] = ''
-    tags: Optional[List[Tag]] = []
 
 
 class StructuredRunAddTagIn(BaseModel):

--- a/aim/web/api/runs/pydantic_models.py
+++ b/aim/web/api/runs/pydantic_models.py
@@ -111,7 +111,7 @@ RunTracesBatchApiIn = List[TraceBase]
 class StructuredRunUpdateIn(BaseModel):
     name: Optional[str] = ''
     description: Optional[str] = ''
-    archived: Optional[bool] = False
+    archived: Optional[bool] = None
     experiment: Optional[str] = ''
 
 

--- a/aim/web/api/runs/utils.py
+++ b/aim/web/api/runs/utils.py
@@ -11,6 +11,16 @@ from aim.storage.sdk.trace import QueryTraceCollection, QueryRunTraceCollection
 from aim.web.api.runs.pydantic_models import AlignedRunIn, TraceBase
 
 
+def get_run_props(run: Run):
+    return {
+        'name': run.props.name if run.props.name else None,
+        'experiment': run.props.experiment.name if run.props.experiment else None,
+        'tags': [{'id': tag.uuid, 'name': tag.name, 'color': tag.color} for tag in run.props.tags],
+        'archived': run.props.archived if run.props.archived else False,
+        'creation_time': run.creation_time,
+    }
+
+
 def numpy_to_encodable(array: np.ndarray) -> dict:
     encoded_numpy = {
         'type': 'numpy',
@@ -134,7 +144,7 @@ def query_traces_dict_constructor(traces: QueryTraceCollection, steps_num: int, 
         runs_dict[run.hashname] = {
             'params': run[...],
             'traces': traces_list,
-            'created_at': run.creation_time,
+            'props': get_run_props(run)
         }
 
     return runs_dict
@@ -147,7 +157,7 @@ def query_runs_dict_constructor(runs: QueryRunTraceCollection) -> dict:
         runs_dict[run.hashname] = {
             'params': run[...],
             'traces': run.get_traces_overview(),
-            'created_at': run.creation_time,
+            'props': get_run_props(run)
         }
 
     return runs_dict

--- a/aim/web/api/runs/views.py
+++ b/aim/web/api/runs/views.py
@@ -99,7 +99,6 @@ async def run_params_api(run_id: str):
         'traces': run.get_traces_overview(),
         'props': get_run_props(run)
     }
-    print(response)
     return JSONResponse(response)
 
 

--- a/aim/web/api/runs/views.py
+++ b/aim/web/api/runs/views.py
@@ -8,22 +8,21 @@ from aim.web.api.projects.project import Project
 from aim.web.api.runs.utils import (
     aligned_traces_dict_constructor,
     collect_requested_traces,
+    get_run_props,
+    encoded_tree_streamer,
     query_runs_dict_constructor,
     query_traces_dict_constructor,
-    encoded_tree_streamer
 )
 from aim.web.api.runs.pydantic_models import (
     MetricAlignApiIn,
     RunTracesBatchApiIn,
     RunMetricCustomAlignApiOut,
     RunMetricSearchApiOut,
+    RunInfoOut,
     RunSearchApiOut,
-    RunTracesApiOut,
     RunTracesBatchApiOut,
     StructuredRunUpdateIn,
     StructuredRunUpdateOut,
-    StructuredRunListOut,
-    StructuredRunOut,
     StructuredRunAddTagIn,
     StructuredRunAddTagOut,
     StructuredRunRemoveTagOut
@@ -85,7 +84,7 @@ async def run_metric_search_api(q: str, p: int = 50,  x_axis: Optional[str] = No
     return StreamingResponse(encoded_tree_streamer(encoded_runs_tree))
 
 
-@runs_router.get('/{run_id}/params/', response_model=dict)
+@runs_router.get('/{run_id}/info/', response_model=RunInfoOut)
 async def run_params_api(run_id: str):
     # Get project
     project = Project()
@@ -94,19 +93,14 @@ async def run_params_api(run_id: str):
     run = project.repo.get_run(hashname=run_id)
     if not run:
         raise HTTPException(status_code=404)
-    return JSONResponse(run[...])
 
-
-@runs_router.get('/{run_id}/traces/', response_model=RunTracesApiOut)
-async def run_traces_api(run_id: str):
-    # Get project
-    project = Project()
-    if not project.exists():
-        raise HTTPException(status_code=404)
-    run = project.repo.get_run(hashname=run_id)
-    if not run:
-        raise HTTPException(status_code=404)
-    return JSONResponse(run.get_traces_overview())
+    response = {
+        'params': run[...],
+        'traces': run.get_traces_overview(),
+        'props': get_run_props(run)
+    }
+    print(response)
+    return JSONResponse(response)
 
 
 @runs_router.post('/{run_id}/traces/get-batch/', response_model=RunTracesBatchApiOut)
@@ -122,42 +116,6 @@ async def run_traces_batch_api(run_id: str, requested_traces: RunTracesBatchApiI
     traces_data = collect_requested_traces(run, requested_traces)
 
     return JSONResponse(traces_data)
-
-
-# TODO: [AT] implement model serializers (JSON) and request validators (discuss with BE team about possible solutions)
-@runs_router.get('/', response_model=StructuredRunListOut)
-async def get_runs_list_api(include_archived: bool = False, factory=Depends(object_factory)):
-    # TODO: [AT] add arbitrary filters to SDK runs() method
-    if include_archived:
-        response = [{'id': run.hashname, 'name': run.name} for run in factory.runs()]
-    else:
-        response = [{'id': run.hashname, 'name': run.name} for run in factory.runs() if not run.archived]
-    return response
-
-
-@runs_router.get('/search/', response_model=StructuredRunListOut)
-async def search_runs_by_name_api(q: str = '', factory=Depends(object_factory)):
-    search_term = q.strip()
-
-    response = [{'id': run.hashname, 'name': run.name} for run in factory.search_runs(search_term)]
-    return response
-
-
-@runs_router.get('/{run_id}/', response_model=StructuredRunOut)
-async def get_run_api(run_id: str, factory=Depends(object_factory)):
-    run = factory.find_run(run_id)
-    if not run:
-        raise HTTPException(status_code=404)
-
-    response = {
-        'id': run.hashname,
-        'name': run.name,
-        'archived': run.archived,
-        'description': run.description or '',
-        'experiment': {'experiment_id': run.experiment.uuid, 'name': run.experiment.name} if run.experiment else '',
-        'tags': [{'tag_id': tag.uuid, 'name': tag.name} for tag in run.tags]
-    }
-    return response
 
 
 @runs_router.put('/{run_id}/', response_model=StructuredRunUpdateOut)

--- a/aim/web/api/tags/pydantic_models.py
+++ b/aim/web/api/tags/pydantic_models.py
@@ -11,7 +11,7 @@ class TagCreateIn(BaseModel):
 class TagUpdateIn(BaseModel):
     name: Optional[str] = ''
     color: Optional[str] = ''
-    archived: Optional[bool] = False
+    archived: Optional[bool] = None
 
 
 class TagUpdateOut(BaseModel):

--- a/aim/web/api/tags/pydantic_models.py
+++ b/aim/web/api/tags/pydantic_models.py
@@ -11,7 +11,7 @@ class TagCreateIn(BaseModel):
 class TagUpdateIn(BaseModel):
     name: Optional[str] = ''
     color: Optional[str] = ''
-    archive: Optional[bool] = None
+    archived: Optional[bool] = False
 
 
 class TagUpdateOut(BaseModel):
@@ -34,6 +34,8 @@ class TagGetRunsOut(BaseModel):
     class Run(BaseModel):
         run_id: str
         name: str
+        experiment: Optional[str] = None
+        creation_time: float
 
     id: UUID
     runs: List[Run]

--- a/aim/web/api/tags/views.py
+++ b/aim/web/api/tags/views.py
@@ -69,8 +69,8 @@ async def update_tag_properties_api(tag_id: str, tag_in: TagUpdateIn, factory=De
             tag.name = tag_in.name.strip()
         if tag_in.color:
             tag.color = tag_in.color.strip()
-        if tag_in.archive is not None:
-            tag.archived = tag_in.archive
+        if tag_in.archived is not None:
+            tag.archived = tag_in.archived
 
     return {
         'id': tag.uuid,
@@ -84,8 +84,19 @@ async def get_tagged_runs_api(tag_id: str, factory=Depends(object_factory)):
     if not tag:
         raise HTTPException
 
+    from aim.storage.sdk.run import Run
+
+    tag_runs = []
+    for run in tag.runs:
+        aimrocks_run = Run(hashname=run.hashname, read_only=True)
+        tag_runs.append({
+            'run_id': run.hashname,
+            'name': run.name,
+            'creation_time': aimrocks_run.creation_time,
+            'experiment': run.experiment.name if run.experiment else None
+        })
     response = {
         'id': tag.uuid,
-        'runs': [{'run_id': run.hashname, 'name': run.name} for run in tag.runs]
+        'runs': tag_runs
     }
     return response

--- a/aim/web/api/tags/views.py
+++ b/aim/web/api/tags/views.py
@@ -87,13 +87,13 @@ async def get_tagged_runs_api(tag_id: str, factory=Depends(object_factory)):
     from aim.storage.sdk.run import Run
 
     tag_runs = []
-    for run in tag.runs:
-        aimrocks_run = Run(hashname=run.hashname, read_only=True)
+    for tagged_run in tag.runs:
+        run = Run(hashname=run.hashname, read_only=True)
         tag_runs.append({
-            'run_id': run.hashname,
-            'name': run.name,
-            'creation_time': aimrocks_run.creation_time,
-            'experiment': run.experiment.name if run.experiment else None
+            'run_id': tagged_run.hashname,
+            'name': tagged_run.name,
+            'creation_time': run.creation_time,
+            'experiment': tagged_run.experiment.name if tagged_run.experiment else None
         })
     response = {
         'id': tag.uuid,

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -121,28 +121,29 @@ class TestRunApi(ApiTestBase):
         for run in decoded_response.values():
             self.assertEqual([], run)
 
-    def test_run_params_api(self):
+    def test_run_info_api(self):
         run = self._find_run_by_name('Run # 1')
 
         self.assertEqual('Run # 1', run.props.name)
         client = self.client
-        response = client.get(f'/api/runs/{run.hashname}/params/')
+        response = client.get(f'/api/runs/{run.hashname}/info/')
         self.assertEqual(200, response.status_code)
 
-        run_params = response.json()
+        data = response.json()
+        run_params = data['params']
         self.assertEqual(1, run_params['run_index'])
         self.assertEqual(0.001, run_params['hparams']['lr'])
 
-    def test_run_traces_overview_api(self):
-        run = self._find_run_by_name('Run # 1')
-        client = self.client
-        response = client.get(f'/api/runs/{run.hashname}/traces/')
-        self.assertEqual(200, response.status_code)
-
-        run_traces_overview = response.json()
+        run_traces_overview = data['traces']
         self.assertEqual(4, len(run_traces_overview))
         for trc_overview in run_traces_overview:
             self.assertAlmostEqual(0.99, trc_overview['last_value']['last'])
+
+        run_props = data['props']
+
+        self.assertEqual('Run # 1', run_props['name'])
+        self.assertEqual(None, run_props['experiment'])
+        self.assertEqual(0, len(run_props['tags']))
 
     def test_run_traces_batch_api(self):
         run = self._find_run_by_name('Run # 1')


### PR DESCRIPTION
 - send props for run endpoints (info, search, metric_search)
 - send experiment name and creation time for tag/tag_id/runs
 - combine traces, params, and props into info instead of separate endpoints
 - make necessary changes for pydantic models and unit tests