### PR TITLE
Handle displaying of empty context in UI

### DIFF
--- a/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
@@ -13,6 +13,7 @@ import {
   CheckBoxOutlineBlank,
   SearchOutlined,
 } from '@material-ui/icons';
+import { isEmpty } from 'lodash-es';
 
 import useModel from 'hooks/model/useModel';
 import { IProjectsModelState } from 'types/services/models/projects/projectsModel';
@@ -108,19 +109,21 @@ function SelectForm({
         index++;
 
         for (let val of projectsData.metrics[key]) {
-          let label: string = Object.keys(val)
-            .map((item) => `${item}="${val[item]}"`)
-            .join(', ');
-          data.push({
-            label: `${key} ${label}`,
-            group: key,
-            color: COLORS[0][index % COLORS[0].length],
-            value: {
-              metric_name: key,
-              context: val,
-            },
-          });
-          index++;
+          if (!isEmpty(val)) {
+            let label: string = Object.keys(val)
+              .map((item) => `${item}="${val[item]}"`)
+              .join(', ');
+            data.push({
+              label: `${key} ${label}`,
+              group: key,
+              color: COLORS[0][index % COLORS[0].length],
+              value: {
+                metric_name: key,
+                context: val,
+              },
+            });
+            index++;
+          }
         }
       }
     }

--- a/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
@@ -19,6 +19,7 @@ import useModel from 'hooks/model/useModel';
 import { IProjectsModelState } from 'types/services/models/projects/projectsModel';
 import projectsModel from 'services/models/projects/projectsModel';
 import COLORS from 'config/colors/colors';
+import contextToString from 'utils/contextToString';
 
 import {
   ISelectMetricsOption,
@@ -110,9 +111,7 @@ function SelectForm({
 
         for (let val of projectsData.metrics[key]) {
           if (!isEmpty(val)) {
-            let label: string = Object.keys(val)
-              .map((item) => `${item}="${val[item]}"`)
-              .join(', ');
+            let label = contextToString(val);
             data.push({
               label: `${key} ${label}`,
               group: key,

--- a/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
@@ -57,7 +57,11 @@ function getParamsTableColumns(
         ...Object.keys(metricsColumns[key]).map((metricContext) => ({
           key: `${key}_${metricContext}`,
           content: (
-            <TagLabel size='small' color={COLORS[0][0]} label={metricContext} />
+            <TagLabel
+              size='small'
+              color={COLORS[0][0]}
+              label={metricContext === '' ? 'No context' : metricContext}
+            />
           ),
           topHeader: key,
           pin: order?.left?.includes(`${key}_${metricContext}`)

--- a/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
@@ -47,7 +47,11 @@ function getRunsTableColumns(
         ...Object.keys(metricsColumns[key]).map((metricContext) => ({
           key: `${key}_${metricContext}`,
           content: (
-            <TagLabel size='small' color={COLORS[0][0]} label={metricContext} />
+            <TagLabel
+              size='small'
+              color={COLORS[0][0]}
+              label={metricContext === '' ? 'No context' : metricContext}
+            />
           ),
           topHeader: key,
           pin: order?.left?.includes(`${key}_${metricContext}`)


### PR DESCRIPTION
If the metric has an empty object as a context value we are removing it from Metrics Explorer select form autocomplete.
Also for Runs and Params Explorer we are rendering the `No context` label in the table column header. 