### PR TITLE
Add debouncing on metrics explorer chart focused point change handler

### DIFF
--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _, { isEmpty, isNil } from 'lodash-es';
+import _, { isEmpty, isNil, debounce } from 'lodash-es';
 import { saveAs } from 'file-saver';
 import moment from 'moment';
 import COLORS from 'config/colors/colors';
@@ -444,7 +444,7 @@ function getGroupingSelectOptions(params: string[]): IGroupingSelectOption[] {
     {
       group: 'metric',
       label: 'metric.name',
-      value: 'metric.name',
+      value: 'metric_name',
     },
     {
       group: 'metric',
@@ -1581,72 +1581,72 @@ function onChangeTooltip(tooltip: Partial<IChartTooltip>): void {
   analytics.trackEvent('[MetricsExplorer] Change tooltip content');
 }
 
-function onActivePointChange(
-  activePoint: IActivePoint,
-  focusedStateActive: boolean = false,
-): void {
-  const { data, params, refs, config } =
-    model.getState() as IMetricAppModelState;
-  const tableRef: any = refs?.tableRef;
-  let tableData = null;
-  if (config.table.resizeMode !== ResizeModeEnum.Hide) {
-    tableData = getDataAsTableRows(
-      data,
-      activePoint.xValue,
-      params,
-      false,
-      config,
-      true,
-    );
-    if (tableRef) {
-      tableRef.current?.updateData({
-        newData: tableData.rows,
-        dynamicData: true,
-      });
-      tableRef.current?.setHoveredRow?.(activePoint.key);
-      tableRef.current?.setActiveRow?.(
-        focusedStateActive ? activePoint.key : null,
+const onActivePointChange = debounce(
+  (activePoint: IActivePoint, focusedStateActive: boolean = false): void => {
+    const { data, params, refs, config } =
+      model.getState() as IMetricAppModelState;
+    const tableRef: any = refs?.tableRef;
+    let tableData = null;
+    if (config.table.resizeMode !== ResizeModeEnum.Hide) {
+      tableData = getDataAsTableRows(
+        data,
+        activePoint.xValue,
+        params,
+        false,
+        config,
+        true,
       );
-      if (focusedStateActive) {
-        tableRef.current?.scrollToRow?.(activePoint.key);
+      if (tableRef) {
+        tableRef.current?.updateData({
+          newData: tableData.rows,
+          dynamicData: true,
+        });
+        tableRef.current?.setHoveredRow?.(activePoint.key);
+        tableRef.current?.setActiveRow?.(
+          focusedStateActive ? activePoint.key : null,
+        );
+        if (focusedStateActive) {
+          tableRef.current?.scrollToRow?.(activePoint.key);
+        }
       }
     }
-  }
-  let configData: IMetricAppConfig = config;
-  if (configData?.chart) {
-    configData = {
-      ...configData,
-      chart: {
-        ...configData.chart,
-        focusedState: {
-          active: focusedStateActive,
-          key: activePoint.key,
-          xValue: activePoint.xValue,
-          yValue: activePoint.yValue,
-          chartIndex: activePoint.chartIndex,
+    let configData: IMetricAppConfig = config;
+    if (configData?.chart) {
+      configData = {
+        ...configData,
+        chart: {
+          ...configData.chart,
+          focusedState: {
+            active: focusedStateActive,
+            key: activePoint.key,
+            xValue: activePoint.xValue,
+            yValue: activePoint.yValue,
+            chartIndex: activePoint.chartIndex,
+          },
+          tooltip: {
+            ...configData.chart.tooltip,
+            content: filterTooltipContent(
+              tooltipData[activePoint.key],
+              configData?.chart.tooltip.selectedParams,
+            ),
+          },
         },
-        tooltip: {
-          ...configData.chart.tooltip,
-          content: filterTooltipContent(
-            tooltipData[activePoint.key],
-            configData?.chart.tooltip.selectedParams,
-          ),
-        },
-      },
-    };
+      };
 
-    if (
-      config.chart.focusedState.active !== focusedStateActive ||
-      (config.chart.focusedState.active &&
-        activePoint.key !== config.chart.focusedState.key)
-    ) {
-      updateURL(configData);
+      if (
+        config.chart.focusedState.active !== focusedStateActive ||
+        (config.chart.focusedState.active &&
+          activePoint.key !== config.chart.focusedState.key)
+      ) {
+        updateURL(configData);
+      }
     }
-  }
-  model.setState({
-    config: configData,
-  });
-}
+    model.setState({
+      config: configData,
+    });
+  },
+  35,
+);
 
 // Table Methods
 


### PR DESCRIPTION
In order to make chart hover interactions more smooth, we are adding debouncing on `LineChart` hover callback.
So that it will be fired after the last call within a given offset (`35ms` for now)