### PR TITLE
Display run creation time in explorer apps tables

### DIFF
--- a/aim/web/ui/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
@@ -384,7 +384,7 @@ function metricsTableRowRenderer(
         content: (
           <Button
             withOnlyIcon={true}
-            size='small'
+            size='medium'
             onClick={actions?.toggleVisibility}
             className='Table__action__icon'
             role='button'

--- a/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
@@ -252,7 +252,7 @@ function paramsTableRowRenderer(
         content: (
           <Button
             withOnlyIcon={true}
-            size='small'
+            size='medium'
             onClick={actions?.toggleVisibility}
             className='Table__action__icon'
             aria-pressed='false'

--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -1128,7 +1128,9 @@ function getDataAsTableRows(
         color: metricsCollection.color ?? metric.color,
         dasharray: metricsCollection.dasharray ?? metric.dasharray,
         experiment: metric.run.props.experiment ?? 'default',
-        run: metric.run.props.name,
+        run: moment(metric.run.props.creation_time * 1000).format(
+          'HH:mm:ss · D MMM, YY',
+        ),
         metric: metric.metric_name,
         context: contextToString(metric.context)?.split(',') || [''],
         value:
@@ -1232,7 +1234,9 @@ function getDataAsTableRows(
       if (metricsCollection.config !== null) {
         rows[groupKey!].data[columnKey] =
           columnsValues[columnKey].length === 1
-            ? columnsValues[columnKey][0]
+            ? paramKeys.includes(columnKey)
+              ? formatValue(columnsValues[columnKey][0])
+              : columnsValues[columnKey][0]
             : columnsValues[columnKey];
       }
     }

--- a/aim/web/ui/src/services/models/params/paramsAppModel.ts
+++ b/aim/web/ui/src/services/models/params/paramsAppModel.ts
@@ -1204,11 +1204,17 @@ function getDataAsTableRows(
         color: metricsCollection.color ?? metric.color,
         dasharray: metricsCollection.dasharray ?? metric.dasharray,
         experiment: metric.run.props.experiment ?? 'default',
-        run: metric.run.props.name ?? '-',
+        run: moment(metric.run.props.creation_time * 1000).format(
+          'HH:mm:ss · D MMM, YY',
+        ),
         metric: metric.metric_name,
         ...metricsRowValues,
       };
       rowIndex++;
+
+      for (let key in metricsRowValues) {
+        columnsValues[key] = ['-'];
+      }
 
       [
         'experiment',
@@ -1273,7 +1279,9 @@ function getDataAsTableRows(
       if (metricsCollection.config !== null) {
         rows[groupKey!].data[columnKey] =
           columnsValues[columnKey].length === 1
-            ? columnsValues[columnKey][0]
+            ? paramKeys.includes(columnKey)
+              ? formatValue(columnsValues[columnKey][0])
+              : columnsValues[columnKey][0]
             : columnsValues[columnKey];
       }
     }

--- a/aim/web/ui/src/services/models/runs/runsAppModel.ts
+++ b/aim/web/ui/src/services/models/runs/runsAppModel.ts
@@ -814,7 +814,9 @@ function getDataAsTableRows(
         color: metricsCollection.color ?? metric.color,
         dasharray: metricsCollection.dasharray ?? metric.dasharray,
         experiment: metric.run.props.experiment ?? 'default',
-        run: metric.run.props.name ?? '-',
+        run: moment(metric.run.props.creation_time * 1000).format(
+          'HH:mm:ss · D MMM, YY',
+        ),
         metric: metric.metric_name,
         ...metricsRowValues,
       };

--- a/aim/web/ui/src/types/services/models/metrics/runModel.d.ts
+++ b/aim/web/ui/src/types/services/models/metrics/runModel.d.ts
@@ -3,6 +3,8 @@ export interface IRun<T> {
   props: {
     experiment: string | null;
     name: string;
+    creation_time: number;
+    end_time: number;
   };
   created_at: number;
   traces: T[];


### PR DESCRIPTION
- Replace run name with creation time in tables
- Fix action icons size (toggle visibility icon)
- Apply formatting on group header row values