### PR TITLE
Server side fixes and additions

### DIFF
--- a/aim/cli/up/commands.py
+++ b/aim/cli/up/commands.py
@@ -66,7 +66,7 @@ def up(dev, host, port, workers, repo, tf_logs):
     if dev or (os.getenv(AIM_UI_TELEMETRY_KEY) is not None and os.getenv(AIM_UI_TELEMETRY_KEY) == '0'):
         os.environ[AIM_UI_TELEMETRY_KEY] = '0'
     else:
-        # os.environ[AIM_UI_TELEMETRY_KEY] = '1'
+        os.environ[AIM_UI_TELEMETRY_KEY] = '1'
         alert_msg = 'Aim UI collects anonymous usage analytics.'
         opt_out_msg = 'Read how to opt-out here: '
         opt_out_url = 'https://github.com/aimhubio/aim#anonymized-telemetry'

--- a/aim/cli/up/commands.py
+++ b/aim/cli/up/commands.py
@@ -14,13 +14,14 @@ from aim.web.utils import ShellCommandException
 @click.command()
 @click.option('-h', '--host', default=AIM_UI_DEFAULT_HOST, type=str)
 @click.option('-p', '--port', default=AIM_UI_DEFAULT_PORT, type=int)
+@click.option('-w', '--workers', default=1, type=int)
 @click.option('--repo', required=False, type=click.Path(exists=True,
                                                         file_okay=False,
                                                         dir_okay=True,
                                                         writable=True))
 @click.option('--tf_logs', type=click.Path(exists=True, readable=True))
 @click.option('--dev', is_flag=True, default=False)
-def up(dev, host, port, repo, tf_logs):
+def up(dev, host, port, workers, repo, tf_logs):
     if dev:
         os.environ[AIM_ENV_MODE_KEY] = 'dev'
     else:
@@ -65,7 +66,7 @@ def up(dev, host, port, repo, tf_logs):
     if dev or (os.getenv(AIM_UI_TELEMETRY_KEY) is not None and os.getenv(AIM_UI_TELEMETRY_KEY) == '0'):
         os.environ[AIM_UI_TELEMETRY_KEY] = '0'
     else:
-        os.environ[AIM_UI_TELEMETRY_KEY] = '1'
+        # os.environ[AIM_UI_TELEMETRY_KEY] = '1'
         alert_msg = 'Aim UI collects anonymous usage analytics.'
         opt_out_msg = 'Read how to opt-out here: '
         opt_out_url = 'https://github.com/aimhubio/aim#anonymized-telemetry'
@@ -90,7 +91,7 @@ def up(dev, host, port, repo, tf_logs):
     click.echo('Press Ctrl+C to exit')
 
     try:
-        server_cmd = build_uvicorn_command(host, port, 1)
+        server_cmd = build_uvicorn_command(host, port, workers)
         exec_cmd(server_cmd, stream_output=True)
     except ShellCommandException:
         click.echo('Failed to run Aim UI. '

--- a/aim/web/api/runs/image_utils.py
+++ b/aim/web/api/runs/image_utils.py
@@ -87,10 +87,10 @@ def get_trace_info(trace: Sequence, rec_slice: slice, idx_slice: slice) -> dict:
     }
 
 
-def image_search_result_streamer(traces: SequenceCollection,
-                                 rec_range: IndexRange, rec_density: int,
-                                 idx_range: IndexRange, idx_density: int,
-                                 calc_total_ranges: bool):
+async def image_search_result_streamer(traces: SequenceCollection,
+                                       rec_range: IndexRange, rec_density: int,
+                                       idx_range: IndexRange, idx_density: int,
+                                       calc_total_ranges: bool):
     record_range_missing = rec_range.start is None or rec_range.stop is None
     index_range_missing = idx_range.start is None or idx_range.stop is None
     run_traces = {}

--- a/aim/web/api/runs/utils.py
+++ b/aim/web/api/runs/utils.py
@@ -124,7 +124,9 @@ def custom_aligned_metrics_streamer(requested_runs: List[AlignedRunIn], x_axis: 
         yield collect_run_streamable_data(encoded_tree)
 
 
-async def metric_search_result_streamer(traces: SequenceCollection, steps_num: int, x_axis: Optional[str]) -> bytes:
+async def metric_search_result_streamer(traces: SequenceCollection,
+                                        steps_num: int,
+                                        x_axis: Optional[str]) -> bytes:
     for run_trace_collection in traces.iter_runs():
         run = None
         traces_list = []

--- a/aim/web/api/runs/utils.py
+++ b/aim/web/api/runs/utils.py
@@ -124,7 +124,7 @@ def custom_aligned_metrics_streamer(requested_runs: List[AlignedRunIn], x_axis: 
         yield collect_run_streamable_data(encoded_tree)
 
 
-def metric_search_result_streamer(traces: SequenceCollection, steps_num: int, x_axis: Optional[str]) -> bytes:
+async def metric_search_result_streamer(traces: SequenceCollection, steps_num: int, x_axis: Optional[str]) -> bytes:
     for run_trace_collection in traces.iter_runs():
         run = None
         traces_list = []

--- a/aim/web/api/runs/views.py
+++ b/aim/web/api/runs/views.py
@@ -80,7 +80,7 @@ def run_metric_custom_align_api(request_data: MetricAlignApiIn):
 
 @runs_router.get('/search/metric/', response_model=RunMetricSearchApiOut,
                  responses={400: {'model': QuerySyntaxErrorOut}})
-def run_metric_search_api(q: Optional[str] = '', p: Optional[int] = 50, x_axis: Optional[str] = None):
+async def run_metric_search_api(q: Optional[str] = '', p: Optional[int] = 50, x_axis: Optional[str] = None):
     steps_num = p
 
     if x_axis:
@@ -110,7 +110,7 @@ def run_metric_search_api(q: Optional[str] = '', p: Optional[int] = 50, x_axis: 
 
 @runs_router.get('/search/images/', response_model=RunImagesSearchApiOut,
                  responses={400: {'model': QuerySyntaxErrorOut}})
-def run_images_search_api(q: Optional[str] = '',
+async def run_images_search_api(q: Optional[str] = '',
                           record_range: Optional[str] = '', record_density: Optional[int] = 50,
                           index_range: Optional[str] = '', index_density: Optional[int] = 5,
                           calc_ranges: Optional[bool] = False):

--- a/aim/web/api/runs/views.py
+++ b/aim/web/api/runs/views.py
@@ -80,7 +80,9 @@ def run_metric_custom_align_api(request_data: MetricAlignApiIn):
 
 @runs_router.get('/search/metric/', response_model=RunMetricSearchApiOut,
                  responses={400: {'model': QuerySyntaxErrorOut}})
-async def run_metric_search_api(q: Optional[str] = '', p: Optional[int] = 50, x_axis: Optional[str] = None):
+async def run_metric_search_api(q: Optional[str] = '',
+                                p: Optional[int] = 50,
+                                x_axis: Optional[str] = None):
     steps_num = p
 
     if x_axis:
@@ -111,9 +113,9 @@ async def run_metric_search_api(q: Optional[str] = '', p: Optional[int] = 50, x_
 @runs_router.get('/search/images/', response_model=RunImagesSearchApiOut,
                  responses={400: {'model': QuerySyntaxErrorOut}})
 async def run_images_search_api(q: Optional[str] = '',
-                          record_range: Optional[str] = '', record_density: Optional[int] = 50,
-                          index_range: Optional[str] = '', index_density: Optional[int] = 5,
-                          calc_ranges: Optional[bool] = False):
+                                record_range: Optional[str] = '', record_density: Optional[int] = 50,
+                                index_range: Optional[str] = '', index_density: Optional[int] = 5,
+                                calc_ranges: Optional[bool] = False):
     # Get project
     project = Project()
     if not project.exists():


### PR DESCRIPTION
Provide `-w` or `--workers` option for `aim up` command to specify `uvicorn` workers count and make images/metrics search endpoints async to avoid memory piling up