### PR TITLE
Add repo argument on aim init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Improve rendering performance by virtualizing table columns (roubkar)
 - Add ability to apply grouping by higher level param key (roubkar)
-
+- Add ability to specify repository path during `aim init` via `--repo` argument (rubenaprikyan)
 ## 3.0.6 Nov 9 2021
 
 - Fix for blocking container optimization for in progress runs (alberttorosyan)

--- a/aim/cli/init/commands.py
+++ b/aim/cli/init/commands.py
@@ -2,15 +2,21 @@ import click
 import os
 
 from aim.sdk.repo import Repo
+from aim.sdk.utils import clean_repo_path
 
 
 @click.command()
-def init():
+@click.option('--repo', required=False, type=click.Path(exists=True,
+                                                        file_okay=False,
+                                                        dir_okay=True,
+                                                        writable=True))
+def init(repo):
     """
-    Initializes new repository in the current working directory:
+    Initializes new repository in the --repo directory.
+    Initializes new repository in the current working directory if --repo argument is provided:
      - Creates .aim directory & runs upgrades for structured DB
     """
-    repo_path = os.getcwd()
+    repo_path = clean_repo_path(repo) or os.getcwd()
     re_init = False
     if Repo.exists(repo_path):
         re_init = click.confirm('Aim repository is already initialized. '

--- a/docs/source/refs/cli.md
+++ b/docs/source/refs/cli.md
@@ -22,6 +22,11 @@ $ aim init
 Creates `.aim` directory to save the recorded experiments to.
 Running `aim init` in an existing repository will prompt the user for re-initialization.
 
+| Args                              | Description                                               |
+| --------------------------------- | --------------------------------------------------------- |
+| `--repo <repo_path>`              | Path to parent directory of `.aim` repo. _Current working directory by default_ |
+
+
   **_Beware:_** Re-initialization of the repo clears `.aim` folder from previously saved data and initializes new repo.
   **_Note:_** This command is not necessary to be able to get started with Aim as aim is automatically initializes with the first aim function call.
 


### PR DESCRIPTION
Add ability to specify repository path during `aim init` via `--repo` argument