### PR TITLE
Remote fs and tracking queue fixes

### DIFF
--- a/aim/ext/sshfs/utils.py
+++ b/aim/ext/sshfs/utils.py
@@ -146,7 +146,7 @@ def mount_remote_repo(remote_path: str) -> Tuple[str, str]:
 
     # TODO: experiment on sshfs options to find an optimal set
     # construct sshfs options, use IdentityFile if provided by the user
-    sshfs_options = 'allow_other,default_permissions'
+    sshfs_options = 'default_permissions'
     identity_file = os.environ.get('AIM_REMOTE_REPO_KEY_FILE')
     if identity_file:
         sshfs_options = f'{sshfs_options},IdentityFile={identity_file}'

--- a/aim/ext/task_queue/queue.py
+++ b/aim/ext/task_queue/queue.py
@@ -43,11 +43,14 @@ class TaskQueue(object):
                 break
             task_f, args, kwargs = self._queue.get()
             task_f(*args, **kwargs)
+            # clear the unnecessary references to Run objects
+            task_f, args, kwargs = None, None, None
             self._queue.task_done()
 
     def wait_for_finish(self):
         if self._stopped:
             return
+        # TODO: [MV, AT] think about other solution instead of join()
         self._queue.join()
 
     def stop_workers(self):


### PR DESCRIPTION
- fix the issue with additional reference to run from tracking thread(this was causing the last run to not finalize) 
- remove `allow_other` option from sshfs options list as on ubuntu it was disabling the auto-mounting and is not really needed by aim