### PR TITLE
skip queue wait_for_finished when Run is garbage-collected

### DIFF
--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -487,7 +487,7 @@ class Run(StructuredRunMixin):
             self._system_resource_tracker.stop()
 
         logger.debug(f'finalizing {self}')
-        self.finalize()
+        self.finalize(skip_wait=True)
 
     @classmethod
     def finalize_msg(cls):
@@ -503,12 +503,13 @@ class Run(StructuredRunMixin):
                            'Consider tracking at lower pace.')
             cls._track_warning_shown = True
 
-    def finalize(self):
+    def finalize(self, skip_wait=False):
         if self._finalized:
             return
         self._finalized = True
         self.finalize_msg()
-        self.repo.tracking_queue.wait_for_finish()
+        if not skip_wait:
+            self.repo.tracking_queue.wait_for_finish()
 
         self.props.finalized_at = datetime.datetime.utcnow()
         index = self.repo._get_container('meta/index',


### PR DESCRIPTION
Wait for queue only if `Run.finalize()` is called explicitly.
When run object is garbage collected (in a separate gc thread) no refs are left for that run, hence queue doesn't have any pending tasks for that run.