### PR TITLE
Keep table resize state in model config

### DIFF
--- a/aim/web/ui_v2/src/pages/Metrics/MetricsContainer.tsx
+++ b/aim/web/ui_v2/src/pages/Metrics/MetricsContainer.tsx
@@ -52,7 +52,8 @@ function MetricsContainer(): React.FunctionComponentElement<React.ReactNode> {
     chartElemRef,
     tableElemRef,
     resizeElemRef,
-    metricsData?.config?.table.resizeMode || ResizeModeEnum.Resizable,
+    metricsData?.config?.table || {},
+    metricAppModel.onTableResizeEnd,
   );
 
   React.useEffect(() => {

--- a/aim/web/ui_v2/src/pages/Params/ParamsContainer.tsx
+++ b/aim/web/ui_v2/src/pages/Params/ParamsContainer.tsx
@@ -12,7 +12,6 @@ import usePanelResize from 'hooks/resize/usePanelResize';
 import { IParamsAppConfig } from 'types/services/models/params/paramsAppModel';
 import { useRouteMatch } from 'react-router-dom';
 import { RowHeightSize } from 'config/table/tableConfigs';
-import { ResizeModeEnum } from 'config/enums/tableEnums';
 
 function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
   const chartElemRef = React.useRef<HTMLDivElement>(null);
@@ -27,7 +26,8 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
     chartElemRef,
     tableElemRef,
     resizeElemRef,
-    paramsData?.config?.table.resizeMode || ResizeModeEnum.Resizable,
+    paramsData?.config?.table || {},
+    paramsAppModel.onTableResizeEnd,
   );
 
   React.useEffect(() => {

--- a/aim/web/ui_v2/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/metrics/metricsAppModel.ts
@@ -168,6 +168,7 @@ function getConfig(): IMetricAppConfig {
         middle: [],
         right: [],
       },
+      height: '',
     },
   };
 }
@@ -2013,6 +2014,25 @@ function onTableResizeModeChange(mode: ResizeModeEnum): void {
   }
 }
 
+function onTableResizeEnd(tableHeight: string) {
+  const configData: IMetricAppConfig | undefined = model.getState()?.config;
+  if (configData?.table) {
+    const table = {
+      ...configData.table,
+      height: tableHeight,
+    };
+    const config = {
+      ...configData,
+      table,
+    };
+    model.setState({
+      config,
+    });
+    setItem('metricsTable', encode(table));
+    updateModelData(config);
+  }
+}
+
 const metricAppModel = {
   ...model,
   initialize,
@@ -2060,6 +2080,7 @@ const metricAppModel = {
   onColumnsOrderChange,
   getQueryStringFromSelect,
   onTableResizeModeChange,
+  onTableResizeEnd,
 };
 
 export default metricAppModel;

--- a/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui_v2/src/services/models/params/paramsAppModel.ts
@@ -1466,6 +1466,26 @@ function onRowVisibilityChange(metricKey: string) {
     updateModelData(config);
   }
 }
+
+function onTableResizeEnd(tableHeight: string) {
+  const configData: IParamsAppConfig | undefined = model.getState()?.config;
+  if (configData?.table) {
+    const table = {
+      ...configData.table,
+      height: tableHeight,
+    };
+    const config = {
+      ...configData,
+      table,
+    };
+    model.setState({
+      config,
+    });
+    setItem('metricsTable', encode(table));
+    updateModelData(config);
+  }
+}
+
 const paramsAppModel = {
   ...model,
   initialize,
@@ -1502,6 +1522,7 @@ const paramsAppModel = {
   onTableResizeModeChange,
   getAppConfigData,
   onTableDiffShow,
+  onTableResizeEnd,
 };
 
 export default paramsAppModel;

--- a/aim/web/ui_v2/src/types/services/models/metrics/metricsAppModel.d.ts
+++ b/aim/web/ui_v2/src/types/services/models/metrics/metricsAppModel.d.ts
@@ -152,6 +152,7 @@ interface IMetricAppConfig {
       middle: string[];
       right: string[];
     };
+    height: string;
   };
 }
 


### PR DESCRIPTION
Setting and recovering table and chart heights (resize mode) in params and metrics pages