### PR TITLE
Add value formatter for params and context fields

### DIFF
--- a/aim/web/ui/src/pages/RunDetail/RunMetricCard.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunMetricCard.tsx
@@ -54,7 +54,7 @@ function RunMetricCard({
             <TagLabel
               key={index}
               color={COLORS[0][(i + index) % COLORS[0].length]}
-              label={label || ''}
+              label={label || 'No context'}
             />
           ))}
       </div>

--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -255,9 +255,9 @@ function getQueryStringFromSelect(
                 (item) =>
                   `(metric.name == "${
                     metric.value.metric_name
-                  }" and metric.context.${item} == "${
-                    (metric.value.context as any)[item]
-                  }")`,
+                  }" and metric.context.${item} == ${formatValue(
+                    (metric.value.context as any)[item],
+                  )})`,
               )}`,
         )
         .join(' or ')})`.trim();

--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -369,8 +369,8 @@ function getChartTitleData(
       chartTitleData[metricsCollection.chartIndex] = groupData.chart.reduce(
         (acc: IChartTitle, groupItemKey: string) => {
           if (metricsCollection.config?.hasOwnProperty(groupItemKey)) {
-            acc[groupItemKey.replace('run.params.', '')] = JSON.stringify(
-              metricsCollection.config[groupItemKey] || 'None',
+            acc[groupItemKey.replace('run.params.', '')] = formatValue(
+              metricsCollection.config[groupItemKey],
             );
           }
           return acc;
@@ -1094,15 +1094,15 @@ function getDataAsTableRows(
         value:
           closestIndex === null
             ? '-'
-            : `${metric.data.values[closestIndex] ?? '-'}`,
+            : formatValue(metric.data.values[closestIndex]),
         step:
           closestIndex === null
             ? '-'
-            : `${metric.data.steps[closestIndex] ?? '-'}`,
+            : formatValue(metric.data.steps[closestIndex]),
         epoch:
           closestIndex === null
             ? '-'
-            : `${metric.data.epochs[closestIndex] ?? '-'}`,
+            : formatValue(metric.data.epochs[closestIndex]),
         time:
           closestIndex !== null ? metric.data.timestamps[closestIndex] : null,
         parentId: groupKey,
@@ -1229,8 +1229,8 @@ function getGroupConfig(
     if (groupItem.length) {
       groupConfig[groupItemKey] = groupItem.reduce((acc, paramKey) => {
         Object.assign(acc, {
-          [paramKey.replace('run.params.', '')]: JSON.stringify(
-            _.get(metricsCollection.config, paramKey, '-'),
+          [paramKey.replace('run.params.', '')]: formatValue(
+            _.get(metricsCollection.config, paramKey),
           ),
         });
         return acc;
@@ -1257,9 +1257,7 @@ function setTooltipData(
         groupConfig,
         params: paramKeys.reduce((acc, paramKey) => {
           Object.assign(acc, {
-            [paramKey]: JSON.stringify(
-              _.get(metric, `run.params.${paramKey}`, '-'),
-            ),
+            [paramKey]: formatValue(_.get(metric, `run.params.${paramKey}`)),
           });
           return acc;
         }, {}),

--- a/aim/web/ui/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui/src/services/models/params/paramsAppModel.ts
@@ -348,8 +348,8 @@ function getChartTitleData(
       chartTitleData[metricsCollection.chartIndex] = groupData.chart.reduce(
         (acc: IChartTitle, groupItemKey: string) => {
           if (metricsCollection.config?.hasOwnProperty(groupItemKey)) {
-            acc[groupItemKey.replace('run.params.', '')] = JSON.stringify(
-              metricsCollection.config[groupItemKey] || 'None',
+            acc[groupItemKey.replace('run.params.', '')] = formatValue(
+              metricsCollection.config[groupItemKey],
             );
             return acc;
           }
@@ -373,7 +373,7 @@ function processData(data: IRun<IParamTrace>[]): {
   const paletteIndex: number = grouping?.paletteIndex || 0;
   const metricsColumns: any = {};
 
-  data.forEach((run: IRun<IParamTrace>, index) => {
+  data?.forEach((run: IRun<IParamTrace>, index) => {
     params = params.concat(getObjectPaths(run.params, run.params));
     run.traces.forEach((trace) => {
       metricsColumns[trace.metric_name] = {
@@ -541,8 +541,8 @@ function getGroupConfig(
     if (groupItem.length) {
       groupConfig[groupItemKey] = groupItem.reduce((acc, paramKey) => {
         Object.assign(acc, {
-          [paramKey.replace('run.params.', '')]: JSON.stringify(
-            _.get(metricsCollection.config, paramKey, '-'),
+          [paramKey.replace('run.params.', '')]: formatValue(
+            _.get(metricsCollection.config, paramKey),
           ),
         });
         return acc;
@@ -566,9 +566,7 @@ function setTooltipData(
         groupConfig,
         params: paramKeys.reduce((acc, paramKey) => {
           Object.assign(acc, {
-            [paramKey]: JSON.stringify(
-              _.get(param, `run.params.${paramKey}`, '-'),
-            ),
+            [paramKey]: formatValue(_.get(param, `run.params.${paramKey}`)),
           });
           return acc;
         }, {}),

--- a/aim/web/ui/src/utils/contextToString.ts
+++ b/aim/web/ui/src/utils/contextToString.ts
@@ -1,3 +1,5 @@
+import { formatValue } from './formatValue';
+
 function contextToString(
   obj: { [key: string]: unknown },
   mode?: string,
@@ -9,7 +11,7 @@ function contextToString(
             case 'keyHash':
               return `${key}-${obj[key]}`;
             default:
-              return `${key}="${obj[key]}"`;
+              return `${key}=${formatValue(obj[key])}`;
           }
         })
         .join(mode === 'keyHash' ? '' : ', ')

--- a/aim/web/ui/src/utils/formatValue.ts
+++ b/aim/web/ui/src/utils/formatValue.ts
@@ -11,7 +11,7 @@ export function formatValue(value: any, undefinedValue: any = '-') {
   if (value === false) {
     return 'False';
   }
-  if (typeof value === 'number' || typeof value === 'string') {
+  if (typeof value === 'number') {
     return value;
   }
 


### PR DESCRIPTION
Use value formatter in explorer pages for `params` and `context` fields.