### PR TITLE
Filter out runs with missing params in HighPlot

### DIFF
--- a/aim/web/ui/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui/src/services/models/params/paramsAppModel.ts
@@ -498,33 +498,35 @@ function getDataAsLines(
     _.groupBy(flattedLines, 'chartIndex'),
   );
 
-  return Object.keys(dimensionsObject).map((keyOfDimension, i) => {
-    const dimensions: IDimensionsType = {};
-    Object.keys(dimensionsObject[keyOfDimension]).forEach((key: string) => {
-      if (dimensionsObject[keyOfDimension][key].scaleType === 'linear') {
-        dimensions[key] = {
-          scaleType: dimensionsObject[keyOfDimension][key].scaleType,
-          domainData: [
-            Math.min(...dimensionsObject[keyOfDimension][key].values),
-            Math.max(...dimensionsObject[keyOfDimension][key].values),
-          ],
-          displayName: dimensionsObject[keyOfDimension][key].displayName,
-          dimensionType: dimensionsObject[keyOfDimension][key].dimensionType,
-        };
-      } else {
-        dimensions[key] = {
-          scaleType: dimensionsObject[keyOfDimension][key].scaleType,
-          domainData: [...dimensionsObject[keyOfDimension][key].values],
-          displayName: dimensionsObject[keyOfDimension][key].displayName,
-          dimensionType: dimensionsObject[keyOfDimension][key].dimensionType,
-        };
-      }
-    });
-    return {
-      dimensions,
-      data: groupedByChartIndex[i],
-    };
-  });
+  return Object.keys(dimensionsObject)
+    .map((keyOfDimension, i) => {
+      const dimensions: IDimensionsType = {};
+      Object.keys(dimensionsObject[keyOfDimension]).forEach((key: string) => {
+        if (dimensionsObject[keyOfDimension][key].scaleType === 'linear') {
+          dimensions[key] = {
+            scaleType: dimensionsObject[keyOfDimension][key].scaleType,
+            domainData: [
+              Math.min(...dimensionsObject[keyOfDimension][key].values),
+              Math.max(...dimensionsObject[keyOfDimension][key].values),
+            ],
+            displayName: dimensionsObject[keyOfDimension][key].displayName,
+            dimensionType: dimensionsObject[keyOfDimension][key].dimensionType,
+          };
+        } else {
+          dimensions[key] = {
+            scaleType: dimensionsObject[keyOfDimension][key].scaleType,
+            domainData: [...dimensionsObject[keyOfDimension][key].values],
+            displayName: dimensionsObject[keyOfDimension][key].displayName,
+            dimensionType: dimensionsObject[keyOfDimension][key].dimensionType,
+          };
+        }
+      });
+      return {
+        dimensions,
+        data: groupedByChartIndex[i],
+      };
+    })
+    .filter((data) => !isEmpty(data.data) && !isEmpty(data.dimensions));
 }
 
 function getGroupConfig(


### PR DESCRIPTION
We had an issue while grouping charts. If the run doesn't include a value that matches with the dimension name we filtering it.