### PR TITLE
Fix activity cell click action functionality

### DIFF
--- a/aim/web/ui/src/components/HeatMap/HeatMap.tsx
+++ b/aim/web/ui/src/components/HeatMap/HeatMap.tsx
@@ -147,7 +147,7 @@ function HeatMap({
           } and run.creation_time <= ${endDate / 1000}`,
         });
         analytics.trackEvent('[Home][HeatMap] Activity cell click');
-        history.push(`/runs?search=${search}`);
+        history.push(`/runs?select=${search}`);
       }
     }
 


### PR DESCRIPTION
Changed URL `search` param name to `select` to correspond to app config.