### PR TITLE
Avoid null-terminating C-style strings

### DIFF
--- a/aim/storage/encoding/encoding_native.pxd
+++ b/aim/storage/encoding/encoding_native.pxd
@@ -14,7 +14,7 @@ ctypedef long long ll
 
 cdef ll q(const unsigned char* b) nogil
 cdef vector[pair[ll, ll]] split_path(const unsigned char* buffer, ll N) nogil
-cpdef decode_path(const unsigned char* buffer)
+cpdef decode_path(bytes buffer)
 cpdef bytes encode_int(long long value)
 cpdef long decode_int(const unsigned char* buffer) nogil
 cpdef bytes encode_float(double value)

--- a/aim/storage/encoding/encoding_native.pyx
+++ b/aim/storage/encoding/encoding_native.pyx
@@ -55,7 +55,7 @@ cdef inline vector[pair[ll, ll]] split_path(const unsigned char* buffer, ll N) n
 
 
 
-cpdef inline decode_path(const unsigned char* buffer):
+cpdef inline decode_path(bytes buffer):
     path = []
     cdef vector[pair[ll, ll]] p = split_path(buffer, len(buffer))
     for si in p:


### PR DESCRIPTION
This PR fixes issues with encoded values being truncated with null-byte because of c-style strings are used by cython.
