### PR TITLE
Rename Run's 'hashname' member to 'hash'

### DIFF
--- a/aim/cli/upgrade/utils.py
+++ b/aim/cli/upgrade/utils.py
@@ -89,7 +89,7 @@ def check_repo_integrity(repo: Repo, legacy_run_map: dict):
     try:
         ok = True
         with click.progressbar(repo.iter_runs(),
-                               item_show_func=lambda r: (f'Checking run {r.hashname}' if r else '')) as runs:
+                               item_show_func=lambda r: (f'Checking run {r.hash}' if r else '')) as runs:
             for run in runs:
                 legacy_hash = run.get(['v2_params', 'run_hash'])
                 run_metrics = legacy_run_map.pop(legacy_hash)
@@ -99,7 +99,7 @@ def check_repo_integrity(repo: Repo, legacy_run_map: dict):
                     if not run_metrics[metric_name]:
                         del run_metrics[metric_name]
                 if run_metrics:
-                    click.echo(f'Run \'{run.hashname}\' [\'{legacy_hash}\'] missing metrics \'{run_metrics.keys()}\'.')
+                    click.echo(f'Run \'{run.hash}\' [\'{legacy_hash}\'] missing metrics \'{run_metrics.keys()}\'.')
                     ok = False
         if legacy_run_map:
             click.echo(f'Repo missing runs \'{legacy_run_map.keys()}\'.')

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -99,7 +99,7 @@ class AimLogger(object):
 
             @property
             def version(self) -> str:
-                return self.experiment.hashname
+                return self.experiment.hash
 
         cls.__pl_logger_cls = _PytorchLightningLogger
         return cls.__pl_logger_cls

--- a/aim/sdk/legacy/session/session.py
+++ b/aim/sdk/legacy/session/session.py
@@ -32,7 +32,7 @@ class Session:
         self._repo_path = self._repo.path
         self._run = Run(run, repo=self._repo, experiment=experiment,
                         system_tracking_interval=system_tracking_interval)
-        self._run_hash = self._run.hashname
+        self._run_hash = self._run.hash
         self.active = True
 
         Session.sessions.setdefault(self._repo_path, [])

--- a/aim/sdk/metric.py
+++ b/aim/sdk/metric.py
@@ -32,7 +32,7 @@ class Metric(Sequence):
              include_name: (:obj:`int`, optional): If true, include metric name in dataframe. False by default.
              include_context: (:obj:`int`, optional): If true, include metric context
                 path:value pairs in dataframe. False by default.
-             include_run: (:obj:`int`, optional): If true, include run run.hashname and run hparams
+             include_run: (:obj:`int`, optional): If true, include run run.hash and run hparams
                 path:value pairs in dataframe. False by default.
              only_last: (:obj:`int`, optional): If true return dataframe for only last value, step, timestamp
                 and epoch. False by default.
@@ -69,7 +69,7 @@ class Metric(Sequence):
         }
 
         if include_run:
-            data['run'] = [self.run.hashname] * len(indices)
+            data['run'] = [self.run.hash] * len(indices)
             for path, val in treeutils.unfold_tree(self.run[...],
                                                    unfold_array=False,
                                                    depth=3):

--- a/aim/sdk/query_utils.py
+++ b/aim/sdk/query_utils.py
@@ -14,14 +14,14 @@ class RunView:
 
     def __init__(self, run: 'Run'):
         self.db = run.repo.structured_db
-        self.hashname = run.hashname
+        self.hash = run.hash
         self.structured_run_cls: type(StructuredObject) = self.db.run_cls()
         self.meta_run_tree: TreeView = run.meta_run_tree
         self.meta_run_attrs_tree: TreeView = run.meta_run_attrs_tree
 
     def __getattr__(self, item):
         if item in self.structured_run_cls.fields():
-            return getattr(self.db.caches['runs_cache'][self.hashname], item)
+            return getattr(self.db.caches['runs_cache'][self.hash], item)
         else:
             return self[item]
 

--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -267,19 +267,19 @@ class Repo:
         else:
             raise StopIteration
 
-    def get_run(self, hashname: str) -> Optional['Run']:
+    def get_run(self, run_hash: str) -> Optional['Run']:
         """Get run if exists.
 
         Args:
-            hashname (str): Run hashname.
+            run_hash (str): Run hash.
         Returns:
-            :obj:`Run` object if hashname is found in repository. `None` otherwise.
+            :obj:`Run` object if hash is found in repository. `None` otherwise.
         """
         # TODO: [MV] optimize existence check for run
-        if hashname is None or hashname not in self.meta_tree.view('chunks').keys():
+        if run_hash is None or run_hash not in self.meta_tree.view('chunks').keys():
             return None
         else:
-            return Run(hashname, repo=self, read_only=True)
+            return Run(run_hash, repo=self, read_only=True)
 
     def query_runs(self, query: str = '', paginated: bool = False, offset: str = None) -> QueryRunSequenceCollection:
         """Get runs satisfying query expression.
@@ -288,14 +288,14 @@ class Repo:
              query (:obj:`str`, optional): query expression.
                 If not specified, query results will include all runs.
              paginated (:obj:`bool`, optional): query results pagination flag. False if not specified.
-             offset (:obj:`str`, optional): `hashname` of Run to skip to.
+             offset (:obj:`str`, optional): `hash` of Run to skip to.
         Returns:
             :obj:`MetricCollection`: Iterable for runs/metrics matching query expression.
         """
         db = self.structured_db
         cache_name = 'runs_cache'
         db.invalidate_cache(cache_name)
-        db.init_cache(cache_name, db.runs, lambda run: run.hashname)
+        db.init_cache(cache_name, db.runs, lambda run: run.hash)
         self.run_props_cache_hint = cache_name
         return QueryRunSequenceCollection(self, Metric, query, paginated, offset)
 
@@ -318,7 +318,7 @@ class Repo:
         db = self.structured_db
         cache_name = 'runs_cache'
         db.invalidate_cache(cache_name)
-        db.init_cache(cache_name, db.runs, lambda run: run.hashname)
+        db.init_cache(cache_name, db.runs, lambda run: run.hash)
         self.run_props_cache_hint = cache_name
 
         return QuerySequenceCollection(repo=self, seq_cls=Metric, query=query)

--- a/aim/storage/structured/entities.py
+++ b/aim/storage/structured/entities.py
@@ -35,7 +35,7 @@ class Searchable(ABC, Generic[T]):
 class Run(StructuredObject, Searchable['Run']):
     @property
     @abstractmethod
-    def hashname(self) -> str:
+    def hash(self) -> str:
         ...
 
     @property

--- a/aim/storage/structured/sql_engine/entities.py
+++ b/aim/storage/structured/sql_engine/entities.py
@@ -32,7 +32,7 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
         Property('creation_time', 'created_at', get_modifier=timestamp_or_none, with_setter=False),
         Property('end_time', 'finalized_at', get_modifier=timestamp_or_none, with_setter=False),
         Property('updated_at', with_setter=False),
-        Property('hashname', 'hash', with_setter=False),
+        Property('hash', with_setter=False),
         Property('experiment', autogenerate=False),
         Property('tags', autogenerate=False),
     ]
@@ -43,7 +43,7 @@ class ModelMappedRun(IRun, metaclass=ModelMappedClassMeta):
         self._session = session
 
     def __repr__(self) -> str:
-        return f'<ModelMappedRun id={self.hashname}, name=\'{self.name}\'>'
+        return f'<ModelMappedRun id={self.hash}, name=\'{self.name}\'>'
 
     @classmethod
     def from_model(cls, model_obj, session) -> 'ModelMappedRun':

--- a/aim/web/api/experiments/views.py
+++ b/aim/web/api/experiments/views.py
@@ -88,6 +88,6 @@ async def get_experiment_runs_api(exp_id: str, factory=Depends(object_factory)):
 
     response = {
         'id': exp.uuid,
-        'runs': [{'run_id': run.hashname, 'name': run.name} for run in exp.runs]
+        'runs': [{'run_id': run.hash, 'name': run.name} for run in exp.runs]
     }
     return response

--- a/aim/web/api/runs/utils.py
+++ b/aim/web/api/runs/utils.py
@@ -87,9 +87,9 @@ def collect_run_streamable_data(encoded_tree: Iterator[Tuple[bytes, bytes]]) -> 
 
 def custom_aligned_metrics_streamer(requested_runs: List[AlignedRunIn], x_axis: str) -> bytes:
     for run_data in requested_runs:
-        run_hashname = run_data.run_id
+        run_hash = run_data.run_id
         requested_traces = run_data.traces
-        run = Run(hashname=run_hashname, read_only=True)
+        run = Run(run_hash, read_only=True)
 
         traces_list = []
         for trace_data in requested_traces:
@@ -112,7 +112,7 @@ def custom_aligned_metrics_streamer(requested_runs: List[AlignedRunIn], x_axis: 
                 'x_axis_iters': x_axis_iters,
             })
         run_dict = {
-            run_hashname: traces_list
+            run_hash: traces_list
         }
         encoded_tree = encode_tree(run_dict)
         yield collect_run_streamable_data(encoded_tree)
@@ -147,7 +147,7 @@ def metric_search_result_streamer(traces: SequenceCollection, steps_num: int, x_
 
         if run:
             run_dict = {
-                run.hashname: {
+                run.hash: {
                     'params': run.get(...),
                     'traces': traces_list,
                     'props': get_run_props(run)
@@ -163,7 +163,7 @@ def run_search_result_streamer(runs: SequenceCollection, limit: int) -> bytes:
     for run_trace_collection in runs.iter_runs():
         run = run_trace_collection.run
         run_dict = {
-            run.hashname: {
+            run.hash: {
                 'params': run.get(...),
                 'traces': run.collect_metrics_info(),
                 'props': get_run_props(run)

--- a/aim/web/api/runs/views.py
+++ b/aim/web/api/runs/views.py
@@ -105,7 +105,7 @@ async def run_params_api(run_id: str):
     project = Project()
     if not project.exists():
         raise HTTPException(status_code=404)
-    run = project.repo.get_run(hashname=run_id)
+    run = project.repo.get_run(run_id)
     if not run:
         raise HTTPException(status_code=404)
 
@@ -123,7 +123,7 @@ async def run_traces_batch_api(run_id: str, requested_traces: RunTracesBatchApiI
     project = Project()
     if not project.exists():
         raise HTTPException(status_code=404)
-    run = project.repo.get_run(hashname=run_id)
+    run = project.repo.get_run(run_id)
     if not run:
         raise HTTPException(status_code=404)
 
@@ -148,7 +148,7 @@ async def update_run_properties_api(run_id: str, run_in: StructuredRunUpdateIn, 
         run.archived = run_in.archived
 
     return {
-        'id': run.hashname,
+        'id': run.hash,
         'status': 'OK'
     }
 
@@ -163,7 +163,7 @@ async def add_run_tag_api(run_id: str, tag_in: StructuredRunAddTagIn, factory=De
         tag = run.add_tag(tag_in.tag_name)
 
     return {
-        'id': run.hashname,
+        'id': run.hash,
         'tag_id': tag.uuid,
         'status': 'OK'
     }
@@ -179,7 +179,7 @@ async def remove_run_tag_api(run_id: str, tag_id: str, factory=Depends(object_fa
         removed = run.remove_tag(tag_id)
 
     return {
-        'id': run.hashname,
+        'id': run.hash,
         'removed': removed,
         'status': 'OK'
     }

--- a/aim/web/api/tags/views.py
+++ b/aim/web/api/tags/views.py
@@ -110,9 +110,9 @@ async def get_tagged_runs_api(tag_id: str, factory=Depends(object_factory)):
 
     tag_runs = []
     for tagged_run in tag.runs:
-        run = Run(hashname=tagged_run.hashname, read_only=True)
+        run = Run(tagged_run.hash, read_only=True)
         tag_runs.append({
-            'run_id': tagged_run.hashname,
+            'run_id': tagged_run.hash,
             'name': tagged_run.name,
             'creation_time': run.creation_time,
             'end_time': run.end_time,

--- a/tests/api/test_structured_data_api.py
+++ b/tests/api/test_structured_data_api.py
@@ -33,12 +33,12 @@ class TestStructuredRunApi(StructuredApiTestBase):
 
         client = self.client
         # set existing experiment
-        resp = client.put(f'/api/runs/{run.hashname}', json={'experiment': 'Experiment 2'})
+        resp = client.put(f'/api/runs/{run.hash}', json={'experiment': 'Experiment 2'})
         self.assertEqual(200, resp.status_code)
         self.assertEqual('Experiment 2', run.experiment)
 
         # set non-existing experiment (create new)
-        resp = client.put(f'/api/runs/{run.hashname}', json={'experiment': 'New experiment'})
+        resp = client.put(f'/api/runs/{run.hash}', json={'experiment': 'New experiment'})
         self.assertEqual(200, resp.status_code)
         self.assertEqual('New experiment', run.experiment)
 
@@ -53,14 +53,14 @@ class TestStructuredRunApi(StructuredApiTestBase):
 
         client = self.client
         # remove tag # 1
-        resp = client.delete(f'/api/runs/{run.hashname}/tags/{tags[0].uuid}')
+        resp = client.delete(f'/api/runs/{run.hash}/tags/{tags[0].uuid}')
         self.assertEqual(200, resp.status_code)
         self.assertEqual(1, len(run.tags))
         tag_names = [t.name for t in run.tags]
         self.assertListEqual(['last runs'], tag_names)
 
         # add new tag
-        resp = client.post(f'/api/runs/{run.hashname}/tags/new', json={'tag_name': 'new tag'})
+        resp = client.post(f'/api/runs/{run.hash}/tags/new', json={'tag_name': 'new tag'})
         self.assertEqual(200, resp.status_code)
         self.assertEqual(2, len(run.tags))
         tag_names = [t.name for t in run.tags]
@@ -70,7 +70,7 @@ class TestStructuredRunApi(StructuredApiTestBase):
         matching_runs = self.repo.structured_db.search_runs('Run number 3')
         run = next(iter(matching_runs))
         client = self.client
-        resp = client.put(f'/api/runs/{run.hashname}', json={'description': 'long text', 'name': 'best run'})
+        resp = client.put(f'/api/runs/{run.hash}', json={'description': 'long text', 'name': 'best run'})
         self.assertEqual(200, resp.status_code)
         self.assertEqual('best run', run.name)
         self.assertEqual('long text', run.description)

--- a/tests/storage/test_structured_db.py
+++ b/tests/storage/test_structured_db.py
@@ -3,7 +3,7 @@ from tests.base import TestBase
 
 class TestStructuredDatabase(TestBase):
     def test_entity_chaining_syntax(self):
-        run = self.repo.structured_db.find_run('missing_run_hashname')
+        run = self.repo.structured_db.find_run('missing_run_hash')
         self.assertFalse(run.experiment)
         self.assertFalse(run.experiment.name)
         self.assertFalse(run.tags)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,8 +66,8 @@ def fill_up_test_data():
 
     with repo.structured_db:
         runs = []
-        for idx, hash_name in enumerate(run_hashes):
-            run = Run(hashname=hash_name, repo=repo, system_tracking_interval=None)
+        for idx, run_hash in enumerate(run_hashes):
+            run = Run(run_hash, repo=repo, system_tracking_interval=None)
             run['hparams'] = create_run_params()
             run['run_index'] = idx
             run['start_time'] = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
Renamed Run's 'hashname' member to 'hash'.
Renamed __init__ argument 'hashname' to 'run_hash' ['hash' can't be used since it shadows builtin global]