### PR TITLE
Add errorHandler for decoding of wrong values from URL

### DIFF
--- a/aim/web/ui/src/utils/encoder/encoder.ts
+++ b/aim/web/ui/src/utils/encoder/encoder.ts
@@ -11,5 +11,9 @@ export function encode(
 }
 
 export function decode(value: string): string {
-  return bs58check.decode(value).toString();
+  try {
+    return bs58check.decode(value).toString();
+  } catch (ex) {
+    return '{}';
+  }
 }


### PR DESCRIPTION
Add error handler for cases when URL can have a search query param which value is not an encoded object