### PR TITLE
Fix issue with navigating to run details page from metrics table

### DIFF
--- a/aim/web/ui/src/components/CustomTable/Table.scss
+++ b/aim/web/ui/src/components/CustomTable/Table.scss
@@ -37,6 +37,7 @@ $border-radius: 0.2rem;
   min-height: 100%;
   box-sizing: border-box;
   content-visibility: auto;
+  contain: content;
 }
 
 .Table__pane {
@@ -47,6 +48,7 @@ $border-radius: 0.2rem;
   min-height: 100%;
   box-sizing: border-box;
   z-index: 0;
+  contain: content;
 }
 
 .Table__action__icon {
@@ -79,6 +81,7 @@ $border-radius: 0.2rem;
   width: -webkit-fill-available;
   width: -moz-available;
   max-width: 500px;
+  contain: content;
 
   &:last-of-type {
     .Table__cell,
@@ -349,6 +352,7 @@ $border-radius: 0.2rem;
       .Table__column {
         &:first-of-type {
           .Table__group {
+            border-left: 1px solid $border-color;
             margin-left: var(--group-margin);
             border-top-left-radius: $border-radius;
             border-bottom-left-radius: $border-radius;

--- a/aim/web/ui/src/components/CustomTable/TableColumn.tsx
+++ b/aim/web/ui/src/components/CustomTable/TableColumn.tsx
@@ -263,7 +263,17 @@ function Column({
       </div>
       {groups
         ? Object.keys(data).map((groupKey) => (
-            <div key={groupKey} className='Table__group'>
+            <div
+              key={groupKey}
+              className='Table__group'
+              style={
+                col.key === '#' && data[groupKey].data.meta.color
+                  ? {
+                      borderLeft: 'none',
+                    }
+                  : null
+              }
+            >
               {col.key === '#' ? (
                 <div
                   className={classNames({

--- a/aim/web/ui/src/components/Table/Table.tsx
+++ b/aim/web/ui/src/components/Table/Table.tsx
@@ -327,7 +327,7 @@ const Table = React.forwardRef(function Table(
 
   function onGroupExpandToggle(groupKey) {
     if (Array.isArray(groupKey)) {
-      expandedGroups.current = expandedGroups.current;
+      expandedGroups.current = groupKey;
     } else if (expandedGroups.current.includes(groupKey)) {
       expandedGroups.current = expandedGroups.current.filter(
         (item) => item !== groupKey,
@@ -433,11 +433,6 @@ const Table = React.forwardRef(function Table(
           props.infiniteLoadHandler &&
           isDownScrolling
         ) {
-          // const index = windowEdges.endIndex - 15 - 3; // 15: offset, 3: header rows
-          // if (index + 5 >= rowData.length) {
-          //   props.infiniteLoadHandler(index);
-          // }
-
           if (
             target.scrollTop + target.offsetHeight >
             target.scrollHeight - 2 * rowHeight

--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -1636,67 +1636,70 @@ const onActivePointChange = debounce(
   (activePoint: IActivePoint, focusedStateActive: boolean = false): void => {
     const { data, params, refs, config } =
       model.getState() as IMetricAppModelState;
-    const tableRef: any = refs?.tableRef;
-    let tableData = null;
-    if (config.table.resizeMode !== ResizeModeEnum.Hide) {
-      tableData = getDataAsTableRows(
-        data,
-        activePoint.xValue,
-        params,
-        false,
-        config,
-        true,
-      );
-      if (tableRef) {
-        tableRef.current?.updateData({
-          newData: tableData.rows,
-          dynamicData: true,
-        });
-        tableRef.current?.setHoveredRow?.(activePoint.key);
-        tableRef.current?.setActiveRow?.(
-          focusedStateActive ? activePoint.key : null,
+    if (!!config) {
+      const tableRef: any = refs?.tableRef;
+      let tableData = null;
+      if (config.table.resizeMode !== ResizeModeEnum.Hide) {
+        tableData = getDataAsTableRows(
+          data,
+          activePoint.xValue,
+          params,
+          false,
+          config,
+          true,
         );
-        if (focusedStateActive) {
-          tableRef.current?.scrollToRow?.(activePoint.key);
+        if (tableRef) {
+          tableRef.current?.updateData({
+            newData: tableData.rows,
+            dynamicData: true,
+          });
+          tableRef.current?.setHoveredRow?.(activePoint.key);
+          tableRef.current?.setActiveRow?.(
+            focusedStateActive ? activePoint.key : null,
+          );
+          if (focusedStateActive) {
+            tableRef.current?.scrollToRow?.(activePoint.key);
+          }
         }
       }
-    }
-    let configData: IMetricAppConfig = config;
-    if (configData?.chart) {
-      configData = {
-        ...configData,
-        chart: {
-          ...configData.chart,
-          focusedState: {
-            active: focusedStateActive,
-            key: activePoint.key,
-            xValue: activePoint.xValue,
-            yValue: activePoint.yValue,
-            chartIndex: activePoint.chartIndex,
+      let configData: IMetricAppConfig = config;
+      if (configData?.chart) {
+        configData = {
+          ...configData,
+          chart: {
+            ...configData.chart,
+            focusedState: {
+              active: focusedStateActive,
+              key: activePoint.key,
+              xValue: activePoint.xValue,
+              yValue: activePoint.yValue,
+              chartIndex: activePoint.chartIndex,
+            },
+            tooltip: {
+              ...configData.chart.tooltip,
+              content: filterTooltipContent(
+                tooltipData[activePoint.key],
+                configData?.chart.tooltip.selectedParams,
+              ),
+            },
           },
-          tooltip: {
-            ...configData.chart.tooltip,
-            content: filterTooltipContent(
-              tooltipData[activePoint.key],
-              configData?.chart.tooltip.selectedParams,
-            ),
-          },
-        },
-      };
+        };
 
-      if (
-        config.chart.focusedState.active !== focusedStateActive ||
-        (config.chart.focusedState.active &&
-          activePoint.key !== config.chart.focusedState.key)
-      ) {
-        updateURL(configData);
+        if (
+          config.chart.focusedState.active !== focusedStateActive ||
+          (config.chart.focusedState.active &&
+            activePoint.key !== config.chart.focusedState.key)
+        ) {
+          updateURL(configData);
+        }
       }
+
+      model.setState({
+        config: configData,
+      });
     }
-    model.setState({
-      config: configData,
-    });
   },
-  35,
+  50,
 );
 
 // Table Methods


### PR DESCRIPTION
- Fix issue with navigating to run details page from metrics table occurred due to enabling debounce on active point change
- Change debounce time offset to `50ms` (adds more smoothness)
- Fix table group left border issue when color grouping is not applied
- Fix setting of expanded groups on `Expand/Collapse All` actions
- Add CSS `contain` property to `table` elements to reduce browser painting time (works only for chrome)