### PR TITLE
Improve Images Explorer rendering performance through better images list virtualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve Images Explorer rendering performance through better images list virtualization (roubkar)
+
 ## 3.1.0 Nov 20 2021
 
 - Add ability to explore tracked images (VkoHov)

--- a/aim/web/ui/src/components/ImagesList/ImageBox.tsx
+++ b/aim/web/ui/src/components/ImagesList/ImageBox.tsx
@@ -2,14 +2,13 @@ import React, { memo, useEffect } from 'react';
 
 import { Skeleton } from '@material-ui/lab';
 
-import { imageFixedHeight } from 'config/imagesConfigs/imagesConfig';
-
 const ImageBox = ({
   index,
   style,
   data,
   imagesBlobs,
   addUriToList,
+  imageHeight,
 }: any): React.FunctionComponentElement<React.ReactNode> => {
   const { format, blob_uri } = data;
 
@@ -33,7 +32,7 @@ const ImageBox = ({
         ) : (
           <Skeleton
             variant='rect'
-            height={imageFixedHeight - 10}
+            height={imageHeight - 10}
             width={style.width - 10}
           />
         )}

--- a/aim/web/ui/src/components/ImagesList/ImagesList.tsx
+++ b/aim/web/ui/src/components/ImagesList/ImagesList.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { VariableSizeList as List } from 'react-window';
 
-import { imageFixedHeight } from 'config/imagesConfigs/imagesConfig';
-
 import ImageBox from './ImageBox';
 
 function ImagesList({
@@ -11,13 +9,14 @@ function ImagesList({
   onScroll,
   imageSetWrapperWidth,
   addUriToList,
+  imageHeight,
 }: any): React.FunctionComponentElement<React.ReactNode> {
   return (
     <List
-      height={imageFixedHeight}
+      height={imageHeight}
       itemCount={data.length}
       itemSize={(index: number) =>
-        (imageFixedHeight / data[index].height) * data[index].width
+        (imageHeight / data[index].height) * data[index].width
       }
       layout='horizontal'
       width={imageSetWrapperWidth || 0}
@@ -31,6 +30,7 @@ function ImagesList({
           data={data[index]}
           imagesBlobs={imagesBlobs}
           addUriToList={addUriToList}
+          imageHeight={imageHeight}
         />
       )}
     </List>

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
@@ -95,12 +95,11 @@ function ImagesPanel({
               <div className='ImagesPanel__imagesContainer'>
                 <ImagesSet
                   data={imagesData}
-                  title={'root'}
                   imagesBlobs={imagesBlobs}
                   onScroll={onScroll}
                   addUriToList={addUriToList}
                   imagesSetKey={imagesSetKey}
-                  imageSetWrapperHeight={imageWrapperOffsetHeight - 36}
+                  imageSetWrapperHeight={imageWrapperOffsetHeight - 40}
                   imageSetWrapperWidth={imageWrapperOffsetWidth}
                 />
               </div>

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
@@ -8,6 +8,8 @@ import EmptyComponent from 'components/EmptyComponent/EmptyComponent';
 import ImagesExploreRangePanel from 'components/ImagesExploreRangePanel';
 import { Text } from 'components/kit';
 
+import { imageFixedHeight } from 'config/imagesConfigs/imagesConfig';
+
 import { IImagesPanelProps } from './ImagesPanel.d';
 
 import './ImagesPanel.scss';
@@ -101,6 +103,7 @@ function ImagesPanel({
                   imagesSetKey={imagesSetKey}
                   imageSetWrapperHeight={imageWrapperOffsetHeight - 40}
                   imageSetWrapperWidth={imageWrapperOffsetWidth}
+                  imageHeight={imageFixedHeight}
                 />
               </div>
             ) : (

--- a/aim/web/ui/src/components/ImagesSet/ImageSet.scss
+++ b/aim/web/ui/src/components/ImagesSet/ImageSet.scss
@@ -3,47 +3,47 @@
 .ImagesSet {
   width: 100%;
   background-color: #ffffff;
-  &.withLeftBorder {
-    border-left: 0.0625rem solid $cuddle-70;
-    padding: 0.375rem 0 0 0.625rem;
-    &__container__title {
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0.375rem;
-        left: -0.625rem;
-        width: 0.375rem;
-        height: 0.0625rem;
-        background: $cuddle-70;
-      }
-    }
+
+  &__connectorLine {
+    position: absolute;
+    top: -0.375rem;
+    height: 100%;
+    width: 1px;
+    background: $cuddle-70;
   }
 
   &__container {
     display: flex;
     flex-direction: column;
+
     &__title {
       padding-bottom: 0.125rem;
       font-size: $text-sm;
       position: relative;
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0.375rem;
-        left: -0.625rem;
-        width: 0.375rem;
-        height: 0.0625rem;
-        background: $cuddle-70;
+
+      &.withDash {
+        &::after {
+          content: '';
+          position: absolute;
+          top: 0.375rem;
+          left: -0.625rem;
+          width: 0.375rem;
+          height: 0.0625rem;
+          background: $cuddle-70;
+        }
       }
     }
+
     &__imagesBox {
       padding-bottom: 0.25rem;
       padding-top: 0.375rem;
       display: flex;
+
       &__imageBox {
         margin-right: toRem(10px);
         height: 100%;
         position: absolute;
+
         img {
           height: calc(100% - 0.625rem);
           width: calc(100% - 0.625rem);

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
@@ -7,4 +7,5 @@ export interface IImageSetProps {
   imagesSetKey: number;
   imageSetWrapperHeight?: number;
   imageSetWrapperWidth?: number;
+  imageHeight: number;
 }

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
@@ -1,6 +1,5 @@
 export interface IImageSetProps {
   data: any;
-  title: string;
   imagesBlobs: object;
   onScroll: () => void;
   addUriToList: (blobUrl: string) => void;

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
@@ -5,8 +5,6 @@ import classNames from 'classnames';
 
 import ImagesList from 'components/ImagesList';
 
-import { imageFixedHeight } from 'config/imagesConfigs/imagesConfig';
-
 import { IImageSetProps } from './ImagesSet.d';
 
 import './ImageSet.scss';
@@ -24,6 +22,7 @@ const ImagesSet = ({
   imagesSetKey,
   imageSetWrapperHeight,
   imageSetWrapperWidth,
+  imageHeight,
 }: IImageSetProps): React.FunctionComponentElement<React.ReactNode> => {
   let content: [string[], []][] = []; // the actual items list to be passed to virtualized list component
   let keysMap: { [key: string]: number } = {}; // cache for checking whether the group title is already added to list
@@ -51,7 +50,7 @@ const ImagesSet = ({
     }
 
     if (items.length > 0) {
-      return imageFixedHeight + imageWrapperHeight;
+      return imageHeight + imageWrapperHeight;
     }
 
     return imageSetTitleHeight + imageSetWrapperPaddingHeight;
@@ -73,6 +72,7 @@ const ImagesSet = ({
         imageSetWrapperWidth,
         index,
         imagesSetKey,
+        imageHeight,
       }}
     >
       {ImagesGroupedList}
@@ -132,6 +132,7 @@ const ImagesGroupedList = React.memo(function ImagesGroupedList(props: any) {
               onScroll={data.onScroll}
               addUriToList={data.addUriToList}
               imageSetWrapperWidth={data.imageSetWrapperWidth}
+              imageHeight={data.imageHeight}
             />
           </div>
         )}

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
@@ -65,6 +65,7 @@ const ImagesSet = ({
 
   return (
     <List
+      key={content.length}
       height={imageSetWrapperHeight || 0}
       itemCount={content.length}
       itemSize={getItemSize}

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
@@ -14,11 +14,9 @@ import './ImageSet.scss';
 const imageWrapperHeight = 33;
 const imageSetTitleHeight = 17;
 const imageSetWrapperPaddingHeight = 6;
-const gapBetweenItems = 20;
 
 const ImagesSet = ({
   data,
-  title,
   imagesBlobs,
   onScroll,
   addUriToList,
@@ -27,8 +25,8 @@ const ImagesSet = ({
   imageSetWrapperHeight,
   imageSetWrapperWidth,
 }: IImageSetProps): React.FunctionComponentElement<React.ReactNode> => {
-  let content: [string[], []][] = [];
-  let keysMap: { [key: string]: number } = {};
+  let content: [string[], []][] = []; // the actual items list to be passed to virtualized list component
+  let keysMap: { [key: string]: number } = {}; // cache for checking whether the group title is already added to list
 
   function fillContent(list: [] | { [key: string]: [] | {} }, path = ['']) {
     if (Array.isArray(list)) {
@@ -50,10 +48,6 @@ const ImagesSet = ({
     let [path, items] = content[index];
     if (path.length === 1) {
       return 0;
-    }
-
-    if (path.length === 2) {
-      return imageSetTitleHeight + imageSetWrapperPaddingHeight;
     }
 
     if (items.length > 0) {

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
@@ -7,8 +7,6 @@ import ImagesList from 'components/ImagesList';
 
 import { imageFixedHeight } from 'config/imagesConfigs/imagesConfig';
 
-import contextToString from 'utils/contextToString';
-
 import { IImageSetProps } from './ImagesSet.d';
 
 import './ImageSet.scss';
@@ -29,101 +27,61 @@ const ImagesSet = ({
   imageSetWrapperHeight,
   imageSetWrapperWidth,
 }: IImageSetProps): React.FunctionComponentElement<React.ReactNode> => {
-  const getItemSize = (index: number) => {
-    const imagesHeights: any = getNestedDataHeight(
-      _.isArray(Object.values(data)[index])
-        ? [Object.values(data)[index]]
-        : Object.values(data)[index],
-    );
-    return (
-      imagesHeights +
-      (_.isArray(Object.values(data)[index])
-        ? gapBetweenItems
-        : gapBetweenItems + imageSetTitleHeight)
-    );
-  };
+  let content: [string[], []][] = [];
+  let keysMap: { [key: string]: number } = {};
 
-  function getNestedDataHeight(data: any): number {
-    let objectData = !_.isArray(data[0]) ? Object.values(data) : data;
-    const calculatedHeight = objectData.reduce((acc: number, item: any) => {
-      if (!_.isArray(item)) {
-        acc +=
-          imageSetTitleHeight +
-          imageSetWrapperPaddingHeight +
-          getNestedDataHeight(item);
-      } else {
-        acc += imageWrapperHeight + imageFixedHeight;
+  function fillContent(list: [] | { [key: string]: [] | {} }, path = ['']) {
+    if (Array.isArray(list)) {
+      content.push([path, list]);
+    } else {
+      for (let key in list) {
+        if (!keysMap.hasOwnProperty(path.join(''))) {
+          content.push([path, []]);
+          keysMap[path.join('')] = 1;
+        }
+        fillContent(list[key], path.concat([key]));
       }
-      return acc;
-    }, 0);
+    }
+  }
 
-    return calculatedHeight;
+  fillContent(data);
+
+  function getItemSize(index: number) {
+    let [path, items] = content[index];
+    if (path.length === 1) {
+      return 0;
+    }
+
+    if (path.length === 2) {
+      return imageSetTitleHeight + imageSetWrapperPaddingHeight;
+    }
+
+    if (items.length > 0) {
+      return imageFixedHeight + imageWrapperHeight;
+    }
+
+    return imageSetTitleHeight + imageSetWrapperPaddingHeight;
   }
 
   return (
-    <div className={classNames('ImagesSet', { withLeftBorder: index > 1 })}>
-      {Array.isArray(data) ? (
-        <div className='ImagesSet__container'>
-          {index !== 0 && (
-            <span className='ImagesSet__container__title'>{title}</span>
-          )}
-          <div className='ImagesSet__container__imagesBox'>
-            <ImagesList
-              data={data}
-              imagesBlobs={imagesBlobs}
-              onScroll={onScroll}
-              addUriToList={addUriToList}
-              imageSetWrapperWidth={imageSetWrapperWidth}
-              index={index + 1}
-            />
-          </div>
-        </div>
-      ) : (
-        <div
-          className='ImagesSet__container'
-          key={contextToString(data)?.length}
-        >
-          {index !== 0 && (
-            <p className='ImagesSet__container__title'>{title}</p>
-          )}
-          {index === 0 ? (
-            <List
-              height={imageSetWrapperHeight || 0}
-              itemCount={Object.keys(data).length}
-              itemSize={getItemSize}
-              width={'100%'}
-              itemData={{
-                data,
-                imagesBlobs,
-                onScroll,
-                addUriToList,
-                imageSetWrapperHeight,
-                imageSetWrapperWidth,
-                index,
-                imagesSetKey,
-              }}
-            >
-              {ImagesGroupedList}
-            </List>
-          ) : (
-            Object.keys(data).map((keyName, key) => (
-              <ImagesSet
-                key={key}
-                data={data[keyName]}
-                title={keyName}
-                imagesBlobs={imagesBlobs}
-                onScroll={onScroll}
-                addUriToList={addUriToList}
-                imageSetWrapperHeight={imageSetWrapperHeight}
-                imageSetWrapperWidth={imageSetWrapperWidth}
-                index={index + 1}
-                imagesSetKey={imagesSetKey}
-              />
-            ))
-          )}
-        </div>
-      )}
-    </div>
+    <List
+      height={imageSetWrapperHeight || 0}
+      itemCount={content.length}
+      itemSize={getItemSize}
+      width={'100%'}
+      itemData={{
+        data: content,
+        imagesBlobs,
+        onScroll,
+        addUriToList,
+        imageSetWrapperHeight,
+        imageSetWrapperWidth,
+        index,
+        imagesSetKey,
+      }}
+    >
+      {ImagesGroupedList}
+    </List>
   );
 };
 
@@ -142,21 +100,47 @@ export default React.memo(ImagesSet, propsComparator);
 
 const ImagesGroupedList = React.memo(function ImagesGroupedList(props: any) {
   const { index, style, data } = props;
-  const keyName = Object.keys(data.data)[index];
+  const [path, items] = data.data[index];
 
   return (
-    <div style={style}>
-      <ImagesSet
-        data={data.data[keyName]}
-        title={keyName}
-        imagesBlobs={data.imagesBlobs}
-        onScroll={data.onScroll}
-        addUriToList={data.addUriToList}
-        imageSetWrapperHeight={data.imageSetWrapperHeight}
-        imageSetWrapperWidth={data.imageSetWrapperWidth}
-        index={data.index + 1}
-        imagesSetKey={data.imagesSetKey}
-      />
+    <div
+      className='ImagesSet'
+      style={{
+        paddingLeft: `calc(0.625rem * ${path.length - 2})`,
+        ...style,
+      }}
+    >
+      {path.slice(2).map((key: string, i: number) => (
+        <div
+          key={key}
+          className='ImagesSet__connectorLine'
+          style={{
+            left: `calc(0.625rem * ${i})`,
+          }}
+        />
+      ))}
+      <div className='ImagesSet__container'>
+        {path.length > 1 && (
+          <span
+            className={classNames('ImagesSet__container__title', {
+              withDash: path.length > 2,
+            })}
+          >
+            {path[path.length - 1]}
+          </span>
+        )}
+        {items.length > 0 && (
+          <div className='ImagesSet__container__imagesBox'>
+            <ImagesList
+              data={items}
+              imagesBlobs={data.imagesBlobs}
+              onScroll={data.onScroll}
+              addUriToList={data.addUriToList}
+              imageSetWrapperWidth={data.imageSetWrapperWidth}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }, areEqual);

--- a/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
+++ b/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
@@ -705,8 +705,8 @@ async function getImagesBlobsData(uris: string[]) {
 
   for await (let [keys, val] of objects) {
     imagesBlobs[keys[0]] = arrayBufferToBase64(val as ArrayBuffer) as string;
+    model.setState({ imagesBlobs: { ...imagesBlobs } });
   }
-  model.setState({ imagesBlobs: { ...imagesBlobs } });
 }
 
 function getDataAsImageSet(


### PR DESCRIPTION
- Reimplement vertical virtualization in `ImagesSet` component
- Change component rendering behavior by removing cyclic nested/recursive rendering
- Display an image right after it is received through the stream
- Add `imageHeight` prop on `ImagesSet` component