### PR TITLE
Performance tests fixes

### DIFF
--- a/performance_tests/BASELINE
+++ b/performance_tests/BASELINE
@@ -14,8 +14,8 @@ test_query_metrics_0 2.3099902153015135
 test_query_metrics_1 2.2675888538360596
 test_query_metrics_2 2.1064000129699707
 test_query_metrics_3 2.0363479614257813
-test_container_open 0.15380797386169434
-test_random_access_0 0.671191930770874
-test_random_access_1 1.5739768028259278
-test_random_access_2 2.5968095779418947
+test_container_open 0.14817126989364623
+test_random_access_0 0.639186429977417
+test_random_access_1 1.5699856758117676
+test_random_access_2 2.567618751525879
 test_iterative_access 3.9440258979797362

--- a/performance_tests/conftest.py
+++ b/performance_tests/conftest.py
@@ -51,6 +51,5 @@ def pytest_sessionfinish(session, exitstatus):
     if os.environ.get('AIM_LOCAL_PERFORMANCE_TEST'):
         for path in TEST_REPO_PATHS.values():
             _cleanup_test_repo(path)
-        del os.environ['AIM_LOCAL_PERFORMANCE_TEST']
     if os.environ.get('__AIM_REPO_NAME__'):
         del os.environ['__AIM_REPO_NAME__']

--- a/performance_tests/conftest.py
+++ b/performance_tests/conftest.py
@@ -5,9 +5,6 @@ import tarfile
 import time
 from pathlib import Path
 
-from aim.web.utils import exec_cmd
-from aim.cli.up.utils import build_db_upgrade_command
-from aim.web.configs import AIM_ENV_MODE_KEY
 
 TEST_REPO_PATHS = {
     'real_life_repo': '.aim_performance_repo_1',
@@ -42,12 +39,18 @@ def _cleanup_test_repo(path):
 
 
 def pytest_sessionstart(session):
-    _init_test_repos()
+    if os.environ.get('AIM_LOCAL_PERFORMANCE_TEST'):
+        _init_test_repos()
+    else:
+        # github actions performance tests on self hosted runner
+        os.chdir('/home/ubuntu/performance_logs/')
     time.sleep(10)
 
 
 def pytest_sessionfinish(session, exitstatus):
-    for path in TEST_REPO_PATHS.values():
-        _cleanup_test_repo(path)
+    if os.environ.get('AIM_LOCAL_PERFORMANCE_TEST'):
+        for path in TEST_REPO_PATHS.values():
+            _cleanup_test_repo(path)
+        del os.environ['AIM_LOCAL_PERFORMANCE_TEST']
     if os.environ.get('__AIM_REPO_NAME__'):
         del os.environ['__AIM_REPO_NAME__']


### PR DESCRIPTION
Restructure performance tests to use in-place logs instead of downloading from S3 and extracting and adjust baselines for newly added tests. Also added env variable to fallback to the previous download/extract approach.