### PR TITLE
Fix Table export CSV button for all (Metrics, Params, Runs) pages

### DIFF
--- a/aim/web/ui_v2/src/components/CustomTable/Table.tsx
+++ b/aim/web/ui_v2/src/components/CustomTable/Table.tsx
@@ -233,7 +233,10 @@ function Table(props) {
                 headerMeta={props.headerMeta}
                 isAlwaysVisible={props.alwaysVisibleColumns?.includes(col.key)}
                 hideColumn={() =>
-                  props.setExcludedFields([...props.excludedFields, col.key])
+                  props.setExcludedFields?.([
+                    ...(props.excludedFields || []),
+                    col.key,
+                  ])
                 }
                 paneFirstColumn={index === 0}
                 paneLastColumn={index === leftPane.length - 1}
@@ -279,7 +282,10 @@ function Table(props) {
               headerMeta={props.headerMeta}
               isAlwaysVisible={props.alwaysVisibleColumns?.includes(col.key)}
               hideColumn={() =>
-                props.setExcludedFields([...props.excludedFields, col.key])
+                props.setExcludedFields?.([
+                  ...(props.excludedFields || []),
+                  col.key,
+                ])
               }
               paneFirstColumn={index === 0}
               paneLastColumn={index === middlePane.length - 1}
@@ -336,7 +342,10 @@ function Table(props) {
                 headerMeta={props.headerMeta}
                 isAlwaysVisible={props.alwaysVisibleColumns?.includes(col.key)}
                 hideColumn={() =>
-                  props.setExcludedFields([...props.excludedFields, col.key])
+                  props.setExcludedFields?.([
+                    ...(props.excludedFields || []),
+                    col.key,
+                  ])
                 }
                 paneFirstColumn={index === 0}
                 paneLastColumn={index === rightPane.length - 1}

--- a/aim/web/ui_v2/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
+++ b/aim/web/ui_v2/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
@@ -17,7 +17,7 @@ function getMetricsTableColumns(
     line: AggregationLineMethods;
   },
 ): ITableColumn[] {
-  let columns = [
+  let columns: ITableColumn[] = [
     {
       key: 'experiment',
       content: <span>Experiment</span>,
@@ -156,6 +156,8 @@ function getMetricsTableColumns(
     if (!columnsOrder.includes(a.key) && !columnsOrder.includes(b.key)) {
       return 0;
     } else if (!columnsOrder.includes(a.key)) {
+      return 1;
+    } else if (!columnsOrder.includes(b.key)) {
       return -1;
     }
     return columnsOrder.indexOf(a.key) - columnsOrder.indexOf(b.key);

--- a/aim/web/ui_v2/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/aim/web/ui_v2/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -144,7 +144,7 @@ function ManageColumnsPopover({
                     key={index}
                     data={data}
                     index={index}
-                    isHidden={hiddenColumns.includes(data)}
+                    isHidden={!!hiddenColumns?.includes(data)}
                     onClick={() =>
                       onColumnsVisibilityChange(
                         hiddenColumns.includes(data)
@@ -188,7 +188,7 @@ function ManageColumnsPopover({
                       key={index}
                       data={data}
                       index={index}
-                      isHidden={hiddenColumns.includes(data)}
+                      isHidden={!!hiddenColumns?.includes(data)}
                       onClick={() =>
                         onColumnsVisibilityChange(
                           hiddenColumns.includes(data)
@@ -225,7 +225,7 @@ function ManageColumnsPopover({
                       key={index}
                       data={data}
                       index={index}
-                      isHidden={hiddenColumns.includes(data)}
+                      isHidden={!!hiddenColumns?.includes(data)}
                       onClick={() =>
                         onColumnsVisibilityChange(
                           hiddenColumns.includes(data)

--- a/aim/web/ui_v2/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
+++ b/aim/web/ui_v2/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
@@ -6,8 +6,9 @@ function getParamsTableColumns(
   paramColumns: string[] = [],
   groupFields: { [key: string]: string } | null,
   order: { left: string[]; middle: string[]; right: string[] },
+  hiddenColumns: string[],
 ): ITableColumn[] {
-  const columns = [
+  let columns: ITableColumn[] = [
     {
       key: 'experiment',
       content: <span>Experiment</span>,
@@ -43,31 +44,9 @@ function getParamsTableColumns(
     })),
   );
 
-  // if (groupFields) {
-  //   Object.keys(groupFields).forEach((field) => {
-  //     const key = field.replace('run.params.', '');
-  //     const column = columns.find((col) => col.key === key);
-  //     if (!!column) {
-  //       column.pin = 'left';
-  //       column.topHeader = 'Grouping';
-  //     }
-  //   });
-  //   columns.sort((a, b) => {
-  //     if (a.key === '#') {
-  //       return -1;
-  //     } else if (
-  //       groupFields.hasOwnProperty(a.key) ||
-  //       groupFields.hasOwnProperty(`run.params.${a.key}`)
-  //     ) {
-  //       return -1;
-  //     }
-  //     return 0;
-  //   });
-  // }
   if (groupFields) {
     columns.push({
       key: '#',
-      //@ts-ignore
       content: '#',
       topHeader: 'Grouping',
       pin: 'left',
@@ -81,6 +60,12 @@ function getParamsTableColumns(
       }
     });
   }
+
+  columns = columns.map((col) => ({
+    ...col,
+    isHidden: hiddenColumns.includes(col.key),
+  }));
+
   const columnsOrder = order?.left.concat(order.middle).concat(order.right);
   columns.sort((a, b) => {
     if (a.key === '#') {
@@ -96,6 +81,8 @@ function getParamsTableColumns(
     if (!columnsOrder.includes(a.key) && !columnsOrder.includes(b.key)) {
       return 0;
     } else if (!columnsOrder.includes(a.key)) {
+      return 1;
+    } else if (!columnsOrder.includes(b.key)) {
       return -1;
     }
     return columnsOrder.indexOf(a.key) - columnsOrder.indexOf(b.key);

--- a/aim/web/ui_v2/src/pages/Runs/components/RunsTableColumns/RunsTableColumns.tsx
+++ b/aim/web/ui_v2/src/pages/Runs/components/RunsTableColumns/RunsTableColumns.tsx
@@ -5,8 +5,9 @@ function getRunsTableColumns(
   runColumns: string[] = [],
   groupFields: { [key: string]: string } | null,
   order: { left: string[]; middle: string[]; right: string[] },
+  hiddenColumns: string[],
 ): ITableColumn[] {
-  const columns: ITableColumn[] = [
+  let columns: ITableColumn[] = [
     {
       key: 'experiment',
       content: <span>Experiment</span>,
@@ -60,6 +61,11 @@ function getRunsTableColumns(
     });
   }
 
+  columns = columns.map((col) => ({
+    ...col,
+    isHidden: hiddenColumns.includes(col.key),
+  }));
+
   const columnsOrder = order?.left.concat(order.middle).concat(order.right);
   columns.sort((a, b) => {
     if (a.key === '#') {
@@ -75,6 +81,8 @@ function getRunsTableColumns(
     if (!columnsOrder.includes(a.key) && !columnsOrder.includes(b.key)) {
       return 0;
     } else if (!columnsOrder.includes(a.key)) {
+      return 1;
+    } else if (!columnsOrder.includes(b.key)) {
       return -1;
     }
     return columnsOrder.indexOf(a.key) - columnsOrder.indexOf(b.key);

--- a/aim/web/ui_v2/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/metrics/metricsAppModel.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as _ from 'lodash-es';
+import _ from 'lodash-es';
 import { saveAs } from 'file-saver';
 import moment from 'moment';
 
@@ -999,15 +999,21 @@ function getDataAsTableRows(
         metric: metric.metric_name,
         context: Object.entries(metric.context).map((entry) => entry.join(':')),
         value:
-          closestIndex === null ? '-' : `${metric.data.values[closestIndex]}`,
+          closestIndex === null
+            ? '-'
+            : `${metric.data.values[closestIndex] ?? '-'}`,
         step:
-          closestIndex === null ? '-' : `${metric.data.steps[closestIndex]}`,
+          closestIndex === null
+            ? '-'
+            : `${metric.data.steps[closestIndex] ?? '-'}`,
         epoch:
-          closestIndex === null ? '-' : `${metric.data.epochs[closestIndex]}`,
+          closestIndex === null
+            ? '-'
+            : `${metric.data.epochs[closestIndex] ?? '-'}`,
         time:
           closestIndex === null
             ? '-'
-            : `${metric.data.timestamps[closestIndex]}`,
+            : `${metric.data.timestamps[closestIndex] ?? '-'}`,
         parentId: groupKey,
       };
       rowIndex++;
@@ -1231,7 +1237,11 @@ function updateModelData(configData: IMetricAppConfig): void {
   const { data, params } = processData(
     model.getState()?.rawData as IRun<IMetricTrace>[],
   );
-  const tableData = getDataAsTableRows(data, null, params);
+  const tableData = getDataAsTableRows(
+    data,
+    configData?.chart?.focusedState.xValue ?? null,
+    params,
+  );
   const tableColumns = getMetricsTableColumns(
     params,
     data[0]?.config,
@@ -1378,12 +1388,10 @@ function onActivePointChange(
   activePoint: IActivePoint,
   focusedStateActive: boolean = false,
 ): void {
-  const tableRef: any = model.getState()?.refs?.tableRef;
-  const tableData = getDataAsTableRows(
-    model.getState()!.data!,
-    activePoint.xValue,
-    model.getState()!.params!,
-  );
+  const { data, params, refs, config } =
+    model.getState() as IMetricAppModelState;
+  const tableRef: any = refs?.tableRef;
+  const tableData = getDataAsTableRows(data, activePoint.xValue, params);
   if (tableRef) {
     tableRef.current?.updateData({
       newData: tableData.rows,
@@ -1397,7 +1405,7 @@ function onActivePointChange(
       tableRef.current?.scrollToRow?.(activePoint.key);
     }
   }
-  let configData: IMetricAppConfig | undefined = model.getState()?.config;
+  let configData: IMetricAppConfig = config;
   if (configData?.chart) {
     configData = {
       ...configData,
@@ -1465,7 +1473,7 @@ function getFilteredRow(
     if (Array.isArray(value)) {
       value = value.join(', ');
     } else if (typeof value !== 'string') {
-      value = JSON.stringify(value);
+      value = value || value === 0 ? JSON.stringify(value) : '-';
     }
 
     if (column.startsWith('params.')) {
@@ -1479,63 +1487,55 @@ function getFilteredRow(
 }
 
 function onExportTableData(e: React.ChangeEvent<any>): void {
-  const processedData = processData(
-    model.getState()?.rawData as IRun<IMetricTrace>[],
-  );
+  const { data, params, config } = model.getState() as IMetricAppModelState;
 
   const tableData = getDataAsTableRows(
-    processedData.data,
-    null,
-    processedData.params,
+    data,
+    config?.chart?.focusedState.xValue ?? null,
+    params,
   );
   const tableColumns: ITableColumn[] = getMetricsTableColumns(
-    processedData.params,
-    processedData.data[0]?.config,
-    model.getState()?.config?.table.columnsOrder!,
-    model.getState()?.config?.table.hiddenColumns!,
+    params,
+    data[0]?.config,
+    config?.table.columnsOrder!,
+    config?.table.hiddenColumns!,
   );
-  // TODO need to filter excludedFields and sort column order
-  const excludedFields: string[] = [];
+
+  const excludedFields: string[] = ['#', 'actions'];
   const filteredHeader: string[] = tableColumns.reduce(
     (acc: string[], column: ITableColumn) =>
-      acc.concat(excludedFields.indexOf(column.key) === -1 ? column.key : []),
+      acc.concat(
+        excludedFields.indexOf(column.key) === -1 && !column.isHidden
+          ? column.key
+          : [],
+      ),
     [],
   );
-  // const flattenOrders = Object.keys(columnsOrder).reduce(
-  //   (acc, key) => acc.concat(columnsOrder[key]),
-  //   [],
-  // );
-  // filteredHeader.sort(
-  //   (a, b) => flattenOrders.indexOf(a) - flattenOrders.indexOf(b),
-  // );
 
   let emptyRow: { [key: string]: string } = {};
   filteredHeader.forEach((column: string) => {
     emptyRow[column] = '--';
   });
 
-  const dataToExport = tableData.rows?.reduce(
-    (
-      accArray: { [key: string]: string }[],
-      rowData: IMetricTableRowData,
-      rowDataIndex: number,
-    ) => {
-      if (rowData?.children?.length > 0) {
-        rowData.children.forEach((row: IMetricTableRowData) => {
-          const filteredRow = getFilteredRow(filteredHeader, row);
-          accArray = accArray.concat(filteredRow);
-        });
-        if (tableData.rows.length - 1 !== rowDataIndex) {
-          accArray = accArray.concat(emptyRow);
-        }
-      } else {
-        const filteredRow = getFilteredRow(filteredHeader, rowData);
-        accArray = accArray.concat(filteredRow);
-      }
+  const groupedRows: IMetricTableRowData[][] =
+    data.length > 1
+      ? Object.keys(tableData.rows).map(
+          (groupedRowKey: string) => tableData.rows[groupedRowKey].items,
+        )
+      : [tableData.rows];
 
-      return accArray;
+  const dataToExport: { [key: string]: string }[] = [];
+
+  groupedRows.forEach(
+    (groupedRow: IMetricTableRowData[], groupedRowIndex: number) => {
+      groupedRow.forEach((row: IMetricTableRowData) => {
+        const filteredRow = getFilteredRow(filteredHeader, row);
+        dataToExport.push(filteredRow);
+      });
+      if (groupedRows.length - 1 !== groupedRowIndex) {
+        dataToExport.push(emptyRow);
+      }
     },
-    [],
   );
 
   const blob = new Blob([JsonToCSV(dataToExport)], {
@@ -1690,7 +1690,11 @@ function setModelData(
   if (configData) {
     setAggregationEnabled(configData);
   }
-  const tableData = getDataAsTableRows(data, null, params);
+  const tableData = getDataAsTableRows(
+    data,
+    configData?.chart?.focusedState.xValue ?? null,
+    params,
+  );
   model.setState({
     requestIsPending: false,
     rawData,

--- a/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
@@ -1,8 +1,10 @@
 import React from 'react';
-import _, { isEmpty } from 'lodash-es';
+import _ from 'lodash-es';
+import moment from 'moment';
+import { saveAs } from 'file-saver';
+
 import runsService from 'services/api/runs/runsService';
 import createModel from '../model';
-import { saveAs } from 'file-saver';
 import { encode } from 'utils/encoder/encoder';
 import getObjectPaths from 'utils/getObjectPaths';
 import contextToString from 'utils/contextToString';
@@ -36,6 +38,7 @@ import {
   IChartTitle,
   IChartTitleData,
   IMetricTableRowData,
+  IMetricAppModelState,
 } from 'types/services/models/metrics/metricsAppModel';
 import { IRun, IParamTrace } from 'types/services/models/metrics/runModel';
 import {
@@ -52,9 +55,9 @@ import { INotification } from 'types/components/NotificationContainer/Notificati
 import { getParamsTableColumns } from 'pages/Params/components/ParamsTableGrid/ParamsTableGrid';
 import { ITableColumn } from 'types/pages/metrics/components/TableColumns/TableColumns';
 import JsonToCSV from 'utils/JsonToCSV';
-import moment from 'moment';
 import { RowHeightSize } from 'config/table/tableConfigs';
 
+// TODO need to implement state type
 const model = createModel<Partial<any>>({ isParamsLoading: false });
 let tooltipData: ITooltipData = {};
 
@@ -186,7 +189,7 @@ function getParamsData() {
     call: async () => {
       const select = model.getState()?.config?.select;
       getRunsRequestRef = runsService.getRunsData(select?.query);
-      if (!isEmpty(select?.params)) {
+      if (!_.isEmpty(select?.params)) {
         model.setState({ isParamsLoading: true });
         const stream = await getRunsRequestRef.call();
         let gen = adjustable_reader(stream);
@@ -206,6 +209,7 @@ function getParamsData() {
           ];
         }
 
+        const tableData = getDataAsTableRows(data, null, params);
         model.setState({
           data,
           highPlotData: getDataAsLines(data),
@@ -213,11 +217,12 @@ function getParamsData() {
           params,
           rawData: runData,
           config: configData,
-          tableData: getDataAsTableRows(data, null, params),
+          tableData: tableData.rows,
           tableColumns: getParamsTableColumns(
             params,
             data[0]?.config,
             configData.table.columnsOrder!,
+            configData.table.hiddenColumns!,
           ),
           isParamsLoading: false,
           groupingSelectOptions: [...getGroupingSelectOptions(params)],
@@ -679,43 +684,46 @@ function onActivePointChange(
   activePoint: IActivePoint,
   focusedStateActive: boolean = false,
 ): void {
-  const configData: IParamsAppConfig = model.getState()?.config;
-  if (configData?.chart) {
-    const tableRef: any = model.getState()?.refs?.tableRef;
-    if (tableRef) {
-      tableRef.current?.setHoveredRow?.(activePoint.key);
-      tableRef.current?.setActiveRow?.(
-        focusedStateActive ? activePoint.key : null,
-      );
-      if (focusedStateActive) {
-        tableRef.current?.scrollToRow?.(activePoint.key);
-      }
+  const { data, params, refs, config } = model.getState() as any;
+  const tableData = getDataAsTableRows(data, null, params);
+  const tableRef: any = refs?.tableRef;
+  if (tableRef) {
+    tableRef.current?.setHoveredRow?.(activePoint.key);
+    tableRef.current?.setActiveRow?.(
+      focusedStateActive ? activePoint.key : null,
+    );
+    if (focusedStateActive) {
+      tableRef.current?.scrollToRow?.(activePoint.key);
     }
-    model.getState()?.refs?.tableRef?.current?.setHoveredRow(activePoint.key);
-    let chart =
-      focusedStateActive !== configData.chart.focusedState.active
-        ? { ...configData.chart }
-        : configData.chart;
-
-    chart.focusedState = {
-      active: !!focusedStateActive,
-      key: activePoint.key,
-      xValue: activePoint.xValue,
-      yValue: activePoint.yValue,
-      chartIndex: activePoint.chartIndex,
-    };
-    chart.tooltip = {
-      ...configData.chart.tooltip,
-      content: filterTooltipContent(
-        tooltipData[activePoint.key],
-        configData?.chart.tooltip.selectedParams,
-      ),
-    };
-
-    model.setState({
-      config: { ...configData, chart },
-    });
   }
+  let configData: IParamsAppConfig = config;
+  if (configData?.chart) {
+    configData = {
+      ...configData,
+      chart: {
+        ...configData.chart,
+        focusedState: {
+          active: focusedStateActive,
+          key: activePoint.key,
+          xValue: activePoint.xValue,
+          yValue: activePoint.yValue,
+          chartIndex: activePoint.chartIndex,
+        },
+        tooltip: {
+          ...configData.chart.tooltip,
+          content: filterTooltipContent(
+            tooltipData[activePoint.key],
+            configData?.chart.tooltip.selectedParams,
+          ),
+        },
+      },
+    };
+  }
+
+  model.setState({
+    tableData: tableData.rows,
+    config: configData,
+  });
 }
 
 function onParamsSelectChange(data: any[]) {
@@ -836,10 +844,11 @@ function updateModelData(configData: IParamsAppConfig): void {
     params,
     data[0]?.config,
     configData.table.columnsOrder!,
+    configData.table.hiddenColumns!,
   );
   const tableRef: any = model.getState()?.refs?.tableRef;
   tableRef.current?.updateData({
-    newData: tableData,
+    newData: tableData.rows,
     newColumns: tableColumns,
   });
   model.setState({
@@ -848,26 +857,30 @@ function updateModelData(configData: IParamsAppConfig): void {
     highPlotData: getDataAsLines(data),
     chartTitleData: getChartTitleData(data),
     groupingSelectOptions: [...getGroupingSelectOptions(params)],
-    tableData,
+    tableData: tableData.rows,
     tableColumns,
   });
 }
 
 function getDataAsTableRows(
-  processedData: IMetricsCollection<any>[],
+  processedData: IMetricsCollection<IParam>[],
   xValue: number | string | null = null,
   paramKeys: string[],
-): IMetricTableRowData[] | any {
+): { rows: IMetricTableRowData[] | any; sameValueColumns: string[] } {
   if (!processedData) {
-    return [];
+    return {
+      rows: [],
+      sameValueColumns: [],
+    };
   }
 
   const rows: IMetricTableRowData[] | any =
     processedData[0]?.config !== null ? {} : [];
 
   let rowIndex = 0;
+  const sameValueColumns: string[] = [];
 
-  processedData.forEach((metricsCollection: IMetricsCollection<any>) => {
+  processedData.forEach((metricsCollection: IMetricsCollection<IParam>) => {
     const groupKey = metricsCollection.key;
     const columnsValues: { [key: string]: string[] } = {};
 
@@ -943,8 +956,12 @@ function getDataAsTableRows(
       }
     });
 
-    if (metricsCollection.config !== null) {
-      for (let columnKey in columnsValues) {
+    for (let columnKey in columnsValues) {
+      if (columnsValues[columnKey].length === 1) {
+        sameValueColumns.push(columnKey);
+      }
+
+      if (metricsCollection.config !== null) {
         rows[groupKey!].data[columnKey] =
           columnsValues[columnKey].length > 1
             ? 'Mix'
@@ -953,7 +970,7 @@ function getDataAsTableRows(
     }
   });
 
-  return rows;
+  return { rows, sameValueColumns };
 }
 
 function onGroupingApplyChange(groupName: GroupNameType): void {
@@ -1067,7 +1084,7 @@ function getFilteredRow(
     if (Array.isArray(value)) {
       value = value.join(', ');
     } else if (typeof value !== 'string') {
-      value = JSON.stringify(value);
+      value = value || value === 0 ? JSON.stringify(value) : '-';
     }
 
     if (column.startsWith('params.')) {
@@ -1081,23 +1098,23 @@ function getFilteredRow(
 }
 
 function onExportTableData(e: React.ChangeEvent<any>): void {
-  const processedData = processData(model.getState()?.rawData as IRun<any>[]);
+  const { data, params, config } = model.getState() as any;
 
-  const tableData: IMetricTableRowData[] = getDataAsTableRows(
-    processedData.data,
-    null,
-    processedData.params,
-  );
+  const tableData = getDataAsTableRows(data, null, params);
   const tableColumns: ITableColumn[] = getParamsTableColumns(
-    processedData.params,
-    processedData.data[0]?.config,
-    model.getState()?.config.table.columnsOrder!,
+    params,
+    data[0]?.config,
+    config.table.columnsOrder!,
+    config.table.hiddenColumns!,
   );
-  // TODO need to filter excludedFields and sort column order
-  const excludedFields: string[] = [];
+  const excludedFields: string[] = ['#', 'actions'];
   const filteredHeader: string[] = tableColumns.reduce(
     (acc: string[], column: ITableColumn) =>
-      acc.concat(excludedFields.indexOf(column.key) === -1 ? column.key : []),
+      acc.concat(
+        excludedFields.indexOf(column.key) === -1 && !column.isHidden
+          ? column.key
+          : [],
+      ),
     [],
   );
 
@@ -1106,34 +1123,31 @@ function onExportTableData(e: React.ChangeEvent<any>): void {
     emptyRow[column] = '--';
   });
 
-  const dataToExport = tableData?.reduce(
-    (
-      accArray: { [key: string]: string }[],
-      rowData: IMetricTableRowData,
-      rowDataIndex: number,
-    ) => {
-      if (rowData?.children?.length > 0) {
-        rowData.children.forEach((row: IMetricTableRowData) => {
-          const filteredRow = getFilteredRow(filteredHeader, row);
-          accArray = accArray.concat(filteredRow);
-        });
-        if (tableData.length - 1 !== rowDataIndex) {
-          accArray = accArray.concat(emptyRow);
-        }
-      } else {
-        const filteredRow = getFilteredRow(filteredHeader, rowData);
-        accArray = accArray.concat(filteredRow);
-      }
+  const groupedRows: IMetricTableRowData[][] =
+    data.length > 1
+      ? Object.keys(tableData.rows).map(
+          (groupedRowKey: string) => tableData.rows[groupedRowKey].items,
+        )
+      : [tableData.rows];
 
-      return accArray;
+  const dataToExport: { [key: string]: string }[] = [];
+
+  groupedRows.forEach(
+    (groupedRow: IMetricTableRowData[], groupedRowIndex: number) => {
+      groupedRow.forEach((row: IMetricTableRowData) => {
+        const filteredRow = getFilteredRow(filteredHeader, row);
+        dataToExport.push(filteredRow);
+      });
+      if (groupedRows.length - 1 !== groupedRowIndex) {
+        dataToExport.push(emptyRow);
+      }
     },
-    [],
   );
 
   const blob = new Blob([JsonToCSV(dataToExport)], {
     type: 'text/csv;charset=utf-8;',
   });
-  saveAs(blob, `metrics-${moment().format('HH:mm:ss · D MMM, YY')}.csv`);
+  saveAs(blob, `params-${moment().format('HH:mm:ss · D MMM, YY')}.csv`);
 }
 
 function onNotificationDelete(id: number) {

--- a/aim/web/ui_v2/src/services/models/runs/runsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/runs/runsAppModel.ts
@@ -1,3 +1,8 @@
+import React from 'react';
+import _ from 'lodash-es';
+import moment from 'moment';
+import { saveAs } from 'file-saver';
+
 import runsService from 'services/api/runs/runsService';
 import createModel from '../model';
 import {
@@ -16,7 +21,6 @@ import { IParam } from 'types/services/models/params/paramsAppModel';
 import getObjectPaths from 'utils/getObjectPaths';
 import COLORS from 'config/colors/colors';
 import DASH_ARRAYS from 'config/dash-arrays/dashArrays';
-import _ from 'lodash-es';
 import { encode, decode } from 'utils/encoder/encoder';
 import { IMetric } from '../../../types/services/models/metrics/metricModel';
 import {
@@ -38,14 +42,13 @@ import { CurveEnum, ScaleEnum } from '../../../utils/d3';
 import { SmoothingAlgorithmEnum } from '../../../utils/smoothingData';
 import { RowHeightSize } from '../../../config/table/tableConfigs';
 import getStateFromUrl from '../../../utils/getStateFromUrl';
-import React from 'react';
 import getUrlWithParam from '../../../utils/getUrlWithParam';
 import { setItem, getItem } from '../../../utils/storage';
 import { ITableColumn } from '../../../types/pages/metrics/components/TableColumns/TableColumns';
 import JsonToCSV from '../../../utils/JsonToCSV';
-import { saveAs } from 'file-saver';
-import moment from 'moment';
+import { getParamsTableColumns } from '../../../pages/Params/components/ParamsTableGrid/ParamsTableGrid';
 
+// TODO need to implement state type
 const model = createModel<Partial<any>>({
   requestIsPending: true,
   infiniteIsPending: false,
@@ -210,6 +213,7 @@ function getRunsData(isInitial = true) {
           params,
           data[0]?.config,
           model.getState()?.config?.table.columnsOrder!,
+          model.getState()?.config?.table.hiddenColumns!,
         );
 
         model.setState({
@@ -218,7 +222,7 @@ function getRunsData(isInitial = true) {
           requestIsPending: false,
           infiniteIsPending: false,
           tableColumns,
-          tableData,
+          tableData: tableData.rows,
           config: {
             ...modelState?.config,
             pagination: {
@@ -232,7 +236,7 @@ function getRunsData(isInitial = true) {
         setTimeout(() => {
           const tableRef: any = model.getState()?.refs?.tableRef;
           tableRef.current?.updateData({
-            newData: tableData,
+            newData: tableData.rows,
             newColumns: tableColumns,
           });
         }, 0);
@@ -347,7 +351,7 @@ function getFilteredRow(
     if (Array.isArray(value)) {
       value = value.join(', ');
     } else if (typeof value !== 'string') {
-      value = JSON.stringify(value);
+      value = value || value === 0 ? JSON.stringify(value) : '-';
     }
 
     if (column.startsWith('params.')) {
@@ -361,64 +365,53 @@ function getFilteredRow(
 }
 
 function onExportTableData(e: React.ChangeEvent<any>): void {
-  const processedData = processData(
+  const { data, params } = processData(
     model.getState()?.rowData as IRun<IMetricTrace>[],
   );
-
-  const tableData: IMetricTableRowData[] = getDataAsTableRows(
-    processedData.data,
-    null,
-    processedData.params,
+  const tableData = getDataAsTableRows(data, null, params);
+  const configData = model.getState()?.config;
+  const tableColumns: ITableColumn[] = getParamsTableColumns(
+    params,
+    data[0]?.config,
+    configData?.table.columnsOrder!,
+    configData?.table.hiddenColumns!,
   );
-  const tableColumns: ITableColumn[] = getRunsTableColumns(
-    processedData.params,
-    processedData.data[0]?.config,
-    model.getState()?.config?.table.columnsOrder!,
-  );
-  // TODO need to filter excludedFields and sort column order
-  const excludedFields: string[] = [];
+  const excludedFields: string[] = ['#', 'actions'];
   const filteredHeader: string[] = tableColumns.reduce(
     (acc: string[], column: ITableColumn) =>
-      acc.concat(excludedFields.indexOf(column.key) === -1 ? column.key : []),
+      acc.concat(
+        excludedFields.indexOf(column.key) === -1 && !column.isHidden
+          ? column.key
+          : [],
+      ),
     [],
   );
-  // const flattenOrders = Object.keys(columnsOrder).reduce(
-  //   (acc, key) => acc.concat(columnsOrder[key]),
-  //   [],
-  // );
-  // filteredHeader.sort(
-  //   (a, b) => flattenOrders.indexOf(a) - flattenOrders.indexOf(b),
-  // );
 
   let emptyRow: { [key: string]: string } = {};
   filteredHeader.forEach((column: string) => {
     emptyRow[column] = '--';
   });
 
-  const dataToExport = tableData?.reduce(
-    (
-      accArray: { [key: string]: string }[],
-      rowData: IMetricTableRowData,
-      rowDataIndex: number,
-    ) => {
-      if (rowData?.children?.length > 0) {
-        rowData.children.forEach((row: IMetricTableRowData) => {
-          const filteredRow = getFilteredRow(filteredHeader, row);
-          accArray = accArray.concat(filteredRow);
-        });
-        if (tableData.length - 1 !== rowDataIndex) {
-          accArray = accArray.concat(emptyRow);
-        }
-      } else {
-        const filteredRow = getFilteredRow(filteredHeader, rowData);
-        accArray = accArray.concat(filteredRow);
+  const groupedRows: IMetricTableRowData[][] =
+    data.length > 1
+      ? Object.keys(tableData.rows).map(
+          (groupedRowKey: string) => tableData.rows[groupedRowKey].items,
+        )
+      : [tableData.rows];
+
+  const dataToExport: { [key: string]: string }[] = [];
+
+  groupedRows.forEach(
+    (groupedRow: IMetricTableRowData[], groupedRowIndex: number) => {
+      groupedRow.forEach((row: IMetricTableRowData) => {
+        const filteredRow = getFilteredRow(filteredHeader, row);
+        dataToExport.push(filteredRow);
+      });
+      if (groupedRows.length - 1 !== groupedRowIndex) {
+        dataToExport.push(emptyRow);
       }
-
-      return accArray;
     },
-    [],
   );
-
   const blob = new Blob([JsonToCSV(dataToExport)], {
     type: 'text/csv;charset=utf-8;',
   });
@@ -653,12 +646,17 @@ function getDataAsTableRows(
   processedData: any,
   xValue: number | string | null = null,
   paramKeys: string[],
-): any {
+): { rows: IMetricTableRowData[] | any; sameValueColumns: string[] } {
   if (!processedData) {
-    return [];
+    return {
+      rows: [],
+      sameValueColumns: [],
+    };
   }
+
   const rows: any = processedData[0]?.config !== null ? {} : [];
   let rowIndex = 0;
+  const sameValueColumns: string[] = [];
 
   processedData.forEach((metricsCollection: any) => {
     const groupKey = metricsCollection.key;
@@ -727,8 +725,13 @@ function getDataAsTableRows(
         rows.push(rowValues);
       }
     });
-    if (metricsCollection.config !== null) {
-      for (let columnKey in columnsValues) {
+
+    for (let columnKey in columnsValues) {
+      if (columnsValues[columnKey].length === 1) {
+        sameValueColumns.push(columnKey);
+      }
+
+      if (metricsCollection.config !== null) {
         rows[groupKey!].data[columnKey] =
           columnsValues[columnKey].length > 1
             ? 'Mix'
@@ -736,7 +739,8 @@ function getDataAsTableRows(
       }
     }
   });
-  return rows;
+
+  return { rows, sameValueColumns };
 }
 
 function onSelectRunQueryChange(query: string) {
@@ -803,20 +807,21 @@ function updateModelData(configData: IMetricAppConfig): void {
     model.getState()?.rowData as IRun<IMetricTrace>[],
   );
   const tableData = getDataAsTableRows(data, null, params);
-  const tableColumns = getRunsTableColumns(
+  const tableColumns: ITableColumn[] = getRunsTableColumns(
     params,
     data[0]?.config,
     configData.table.columnsOrder!,
+    configData.table.hiddenColumns!,
   );
   const tableRef: any = model.getState()?.refs?.tableRef;
   tableRef.current?.updateData({
-    newData: tableData,
+    newData: tableData.rows,
     newColumns: tableColumns,
   });
   model.setState({
     config: configData,
     data,
-    tableData,
+    tableData: tableData.rows,
     tableColumns,
   });
 }

--- a/aim/web/ui_v2/src/types/pages/metrics/components/TableColumns/TableColumns.d.ts
+++ b/aim/web/ui_v2/src/types/pages/metrics/components/TableColumns/TableColumns.d.ts
@@ -5,4 +5,5 @@ export interface ITableColumn {
   content: React.ReactNode | string;
   topHeader: string;
   pin?: string | null;
+  isHidden?: boolean;
 }

--- a/aim/web/ui_v2/src/types/services/models/params/paramsAppModel.d.ts
+++ b/aim/web/ui_v2/src/types/services/models/params/paramsAppModel.d.ts
@@ -12,7 +12,6 @@ export interface IParam {
   color: string;
   key: string;
   dasharray: string;
-  isHidden?: boolean;
 }
 interface IParamsAppConfig {
   grouping: {


### PR DESCRIPTION
Fix:
 - sorted by order
 - filter hidden columns
 - 'getDataAsTableRows' function
 
 Add: 
 - xStep value for table columns for value, epoch, timestamp
 - tune grouped data export for table