### PR TITLE
Set max width on table column

### DIFF
--- a/aim/web/ui_v2/src/components/CustomTable/Table.scss
+++ b/aim/web/ui_v2/src/components/CustomTable/Table.scss
@@ -8,7 +8,7 @@ $grey-darker: #24292e;
 $grey-bg: #f7f7f7;
 $grey-lighter: #e8e8e8;
 $grey-light-xx: #d4d4d4;
-$primary: #1C2852FF;
+$primary: #1c2852ff;
 $primary-dark: #243969;
 $primary-darker: #142447;
 $primary-bg: #f7faff;
@@ -94,6 +94,7 @@ $group-margin: 8px;
   width: stretch;
   width: -webkit-fill-available;
   width: -moz-available;
+  max-width: 500px;
 
   &:last-of-type {
     .Table__cell,

--- a/aim/web/ui_v2/src/components/CustomTable/TableColumn.tsx
+++ b/aim/web/ui_v2/src/components/CustomTable/TableColumn.tsx
@@ -56,7 +56,7 @@ function Column({
     } else {
       newWidth = evt.pageX - startingPoint.current;
     }
-    if (newWidth > 85) {
+    if (newWidth > 85 && newWidth < 500) {
       widthClone.current = newWidth;
       setMaxWidth(newWidth);
     }


### PR DESCRIPTION
Currently, columns in our table have dynamic width. 
Depending on their content they can shrink and expand.

To avoid viewport overlapping by a column we're setting `max-width: 500px;` on table column. 