### PR TITLE
Query syntax error handling on metrics and params pages

### DIFF
--- a/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
@@ -128,7 +128,7 @@ function getConfig() {
 }
 
 let getRunsRequestRef: {
-  call: () => Promise<any>;
+  call: (exceptionHandler: (detail: any) => void) => Promise<any>;
   abort: () => void;
 };
 
@@ -147,7 +147,44 @@ function initialize(appId: string): void {
     setDefaultAppConfigData();
   }
 }
+function resetModelOnError(detail?: any) {
+  model.setState({
+    data: [],
+    rowData: [],
+    highPlotData: [],
+    chartTitleData: null,
+    requestIsPending: false,
+    infiniteIsPending: false,
+    tableColumns: [],
+    tableData: [],
+    isParamsLoading: false,
+  });
 
+  setTimeout(() => {
+    const tableRef: any = model.getState()?.refs?.tableRef;
+    tableRef.current?.updateData({
+      newData: [],
+      newColumns: [],
+    });
+  }, 0);
+}
+
+function exceptionHandler(detail: any) {
+  let message = detail.message || 'Something went wrong';
+
+  if (detail.name === 'SyntaxError') {
+    message = `Query syntax error at line (${detail.line}, ${detail.offset})`;
+  }
+
+  onNotificationAdd({
+    id: Date.now(),
+    severity: 'error',
+    message,
+  });
+
+  // reset model
+  resetModelOnError(detail);
+}
 function getAppConfigData(appId: string) {
   if (appRequestRef) {
     appRequestRef.abort();
@@ -223,7 +260,7 @@ function getParamsData() {
       getRunsRequestRef = runsService.getRunsData(select?.query);
       if (!isEmpty(select?.params)) {
         model.setState({ isParamsLoading: true });
-        const stream = await getRunsRequestRef.call();
+        const stream = await getRunsRequestRef.call(exceptionHandler);
         let gen = adjustable_reader(stream);
         let buffer_pairs = decode_buffer_pairs(gen);
         let decodedPairs = decodePathsVals(buffer_pairs);


### PR DESCRIPTION
- Handled query syntax error on metrics and params pages
- Changed priority of custom query between generated query before sending the query to the back-end