### PR TITLE
Sub app division for apis and static files

### DIFF
--- a/aim/web/api/__init__.py
+++ b/aim/web/api/__init__.py
@@ -15,7 +15,6 @@ def create_app():
         allow_credentials=True,
         max_age=86400
     )
-    app.add_middleware(GZipMiddleware)
 
     from aim.web.api.runs.views import runs_router
     from aim.web.api.tags.views import tags_router
@@ -23,14 +22,22 @@ def create_app():
     from aim.web.api.dashboard_apps.views import dashboard_apps_router
     from aim.web.api.dashboards.views import dashboards_router
     from aim.web.api.projects.views import projects_router
-    from aim.web.api.views import general_router
+    from aim.web.api.views import statics_router
 
-    app.include_router(dashboard_apps_router, prefix='/api/apps')
-    app.include_router(dashboards_router, prefix='/api/dashboards')
-    app.include_router(experiment_router, prefix='/api/experiments')
-    app.include_router(projects_router, prefix='/api/projects')
-    app.include_router(runs_router, prefix='/api/runs')
-    app.include_router(tags_router, prefix='/api/tags')
-    app.include_router(general_router)
+    api_app = FastAPI()
+    api_app.add_middleware(GZipMiddleware)
+
+    api_app.include_router(dashboard_apps_router, prefix='/apps')
+    api_app.include_router(dashboards_router, prefix='/dashboards')
+    api_app.include_router(experiment_router, prefix='/experiments')
+    api_app.include_router(projects_router, prefix='/projects')
+    api_app.include_router(runs_router, prefix='/runs')
+    api_app.include_router(tags_router, prefix='/tags')
+    app.mount('/api', api_app)
+
+    static_files_app = FastAPI()
+
+    static_files_app.include_router(statics_router)
+    app.mount('/', static_files_app)
 
     return app

--- a/aim/web/api/views.py
+++ b/aim/web/api/views.py
@@ -3,10 +3,10 @@ import os
 from aim.web.api.utils import APIRouter  # wrapper for fastapi.APIRouter
 from fastapi.responses import FileResponse
 
-general_router = APIRouter()
+statics_router = APIRouter()
 
 
-@general_router.get('/static-files/{path:path}/')
+@statics_router.get('/static-files/{path:path}/')
 async def serve_static_files(path):
     from aim import web
     static_file_name = os.path.join(os.path.dirname(web.__file__), 'ui', 'build', path)
@@ -18,7 +18,7 @@ async def serve_static_files(path):
 
 # do not change the placement of this method
 # as it also serves as a fallback for wrong url routes
-@general_router.get('/{path:path}/')
+@statics_router.get('/{path:path}/')
 async def serve_index_html():
     from aim import web
     static_file_name = os.path.join(os.path.dirname(web.__file__), 'ui', 'build', 'index.html')


### PR DESCRIPTION
Use separate sub apps for apis and static-files endpoints to avoid double zipping for static files (only apis sub app will have GZIPMiddleware)