### PR TITLE
Fix recovering state in Metrics explore page while navigation from bookmarks

### DIFF
--- a/aim/web/ui/src/pages/Metrics/MetricsContainer.tsx
+++ b/aim/web/ui/src/pages/Metrics/MetricsContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useRouteMatch, useHistory } from 'react-router-dom';
+import { useRouteMatch, useHistory } from 'react-router-dom';
 
 import Metrics from './Metrics';
 import usePanelResize from 'hooks/resize/usePanelResize';
@@ -79,7 +79,6 @@ function MetricsContainer(): React.FunctionComponentElement<React.ReactNode> {
       appRequestRef = metricAppModel.getAppConfigData(route.params.appId);
       appRequestRef.call().then(() => {
         metricAppModel.getMetricsData().call();
-        metricAppModel.setDefaultAppConfigData();
       });
     } else {
       metricAppModel.setDefaultAppConfigData();


### PR DESCRIPTION
- Deleted unnecessary `setDefaultConfig` function in MetricsContainer