### PR TITLE
Security issue fix for `/static-files/{path}` endpoint 

### DIFF
--- a/aim/web/api/views.py
+++ b/aim/web/api/views.py
@@ -1,7 +1,9 @@
 import os
+from pathlib import Path
 
 from aim.web.api.utils import APIRouter  # wrapper for fastapi.APIRouter
 from fastapi.responses import FileResponse
+from fastapi import HTTPException
 
 statics_router = APIRouter()
 
@@ -9,7 +11,13 @@ statics_router = APIRouter()
 @statics_router.get('/static-files/{path:path}/')
 async def serve_static_files(path):
     from aim import web
-    static_file_name = os.path.join(os.path.dirname(web.__file__), 'ui', 'build', path)
+    static_file_root = os.path.join(os.path.dirname(web.__file__), 'ui', 'build')
+    static_file_name = os.path.join(static_file_root, path)
+
+    # check if path is leading inside ui/build directory
+    if not Path(static_file_root) in Path(static_file_name).resolve().parents:
+        raise HTTPException(404)
+
     compressed_file_name = '{}.gz'.format(static_file_name)
     if os.path.exists(compressed_file_name):
         return FileResponse(compressed_file_name, headers={'Content-Encoding': 'gzip'})

--- a/aim/web/api/views.py
+++ b/aim/web/api/views.py
@@ -11,11 +11,11 @@ statics_router = APIRouter()
 @statics_router.get('/static-files/{path:path}/')
 async def serve_static_files(path):
     from aim import web
-    static_file_root = os.path.join(os.path.dirname(web.__file__), 'ui', 'build')
-    static_file_name = os.path.join(static_file_root, path)
+    static_files_root = os.path.join(os.path.dirname(web.__file__), 'ui', 'build')
+    static_file_name = '/'.join((static_files_root, path))
 
     # check if path is leading inside ui/build directory
-    if not Path(static_file_root) in Path(static_file_name).resolve().parents:
+    if not Path(static_files_root) in Path(static_file_name).resolve().parents:
         raise HTTPException(404)
 
     compressed_file_name = '{}.gz'.format(static_file_name)


### PR DESCRIPTION
Fix security issue when incorrect path is given to the endpoint that serves static files which can lead to a leak of files (e.g. `/static-files/../../../../etc/passwd`)