### PR TITLE
Add context fields to grouping popovers

### DIFF
--- a/aim/web/ui/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui/src/services/models/params/paramsAppModel.ts
@@ -879,19 +879,19 @@ function onSelectRunQueryChange(query: string) {
 
 function getGroupingSelectOptions(params: string[]): IGroupingSelectOption[] {
   const paramsOptions: IGroupingSelectOption[] = params.map((param) => ({
+    group: 'run',
+    label: `run.${param}`,
     value: `run.params.${param}`,
-    group: 'params',
-    label: param,
   }));
 
   return [
     {
-      group: 'Run',
+      group: 'run',
       label: 'run.experiment',
       value: 'run.props.experiment',
     },
     {
-      group: 'Run',
+      group: 'run',
       label: 'run.hash',
       value: 'run.hash',
     },


### PR DESCRIPTION
This PR provides users with the ability to group by any `context` field set on a metric.