### PR TITLE
Fix convert null to object issue

### DIFF
--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -466,7 +466,7 @@ function processData(data: IRun<IMetricTrace>[]): {
   let params: string[] = [];
   const paletteIndex: number = configData?.grouping?.paletteIndex || 0;
 
-  data.forEach((run: IRun<IMetricTrace>) => {
+  data?.forEach((run: IRun<IMetricTrace>) => {
     params = params.concat(getObjectPaths(run.params, run.params));
     metrics = metrics.concat(
       run.traces.map((trace: any) => {

--- a/aim/web/ui/src/utils/getObjectPaths.ts
+++ b/aim/web/ui/src/utils/getObjectPaths.ts
@@ -6,6 +6,9 @@ function getObjectPaths(
   prefix: string = '',
   includeRoot: boolean = false,
 ): string[] {
+  if (obj === null) {
+    return [];
+  }
   let rootKeys = Object.keys(obj).map((key) => {
     return { prefixedKey: prefix ? `${prefix}.${key}` : key, key };
   });


### PR DESCRIPTION
- Check the `null` case when extracting keys as paths from an object
- Add a small fix to prevent Metrics Explorer page fails during `hot reload` in `dev` mode