### PR TITLE
Hide resize panel and table placeholder on empty data

### DIFF
--- a/aim/web/ui_v2/src/components/ResizePanel/ResizePanel.tsx
+++ b/aim/web/ui_v2/src/components/ResizePanel/ResizePanel.tsx
@@ -12,11 +12,12 @@ function ResizePanel({
   resizeElemRef,
   resizeMode,
   onTableResizeModeChange,
+  className,
 }: IResizePanelProps): React.FunctionComponentElement<React.ReactNode> | null {
   return (
     <div
       ref={resizeElemRef}
-      className={`ResizePanel${
+      className={`${className || ''} ResizePanel${
         resizeMode === ResizeModeEnum.Hide && !panelResizing
           ? '__fullHeight'
           : resizeMode !== ResizeModeEnum.Resizable

--- a/aim/web/ui_v2/src/pages/Metrics/Metrics.scss
+++ b/aim/web/ui_v2/src/pages/Metrics/Metrics.scss
@@ -37,6 +37,12 @@
     }
   }
 
+  .Metrics__ResizePanel {
+    &__hide {
+      display: none;
+    }
+  }
+
   .Metrics__table__container {
     flex: 0.5 1 0;
     min-height: 11rem;

--- a/aim/web/ui_v2/src/pages/Metrics/Metrics.tsx
+++ b/aim/web/ui_v2/src/pages/Metrics/Metrics.tsx
@@ -149,6 +149,11 @@ function Metrics(
             </BusyLoaderWrapper>
           </div>
           <ResizePanel
+            className={`Metrics__ResizePanel${
+              props.requestIsPending || props.lineChartData?.[0]?.length
+                ? ''
+                : '__hide'
+            }`}
             panelResizing={props.panelResizing}
             resizeElemRef={props.resizeElemRef}
             resizeMode={props.resizeMode}

--- a/aim/web/ui_v2/src/pages/Params/Params.scss
+++ b/aim/web/ui_v2/src/pages/Params/Params.scss
@@ -16,34 +16,16 @@
     // height: -moz-available; /* WebKit-based browsers will ignore this. */
     // height: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
   }
-
-  .Params__resize {
-    cursor: row-resize;
-    justify-content: center;
-    display: flex;
-    align-items: center;
-    height: 0.5rem;
-    border-top: 0.125rem solid tint($primary-color, 90);
-    border-bottom: 0.125rem solid tint($primary-color, 90);
-    background-color: tint($primary-color, 90);
-    transition: all 0.15s ease-out;
-    transition-delay: 0.3s;
-    i {
-      transition: all 0.15s ease-out;
-      transition-delay: 0.3s;
-    }
-    &:hover,
-    &.resizing {
-      background-color: tint($primary-color, 25);
-      i {
-        opacity: 0;
-      }
-    }
-  }
   .Params__section__div {
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  .Params__ResizePanel {
+    &__hide {
+      display: none;
+    }
   }
 
   .Params__chart__container {
@@ -51,7 +33,6 @@
     -ms-flex: 0.5 1 0;
     flex: 0.5 1 0;
     min-height: 11.25rem;
-    border-bottom: 0.0625rem solid #e8f1fc;
     &__emptyBox {
       display: flex;
       align-items: center;

--- a/aim/web/ui_v2/src/pages/Params/Params.tsx
+++ b/aim/web/ui_v2/src/pages/Params/Params.tsx
@@ -160,6 +160,9 @@ const Params = ({
             </BusyLoaderWrapper>
           </div>
           <ResizePanel
+            className={`Params__ResizePanel${
+              isParamsLoading || highPlotData?.[0]?.data?.length ? '' : '__hide'
+            }`}
             panelResizing={panelResizing}
             resizeElemRef={resizeElemRef}
             resizeMode={resizeMode}

--- a/aim/web/ui_v2/src/types/components/ResizePanel/ResizePanel.d.ts
+++ b/aim/web/ui_v2/src/types/components/ResizePanel/ResizePanel.d.ts
@@ -5,4 +5,5 @@ export interface IResizePanelProps {
   resizeElemRef: IMetricProps['resizeElemRef'];
   resizeMode: IMetricProps['resizeMode'];
   onTableResizeModeChange: IMetricProps['onTableResizeModeChange'];
+  className?: string;
 }


### PR DESCRIPTION
Added className property on ResizePanel component
---
- Deleted unused `Params__resize` class name from Params.scss 