### PR TITLE
Fix the issue with overshadowing

### DIFF
--- a/aim/storage/union.py
+++ b/aim/storage/union.py
@@ -193,7 +193,7 @@ class DB(object):
             self._get_db(prefix, path, self._dbs, new_dbs)
 
         if index_db is not None:
-            new_dbs[index_prefix] = index_db
+            new_dbs[b""] = index_db
         self._dbs = new_dbs
         return new_dbs
 
@@ -205,6 +205,7 @@ class DB(object):
             # Shadowing
             if key.startswith(prefix):
                 return db.get(key)
+        return self.dbs[b""].get(key)
         raise ValueError
 
     def iteritems(
@@ -255,7 +256,7 @@ class RocksUnionContainer(RocksContainer):
         prefix: bytes = b''
     ) -> 'Container':
         container = self
-        if prefix in self.db.dbs:
+        if prefix and prefix in self.db.dbs:
             container = RocksUnionSubContainer(container=self, domain=prefix)
         return PrefixView(prefix=prefix,
                           container=container)

--- a/aim/storage/union.py
+++ b/aim/storage/union.py
@@ -206,7 +206,6 @@ class DB(object):
             if key.startswith(prefix):
                 return db.get(key)
         return self.dbs[b""].get(key)
-        raise ValueError
 
     def iteritems(
         self, *args, **kwargs


### PR DESCRIPTION
In Union db we have an issue, let's call it `overshadowing` - when only a part of the given prefix is in the union but it ignores all the other chunks.

This PR fixes the issue when acquiring a view of union db (`PrefixView` in particular) on `chunks`, and it treats index db as a regular chunk db and always redirects the view into the index. The issue lead to undiscoverable `run`s and was able to only detect indexed / finalized ones.