### PR TITLE
Feature/run props caching fixes

### DIFF
--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -292,6 +292,7 @@ class Repo:
             :obj:`MetricCollection`: Iterable for runs/metrics matching query expression.
         """
         db = self.structured_db
+        db.invalidate_caches()
         db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
         self.run_props_cache_hint = 'runs_cache'
         return QueryRunMetricCollection(self, query, paginated, offset)
@@ -313,6 +314,7 @@ class Repo:
             :obj:`MetricCollection`: Iterable for metrics matching query expression.
         """
         db = self.structured_db
+        db.invalidate_caches()
         db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
         self.run_props_cache_hint = 'runs_cache'
         return QueryMetricCollection(repo=self, query=query)

--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -292,9 +292,10 @@ class Repo:
             :obj:`MetricCollection`: Iterable for runs/metrics matching query expression.
         """
         db = self.structured_db
-        db.invalidate_caches()
-        db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
-        self.run_props_cache_hint = 'runs_cache'
+        cache_name = 'runs_cache'
+        db.invalidate_cache(cache_name)
+        db.init_cache(cache_name, db.runs, lambda run: run.hashname)
+        self.run_props_cache_hint = cache_name
         return QueryRunMetricCollection(self, query, paginated, offset)
 
     @property
@@ -314,9 +315,10 @@ class Repo:
             :obj:`MetricCollection`: Iterable for metrics matching query expression.
         """
         db = self.structured_db
-        db.invalidate_caches()
-        db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
-        self.run_props_cache_hint = 'runs_cache'
+        cache_name = 'runs_cache'
+        db.invalidate_cache(cache_name)
+        db.init_cache(cache_name, db.runs, lambda run: run.hashname)
+        self.run_props_cache_hint = cache_name
         return QueryMetricCollection(repo=self, query=query)
 
     def _get_meta_tree(self):

--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -80,6 +80,7 @@ class Repo:
         self.container_view_pool: Dict[ContainerConfig, Container] = WeakValueDictionary()
 
         self.structured_db = DB.from_path(self.path)
+        self._run_props_cache_hint = None
         if init:
             self.structured_db.run_upgrades()
 
@@ -292,8 +293,16 @@ class Repo:
         """
         db = self.structured_db
         db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
-        Run.set_props_cache_hint('runs_cache')
+        self.run_props_cache_hint = 'runs_cache'
         return QueryRunMetricCollection(self, query, paginated, offset)
+
+    @property
+    def run_props_cache_hint(self):
+        return self._run_props_cache_hint
+
+    @run_props_cache_hint.setter
+    def run_props_cache_hint(self, cache: str):
+        self._run_props_cache_hint = cache
 
     def query_metrics(self, query: str = '') -> QueryMetricCollection:
         """Get metrics satisfying query expression.
@@ -305,7 +314,7 @@ class Repo:
         """
         db = self.structured_db
         db.init_cache('runs_cache', db.runs, lambda run: run.hashname)
-        Run.set_props_cache_hint('runs_cache')
+        self.run_props_cache_hint = 'runs_cache'
         return QueryMetricCollection(repo=self, query=query)
 
     def _get_meta_tree(self):

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -168,7 +168,6 @@ class Run(StructuredRunMixin):
     """
 
     _idx_to_ctx: Dict[int, Context] = dict()
-    _props_cache_hint: str = None
     _finalize_message_shown = False
     _track_warning_shown = False
 
@@ -379,10 +378,6 @@ class Run(StructuredRunMixin):
         epoch_view[step] = epoch
         time_view[step] = track_time
 
-    @classmethod
-    def set_props_cache_hint(cls, cache: str):
-        cls._props_cache_hint = cache
-
     @property
     def props(self):
         if self._props is None:
@@ -391,9 +386,9 @@ class Run(StructuredRunMixin):
 
     def _init_props(self):
         sdb = self.repo.structured_db
-        if self._props_cache_hint:
-            self._props = sdb.caches[self._props_cache_hint][self.hashname]
-        else:
+        if self.repo.run_props_cache_hint:
+            self._props = sdb.caches[self.repo.run_props_cache_hint][self.hashname]
+        if not self._props:
             self._props = sdb.find_run(self.hashname)
             if not self._props:
                 if self.read_only:
@@ -401,6 +396,8 @@ class Run(StructuredRunMixin):
                 else:
                     self._props = sdb.create_run(self.hashname)
                     self._props.experiment = 'default'
+            if self.repo.run_props_cache_hint:
+                sdb.caches[self.repo.run_props_cache_hint][self.hashname] = self._props
 
     def metric_tree(self, name: str, context: Context) -> TreeView:
         return self.series_run_tree.view((context.idx, name))

--- a/aim/storage/structured/db.py
+++ b/aim/storage/structured/db.py
@@ -29,6 +29,10 @@ class ObjectCache:
             self._cached = True
         return list(self._data.keys())
 
+    def __setitem__(self, key, value):
+        assert self._cached
+        self._data[key] = value
+
     def __getitem__(self, key):
         if not self._cached:
             self.fill_cache()

--- a/aim/storage/structured/db.py
+++ b/aim/storage/structured/db.py
@@ -97,5 +97,9 @@ class DB(ObjectFactory):
             return
         self._caches[cache_name] = ObjectCache(callback, key_func)
 
-    def invalidate_caches(self):
+    def invalidate_all_caches(self):
         self._caches.clear()
+
+    def invalidate_cache(self, cache_name):
+        if self._caches.get(cache_name):
+            del self._caches[cache_name]

--- a/aim/web/api/projects/views.py
+++ b/aim/web/api/projects/views.py
@@ -51,7 +51,7 @@ async def project_activity_api(request: Request, factory=Depends(object_factory)
 
     num_runs = 0
     activity_counter = Counter()
-    for run in project.repo.iter_runs():
+    for run in factory.runs():
         creation_timestamp = run.creation_time if run.creation_time > 0 else 0
         # TODO: [AT] fix timezone
         activity_counter[datetime.fromtimestamp(creation_timestamp, timezone).strftime('%Y-%m-%d')] += 1

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,7 +19,7 @@ class TestBase(unittest.TestCase):
         remove_test_data()
 
     def tearDown(self) -> None:
-        self.repo.structured_db.invalidate_caches()
+        self.repo.structured_db.invalidate_all_caches()
         self.repo.run_props_cache_hint = None
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,7 +20,7 @@ class TestBase(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.repo.structured_db.invalidate_caches()
-        Run.set_props_cache_hint(None)
+        self.repo.run_props_cache_hint = None
 
 
 class ApiTestBase(TestBase):


### PR DESCRIPTION
cache per repo
fallback to query if run is not found in cache
add missing run to the cache if cache exists (small optimization)
use `structured_db` runs instead of `rocksdb` in `/projects/activity` endpoint