### PR TITLE
add sqlite Run every time new Run is started

### DIFF
--- a/aim/sdk/errors.py
+++ b/aim/sdk/errors.py
@@ -1,0 +1,2 @@
+class RepoIntegrityError(RuntimeError):
+    pass

--- a/aim/storage/sdk/run.py
+++ b/aim/storage/sdk/run.py
@@ -177,6 +177,7 @@ class Run:
                     raise RepoIntegrityError(f'Missing props for Run {self.hashname}')
                 else:
                     self._props = sdb.create_run(self.hashname)
+                    self._props.experiment = 'default'
 
     def proxy(self):
         run = RunView(self)

--- a/aim/storage/sdk/run.py
+++ b/aim/storage/sdk/run.py
@@ -4,6 +4,7 @@ from time import time
 from typing import Union
 from collections import Counter
 
+from aim.sdk.errors import RepoIntegrityError
 from aim.storage.sdk.types import AimObjectKey, AimObjectPath, AimObject
 
 from aim.storage.sdk.trace import RunTraceCollection
@@ -65,6 +66,7 @@ class Run:
 
         self._creation_time = None
         if not read_only:
+            self.props
             self.creation_time
 
     @property
@@ -161,11 +163,20 @@ class Run:
     @property
     def props(self):
         if self._props is None:
-            if self._props_cache_hint:
-                self._props = self.repo.structured_db.caches[self._props_cache_hint][self.hashname]
-            else:
-                self._props = self.repo.structured_db.find_run(self.hashname)
+            self._init_props()
         return self._props
+
+    def _init_props(self):
+        sdb = self.repo.structured_db
+        if self._props_cache_hint:
+            self._props = sdb.caches[self._props_cache_hint][self.hashname]
+        else:
+            self._props = sdb.find_run(self.hashname)
+            if not self._props:
+                if self.read_only:
+                    raise RepoIntegrityError(f'Missing props for Run {self.hashname}')
+                else:
+                    self._props = sdb.create_run(self.hashname)
 
     def proxy(self):
         run = RunView(self)

--- a/aim/storage/structured/entities.py
+++ b/aim/storage/structured/entities.py
@@ -180,6 +180,10 @@ class ObjectFactory:
         ...
 
     @abstractmethod
+    def create_run(self, runhash: str) -> Run:
+        ...
+
+    @abstractmethod
     def experiments(self) -> ExperimentCollection:
         ...
 

--- a/aim/storage/structured/sql_engine/entities.py
+++ b/aim/storage/structured/sql_engine/entities.py
@@ -1,4 +1,4 @@
-from typing import Optional, Collection
+from typing import Optional, Collection, Union
 from sqlalchemy.orm import joinedload
 
 from aim.storage.types import SafeNone
@@ -23,54 +23,43 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
         Property('archived', 'is_archived'),
         Property('created_at', with_setter=False),
         Property('updated_at', with_setter=False),
-        Property('hashname', autogenerate=False),
+        Property('hashname', 'hash', with_setter=False),
         Property('experiment', autogenerate=False),
         Property('tags', autogenerate=False),
     ]
 
-    def __init__(self, _hash: str, session):
-        self._hash = _hash
-        self._model = None
+    def __init__(self, model: RunModel, session):
+        self._model = model
         self._session = session
 
     def __repr__(self) -> str:
         return f'<ModelMappedRun id={self.hashname}, name=\'{self.name}\'>'
 
-    @property
-    def hashname(self) -> str:
-        return self._hash
+    @classmethod
+    def from_model(cls, model_obj, session) -> 'ModelMappedRun':
+        return ModelMappedRun(model_obj, session)
 
     @classmethod
-    def from_model(cls, model_obj, session):
-        _hash = model_obj.hash
-        run = ModelMappedRun(_hash, session)
-        run._model = model_obj
-        return run
-
-    def create_model_instance(self):
-        if self._model:
-            # TODO: [AT] provide error message
-            raise ValueError()
-        session = self._session
-        model_inst = session.query(RunModel).filter(RunModel.hash == self.hashname).first()
-        if not model_inst:
-            model_inst = RunModel(self._hash)
-            session.add(model_inst)
-            session.flush()
-        self._model = model_inst
+    def from_hash(cls, runhash: str, session) -> 'ModelMappedRun':
+        if session.query(RunModel).filter(RunModel.hash == runhash).scalar():
+            raise ValueError(f'Run with hash \'{runhash}\' already exists.')
+        run = RunModel(runhash)
+        session.add(run)
+        session.flush()
+        return ModelMappedRun(run, session)
 
     @classmethod
-    def find(cls, _id: str, **kwargs) -> Optional[IRun]:
+    def find(cls, _id: str, **kwargs) -> Union[IRun, SafeNone]:
         session = kwargs.get('session')
         if not session:
-            return None
+            return SafeNone()
         model_obj = session.query(RunModel).options([
             joinedload(RunModel.experiment),
             joinedload(RunModel.tags),
         ]).filter(RunModel.hash == _id).first()
         if model_obj:
             return ModelMappedRun.from_model(model_obj, session)
-        return ModelMappedRun(_id, session)
+        return SafeNone()
 
     @classmethod
     def all(cls, **kwargs) -> Collection[IRun]:
@@ -96,7 +85,7 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
         return ModelMappedRunCollection(session, query=q)
 
     @property
-    def experiment(self) -> Optional[IExperiment]:
+    def experiment(self) -> Union[IExperiment, SafeNone]:
         if self._model and self._model.experiment:
             return ModelMappedExperiment(self._model.experiment, self._session)
         else:
@@ -105,8 +94,6 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
     @experiment.setter
     def experiment(self, value: str):
         session = self._session
-        if not self._model:
-            self.create_model_instance()
         if value is None:
             exp = None
         else:
@@ -127,8 +114,6 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
             return []
 
     def add_tag(self, value: str) -> ITag:
-        if not self._model:
-            self.create_model_instance()
         session = self._session
         tag = session.query(TagModel).filter(TagModel.name == value).first()
         if not tag:
@@ -140,8 +125,6 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
         return ModelMappedTag.from_model(tag, session)
 
     def remove_tag(self, tag_id: str) -> bool:
-        if not self._model:
-            self.create_model_instance()
         session = self._session
         tag_removed = False
         for tag in self._model.tags:
@@ -196,16 +179,16 @@ class ModelMappedExperiment(IExperiment, metaclass=ModelMappedClassMeta):
         return ModelMappedRunCollection(self._session, collection=self._model.runs)
 
     @classmethod
-    def find(cls, _id: str, **kwargs) -> Optional[IExperiment]:
+    def find(cls, _id: str, **kwargs) -> Union[IExperiment, SafeNone]:
         session = kwargs.get('session')
         if not session:
-            return None
+            return SafeNone()
         model_obj = session.query(ExperimentModel).options([
             joinedload(ExperimentModel.runs),
         ]).filter(ExperimentModel.uuid == _id).first()
         if model_obj:
             return ModelMappedExperiment(model_obj, session)
-        return None
+        return SafeNone()
 
     @classmethod
     def all(cls, **kwargs) -> Collection[IExperiment]:
@@ -268,16 +251,16 @@ class ModelMappedTag(ITag, metaclass=ModelMappedClassMeta):
         return ModelMappedTag(tag, session)
 
     @classmethod
-    def find(cls, _id: str, **kwargs) -> Optional[ITag]:
+    def find(cls, _id: str, **kwargs) -> Union[ITag, SafeNone]:
         session = kwargs.get('session')
         if not session:
-            return None
+            return SafeNone()
         model_obj = session.query(TagModel).options([
             joinedload(TagModel.runs),
         ]).filter(TagModel.uuid == _id).first()
         if model_obj:
             return ModelMappedTag(model_obj, session)
-        return None
+        return SafeNone()
 
     @classmethod
     def all(cls, **kwargs) -> Collection[ITag]:

--- a/aim/storage/structured/sql_engine/factory.py
+++ b/aim/storage/structured/sql_engine/factory.py
@@ -29,6 +29,9 @@ class ModelMappedFactory(ObjectFactory):
     def find_run(self, _id: str) -> Run:
         return ModelMappedRun.find(_id, session=self._session or self.get_session())
 
+    def create_run(self, runhash: str) -> Run:
+        return ModelMappedRun.from_hash(runhash, session=self._session or self.get_session())
+
     def experiments(self) -> ExperimentCollection:
         return ModelMappedExperiment.all(session=self._session or self.get_session())
 

--- a/aim/storage/structured/sql_engine/utils.py
+++ b/aim/storage/structured/sql_engine/utils.py
@@ -24,8 +24,7 @@ class ModelMappedProperty:
         setter = None
         if self.with_setter:
             def setter(object_, value):
-                if not object_._model:
-                    object_.create_model_instance()
+                assert object_._model
                 setattr(object_._model, self.mapped_name, value)
                 object_._session.add(object_._model)
         return property(getter, setter)

--- a/tests/api/test_project_api.py
+++ b/tests/api/test_project_api.py
@@ -14,7 +14,7 @@ class TestProjectApi(ApiTestBase):
         today = datetime.date.today().isoformat()
         self.assertEqual(10, data['num_runs'])
         self.assertEqual(10, data['activity_map'][today])
-        self.assertEqual(1, data['num_experiments'])
+        self.assertEqual(2, data['num_experiments'])  # count 'default' experiment
 
     def test_project_params_api(self):
         client = self.client

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -15,7 +15,7 @@ class TestRunApi(ApiTestBase):
         response = client.get('/api/runs/search/run/', params={'q': 'run["name"] == "Run # 3"'})
         self.assertEqual(200, response.status_code)
 
-        decoded_response = decode_tree(decode_encoded_tree_stream(response.iter_lines()))
+        decoded_response = decode_tree(decode_encoded_tree_stream(response.iter_content(chunk_size=1024*1024)))
         self.assertEqual(1, len(decoded_response))
         for hashname, run in decoded_response.items():
             self.assertEqual(4, len(run['traces']))
@@ -142,7 +142,7 @@ class TestRunApi(ApiTestBase):
         run_props = data['props']
 
         self.assertEqual('Run # 1', run_props['name'])
-        self.assertEqual(None, run_props['experiment'])
+        self.assertEqual('default', run_props['experiment'])
         self.assertEqual(0, len(run_props['tags']))
 
     def test_run_traces_batch_api(self):

--- a/tests/api/test_structured_data_api.py
+++ b/tests/api/test_structured_data_api.py
@@ -161,7 +161,7 @@ class TestExperimentsApi(StructuredApiTestBase):
         response = client.get('/api/experiments')
         self.assertEqual(200, response.status_code)
         data = response.json()
-        self.assertEqual(2, len(data))
+        self.assertEqual(3, len(data))  # count default experiment
 
     def test_search_experiments_api(self):
         client = self.client

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,7 @@ class TestBase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
+        # TODO [AT]: find a way to run this without breaking run.props in readonly mode
         truncate_structured_db(cls.repo.structured_db)
 
     def tearDown(self) -> None:

--- a/tests/test_upgrade_cmd.py
+++ b/tests/test_upgrade_cmd.py
@@ -1,0 +1,4 @@
+from aim.cli.upgrade.utils import convert_2to3
+
+def test_upgrade_cmd():
+    convert_2to3('/Users/alberttorosyan/aimhub/logs/small_sample/.aim')


### PR DESCRIPTION
Removed all the logic associated with the case when sqlite Run is missing. Added `run.experiment = 'default'` for newly created runs