### PR TITLE
Adding docs tutorials to integration selections

### DIFF
--- a/docs/source/guides/integrations/basic_aim_keras.md
+++ b/docs/source/guides/integrations/basic_aim_keras.md
@@ -1,0 +1,27 @@
+## Integration with Keras & tf.Keras
+
+This tutorial leverages the well-known handwritten digit recognition task to describe how to integrate Aim with Keras & tf.Keras to train a digital image classification model based on the mnist dataset.
+
+It only takes 2 steps to easily integrate aim in keras to record experimental information.
+
+```python
+	
+	# call keras as the high api of tensorflow 
+	from aim.tensorflow import AimCallback
+	# call keras library directly
+	from aim.keras impory AimCallback
+```
+
+In keras, we call the fit method of the model object to train the data. The callbacks are provided here. AimCallback inherits the usage specification of callbacks. We just need to add it to the callbacks list.
+
+```python
+	
+	model.fit(x_train, y_train, epochs=5, callbacks=[
+           # in case of tf.keras, we use aim.tensorflow.AimCallback
+           AimCallback(experiment='aim_on_keras') 
+])
+	
+```
+
+The complete mnist example based on keras + aim can be viewed: [Integration_keras](https://colab.research.google.com/drive/18V8OTQ9RtLEit_yjAZAtUY1jXQmfQ0RN?usp=sharing)
+

--- a/docs/source/guides/integrations/basic_aim_pytorch_lightning.md
+++ b/docs/source/guides/integrations/basic_aim_pytorch_lightning.md
@@ -1,0 +1,34 @@
+## Integration with Pytorch Lightning
+
+The work is designed to build a image classifier to solve a famous real world problem ——handwritten digit recognition. In this work, we will introduce how to introduce aim logger to manage output information.
+
+We only require 2 steps to simply and easily inject Aim into pytorch lightining:
+
+```python
+	# call aim sdk designed for pl
+	from aim.pytorch_lightning import AimLogger
+```
+
+Pytorch lighting provides trainer objects to simplify the training process of pytorch model. One of the parameters is called logger. We can use the logger function defined by aim to simplify the process of tracking experiments. This process is divided into 2 steps:
+
+Step 1.create AimLogger object 
+
+```python
+	
+	# track experimential data by using Aim
+aim_logger = AimLogger(
+        experiment='aim_on_pt_lightning',
+        train_metric_prefix='train_',
+        val_metric_prefix='val_',
+    )
+```
+
+Step 2. Pass the aim_logger object to the logger variable
+
+
+```python
+# track experimential data by using Aim
+trainer = Trainer(gpus=1, progress_bar_refresh_rate=20, max_epochs=5, logger=aim_logger)  
+```
+The complete mnist example based on Pytorch Lightning + Aim can be viewed: [Integration_ptlightning](https://colab.research.google.com/drive/1Kq3-6x0dd7gAVCsiaClJf1TfKnW-d64f?usp=sharing)
+

--- a/docs/source/guides/integrations/basic_aim_xgboost.md
+++ b/docs/source/guides/integrations/basic_aim_xgboost.md
@@ -1,0 +1,30 @@
+## Integration with XGboost
+
+In the real world, there is a well-known handwritten digit recognition problem. In this article, we use the machine learning framework xgboost to help us train an image classification model. In this process, we will use Aim to track our experimental data.
+
+Enjoy using aim to track xgboost experimental data only requires two simple steps:
+
+Step 1: Explicitly import the AimCallback for tracking training data. 
+
+```python
+	
+	# call sdk aim.xgboost 
+	from aim.xgboost import AimCallback
+```
+
+Step 2: XGboost provides the xgboost.train method for model training, in which the callbacks parameter can call back data information from the outside. Here we pass in aimcallbacl designed for tracking data information
+
+```python
+	
+	mnist_model = xgboost.train(param, dtrain, num_round, watchlist,
+                            callbacks=[AimCallback(experiment='xgboost_test')] )
+
+	
+```
+
+During the training process, you can start another terminal, in the same directory, start aim up, you can observe the information in real time.
+
+The complete mnist example based on XGboost + Aim can be viewed: [Integration_xgboost](During the training process, you can start another terminal, in the same directory, start aim up, you can observe the information in real time.)
+
+
+


### PR DESCRIPTION
The submission contains three integrations
(each concludes a short introduction and an outside colab link):

- integrate Aim with Keras (colab example using tf.keras);
- integrate Aim with Pytorch Lightning;
- integrate Aim with XGboost.