### PR TITLE
Rename `trcs` into `seqs`

### DIFF
--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -213,8 +213,8 @@ class Run(StructuredRunMixin):
         self.meta_run_attrs_tree: TreeView = self.meta_run_tree.view('attrs')
 
         self.series_run_tree: TreeView = self.repo.request(
-            'trcs', hashname, read_only=read_only
-        ).tree().view('trcs').view('chunks').view(hashname)
+            'seqs', hashname, read_only=read_only
+        ).tree().view('seqs').view('chunks').view(hashname)
 
         self.series_counters: Dict[Tuple[Context, str], int] = Counter()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,6 +100,6 @@ def remove_test_data():
 
     repo_path_base = repo.path
     shutil.rmtree(os.path.join(repo_path_base, 'meta'), ignore_errors=True)
-    shutil.rmtree(os.path.join(repo_path_base, 'trcs'), ignore_errors=True)
+    shutil.rmtree(os.path.join(repo_path_base, 'seqs'), ignore_errors=True)
     shutil.rmtree(os.path.join(repo_path_base, 'locks'), ignore_errors=True)
     shutil.rmtree(os.path.join(repo_path_base, 'progress'), ignore_errors=True)


### PR DESCRIPTION
This PR quickly replaces `trcs` directories into `seqs` (containers for metric sequences) in the `.aim` repo structure.

Note: This change is not backward-compatible with prior repositories, so one will need to manually rename existing directories.