### PR TITLE
Fixed select form layout issues

### DIFF
--- a/aim/web/ui_v2/src/components/ControlPopover/ControlPopover.tsx
+++ b/aim/web/ui_v2/src/components/ControlPopover/ControlPopover.tsx
@@ -11,6 +11,7 @@ function ControlPopover({
   anchor,
   anchorOrigin,
   transformOrigin,
+  open = true,
 }: IControlPopoverProps): React.FunctionComponentElement<React.ReactNode> {
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
@@ -26,11 +27,17 @@ function ControlPopover({
     setAnchorEl(null);
   }, []);
 
+  React.useEffect(() => {
+    if (!open) {
+      setAnchorEl(null);
+    }
+  }, [open]);
+
   return (
     <>
-      {anchor({ onAnchorClick, opened: !!anchorEl })}
+      {anchor({ onAnchorClick, opened: open && !!anchorEl })}
       <Popover
-        open={!!anchorEl}
+        open={open && !!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorPosition={{ left: 20, top: 0 }}

--- a/aim/web/ui_v2/src/pages/Metrics/components/Controls/Controls.tsx
+++ b/aim/web/ui_v2/src/pages/Metrics/components/Controls/Controls.tsx
@@ -22,15 +22,9 @@ function Controls(
       <div>
         <ControlPopover
           title='Select Aggregation Method'
+          open={!!props.aggregationConfig.isEnabled}
           anchor={({ onAnchorClick, opened }) => (
             <div
-              onClick={() => {
-                if (props.aggregationConfig.isEnabled) {
-                  props.onAggregationConfigChange({
-                    isApplied: !props.aggregationConfig?.isApplied,
-                  });
-                }
-              }}
               className={`Controls__anchor ${
                 props.aggregationConfig.isApplied ? 'active outlined' : ''
               } ${props.aggregationConfig.isEnabled ? '' : 'disabled'}`}
@@ -40,6 +34,7 @@ function Controls(
                   className={`Controls__anchor__arrow ${
                     opened ? 'Controls__anchor__arrow__opened' : ''
                   }`}
+                  onClick={onAnchorClick}
                 >
                   <Icon name='arrow-left' onClick={onAnchorClick} />
                 </span>
@@ -49,16 +44,21 @@ function Controls(
                   props.aggregationConfig.isApplied ? 'active' : ''
                 }`}
                 name='aggregation'
+                onClick={() => {
+                  if (props.aggregationConfig.isEnabled) {
+                    props.onAggregationConfigChange({
+                      isApplied: !props.aggregationConfig?.isApplied,
+                    });
+                  }
+                }}
               />
             </div>
           )}
           component={
-            props.aggregationConfig.isEnabled ? (
-              <AggregationPopup
-                aggregationConfig={props.aggregationConfig}
-                onChange={props.onAggregationConfigChange}
-              />
-            ) : null
+            <AggregationPopup
+              aggregationConfig={props.aggregationConfig}
+              onChange={props.onAggregationConfigChange}
+            />
           }
         />
       </div>
@@ -240,6 +240,7 @@ function Controls(
       <div>
         <ControlPopover
           title='Select Option To Zoom Out'
+          open={!!props.zoom?.history.length}
           anchor={({ onAnchorClick, opened }) => (
             <div
               className={`Controls__anchor ${
@@ -270,12 +271,10 @@ function Controls(
             </div>
           )}
           component={
-            props.zoom?.history.length ? (
-              <ZoomOutPopup
-                zoomHistory={props.zoom?.history}
-                onChange={props.onZoomChange}
-              />
-            ) : null
+            <ZoomOutPopup
+              zoomHistory={props.zoom?.history}
+              onChange={props.onZoomChange}
+            />
           }
         />
       </div>

--- a/aim/web/ui_v2/src/pages/Metrics/components/SelectForm/SelectForm.scss
+++ b/aim/web/ui_v2/src/pages/Metrics/components/SelectForm/SelectForm.scss
@@ -91,6 +91,7 @@
     top: -2px;
     color: white;
     border-radius: 8px;
+    pointer-events: none;
   }
 
   i {

--- a/aim/web/ui_v2/src/pages/Params/components/SelectForm/SelectForm.scss
+++ b/aim/web/ui_v2/src/pages/Params/components/SelectForm/SelectForm.scss
@@ -80,6 +80,7 @@
     top: -2px;
     color: white;
     border-radius: 8px;
+    pointer-events: none;
   }
 
   i {

--- a/aim/web/ui_v2/src/types/components/ControlPopover/ControlPopover.d.ts
+++ b/aim/web/ui_v2/src/types/components/ControlPopover/ControlPopover.d.ts
@@ -8,4 +8,5 @@ export default interface IControlPopoverProps extends Partial<PopoverProps> {
   }) => React.FunctionComponentElement<React.ReactNode> | HTMLElement | null;
   component: React.FunctionComponentElement<React.ReactNode> | null;
   title?: string;
+  open?: boolean;
 }

--- a/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui_v2/src/utils/d3/drawHoverAttributes.ts
@@ -16,7 +16,6 @@ import getFormattedValue from 'utils/formattedValue';
 import { IUpdateFocusedChartProps } from 'types/components/LineChart/LineChart';
 import { HighlightEnum } from 'components/HighlightModesPopover/HighlightModesPopover';
 import { AggregationAreaMethods } from 'utils/aggregateGroupData';
-import { decode } from 'utils/encoder/encoder';
 import { AlignmentOptions } from 'config/alignment/alignmentOptions';
 import shortEnglishHumanizer from 'utils/shortEnglishHumanizer';
 

--- a/aim/web/ui_v2/src/utils/formatXAxisValueByAlignment.ts
+++ b/aim/web/ui_v2/src/utils/formatXAxisValueByAlignment.ts
@@ -12,7 +12,7 @@ function formatXAxisValueByAlignment({
   humanizerConfig?: {};
 }) {
   let formattedXAxisValue;
-  if (xAxisTickValue) {
+  if (xAxisTickValue || xAxisTickValue === 0) {
     switch (type) {
       case AlignmentOptions.RELATIVE_TIME:
         formattedXAxisValue = shortEnglishHumanizer(
@@ -32,7 +32,7 @@ function formatXAxisValueByAlignment({
     }
   }
 
-  return formattedXAxisValue || '--';
+  return formattedXAxisValue ?? '--';
 }
 
 export default formatXAxisValueByAlignment;


### PR DESCRIPTION
Fix: 
- Tune reset button of selected metrics tags
- Chart tooltip 0 step value from "--" to "0" (nullish coalescing)
-  Add ControlsPopover 'open' props