### PR TITLE
Query minor optimization

### DIFF
--- a/aim/storage/query.py
+++ b/aim/storage/query.py
@@ -142,7 +142,7 @@ def query_add_default_expr(query: str) -> str:
         return default_expression
     else:
         if 'run.archived' not in query:
-            return f'{query} and {default_expression}'
+            return f'{default_expression} and {query}'
         else:
             return query
 


### PR DESCRIPTION
Change default query priority, so for archived runs meta_tree won't be accessed during query execution