### PR TITLE
Sort metrics data in ascending order for X-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Sort metrics data in ascending order for X-axis (KaroMourad)
+
 ## 3.0.1 Oct 22 2021
 
-- Implement sorting algorithm on Metric data (KaroMourad)
 - Check telemetry_enabled option on segment initialization (VkoHov)
 - Draw LineChart Y-axis (horizontal) tick lines on zooming (KaroMourad)
 - Sort select options/params based on input value (roubkar)

--- a/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
+++ b/aim/web/ui/src/services/models/metrics/metricsAppModel.ts
@@ -815,8 +815,8 @@ function groupData(data: IMetric[]): IMetricsCollection<IMetric>[] {
 }
 
 /**
- * Sort X-values
- * Depends on sorted X-Values get corresponding Y-values
+ * Sort X-axis values in ascending order
+ * Sort Y-axis values based on corresponding X-axis value order
  * */
 function sortDependingArrays(
   xValues: number[],


### PR DESCRIPTION
To draw lines in the correct way(avoid splines) we should pass X-axis values in ascending order to the d3 line(path) generator.