### PR TITLE
Add tooltip for showing image data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ability to show image data in a tooltip on hover (KaroMourad)
 - Ability to export run props as pandas dataframe (gorarakelyan)
 - Improve Images Explorer rendering performance through better images list virtualization (roubkar)
 

--- a/aim/web/ui/src/components/ChartPanel/ChartPanel.scss
+++ b/aim/web/ui/src/components/ChartPanel/ChartPanel.scss
@@ -2,38 +2,43 @@
 
 .ChartPanel__container {
   height: 100%;
-
-  .ChartPanel__resizing {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: $primary-color-5;
-    user-select: none;
-  }
-
   .ChartPanel {
     overflow: hidden;
     height: 100%;
     border-right: $border-separator;
-  }
-
-  .ChartPanel__paper {
-    padding: 1em;
-    height: 100%;
-    user-select: none;
-  }
-
-  .ChartPanel__paper__grid {
-    height: 100%;
-    overflow: auto;
-    margin: 0;
-    &__chartBox {
-      min-height: 50%;
-      padding: 4px;
-      box-shadow: -1px -1px 0 0 #e8e8e8; // var(--grey-lighter);
+    &__resizing {
+      display: flex;
+      width: 100%;
+      height: 100%;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background-color: $primary-color-5;
+      user-select: none;
+    }
+    &__paper {
+      padding: 1em;
+      height: 100%;
+      user-select: none;
+    }
+    &__paper__grid {
+      height: 100%;
+      overflow: auto;
+      margin: 0;
+      &__chartBox {
+        min-height: 50%;
+        padding: 4px;
+        box-shadow: -1px -1px 0 0 #e8e8e8; // var(--grey-lighter);
+      }
+    }
+    &__controls {
+      width: 3.75rem;
+      max-height: 100%;
+      overflow-y: auto;
     }
   }
+
+
+
+
 }

--- a/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
@@ -50,7 +50,7 @@ const ChartPanel = React.forwardRef(function ChartPanel(
               dataSelector,
             );
           });
-        } else if (props.chartType === ChartTypeEnum.HighPlot) {
+        } else {
           chartRefs.forEach((chartRef, index) => {
             if (index === activePoint.chartIndex) {
               return;

--- a/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
@@ -189,7 +189,7 @@ const ChartPanel = React.forwardRef(function ChartPanel(
               alignmentConfig={props.alignmentConfig}
             />
           </Grid>
-          <Grid className='Metrics__controls__container' item>
+          <Grid className='ChartPanel__controls' item>
             {props.controls}
           </Grid>
         </>

--- a/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.scss
+++ b/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.scss
@@ -3,7 +3,7 @@
 .ChartPopover {
   pointer-events: none;
 
-  .ChartPopover__content {
+  &__content {
     margin: 1em;
     width: 230px;
     max-height: 250px;

--- a/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
@@ -54,10 +54,12 @@ function ChartPopover(props: IChartPopover): JSX.Element | null {
     props.popoverPosition,
     props.containerRef?.current,
     props.tooltipContent,
-    props.focusedState.key,
+    props.focusedState?.key,
     popoverContentRef?.current,
     open,
   ]);
+
+  console.log('ChartPopover -------', props);
 
   return (
     <Popover

--- a/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
@@ -59,8 +59,6 @@ function ChartPopover(props: IChartPopover): JSX.Element | null {
     open,
   ]);
 
-  console.log('ChartPopover -------', props);
-
   return (
     <Popover
       id={id}

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -44,12 +44,12 @@ const PopoverContent = React.forwardRef(function PopoverContent(
               <Text>Y: </Text>
               <span className='PopoverContent__headerValue'>
                 <Text weight={400}>
-                  {isSystemMetric(tooltipContent.metricName)
-                    ? formatSystemMetricName(tooltipContent.metricName)
-                    : tooltipContent.metricName}
+                  {isSystemMetric(tooltipContent.name)
+                    ? formatSystemMetricName(tooltipContent.name)
+                    : tooltipContent.name}
                 </Text>
                 <Text className='PopoverContent__contextValue'>
-                  {contextToString(tooltipContent.metricContext)}
+                  {contextToString(tooltipContent.context)}
                 </Text>
                 <Text component='p' className='PopoverContent__axisValue'>
                   {focusedState?.yValue ?? '--'}
@@ -63,7 +63,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 {alignmentConfig?.type ===
                   AlignmentOptionsEnum.CUSTOM_METRIC && (
                   <Text className='PopoverContent__contextValue'>
-                    {contextToString(tooltipContent.metricContext)}
+                    {contextToString(tooltipContent.context)}
                   </Text>
                 )}
                 <Text component='p' className='PopoverContent__axisValue'>

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -35,8 +35,6 @@ const PopoverContent = React.forwardRef(function PopoverContent(
   } = props;
   const { params = {}, groupConfig = {}, run } = tooltipContent;
 
-  console.log(tooltipContent);
-
   function renderPopoverHeader(): React.ReactNode {
     switch (chartType) {
       case ChartTypeEnum.LineChart:
@@ -101,19 +99,19 @@ const PopoverContent = React.forwardRef(function PopoverContent(
         return (
           <div className='PopoverContent__box'>
             <div className='PopoverContent__value'>
-              Step: <strong>{tooltipContent.step}</strong>
-            </div>
-            <div className='PopoverContent__value'>
-              Index: <strong>{tooltipContent.index}</strong>
-            </div>
-            <div className='PopoverContent__value'>
-              Name: <strong>{tooltipContent.images_name}</strong>{' '}
+              <strong>{tooltipContent.images_name}</strong>
               <Text className='PopoverContent__contextValue'>
                 {contextToString(tooltipContent.context)}
               </Text>
             </div>
             <div className='PopoverContent__value'>
               Caption: <strong>{tooltipContent.caption}</strong>
+            </div>
+            <div className='PopoverContent__value'>
+              Step: <strong>{tooltipContent.step}</strong>
+              <Text className='PopoverContent__contextValue'>
+                Index: <strong>{tooltipContent.index}</strong>
+              </Text>
             </div>
           </div>
         );

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -33,7 +33,9 @@ const PopoverContent = React.forwardRef(function PopoverContent(
     chartType,
     alignmentConfig,
   } = props;
-  const { params = {}, groupConfig = {}, runHash = '' } = tooltipContent;
+  const { params = {}, groupConfig = {}, run } = tooltipContent;
+
+  console.log(tooltipContent);
 
   function renderPopoverHeader(): React.ReactNode {
     switch (chartType) {
@@ -95,6 +97,27 @@ const PopoverContent = React.forwardRef(function PopoverContent(
             </div>
           </div>
         );
+      case ChartTypeEnum.ImageSet:
+        return (
+          <div className='PopoverContent__box'>
+            <div className='PopoverContent__value'>
+              Step: <strong>{tooltipContent.step}</strong>
+            </div>
+            <div className='PopoverContent__value'>
+              Index: <strong>{tooltipContent.index}</strong>
+            </div>
+            <div className='PopoverContent__value'>
+              Name: <strong>{tooltipContent.images_name}</strong>{' '}
+              <Text className='PopoverContent__contextValue'>
+                {contextToString(tooltipContent.context)}
+              </Text>
+            </div>
+            <div className='PopoverContent__value'>
+              Caption: <strong>{tooltipContent.caption}</strong>
+            </div>
+          </div>
+        );
+        break;
       default:
         return null;
     }
@@ -152,13 +175,13 @@ const PopoverContent = React.forwardRef(function PopoverContent(
             </div>
           </div>
         )}
-        {focusedState?.active && runHash ? (
+        {focusedState?.active && run.hash ? (
           <>
             <div>
               <Divider />
               <div className='PopoverContent__box'>
                 <Link
-                  to={PathEnum.Run_Detail.replace(':runHash', runHash)}
+                  to={PathEnum.Run_Detail.replace(':runHash', run.hash)}
                   component={RouteLink}
                   className='PopoverContent__runDetails'
                   underline='none'
@@ -171,7 +194,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
             <div>
               <Divider />
               <div className='PopoverContent__box'>
-                <AttachedTagsList runHash={runHash} />
+                <AttachedTagsList runHash={run.hash} />
               </div>
             </div>
           </>

--- a/aim/web/ui/src/components/ImagesList/ImageBox.tsx
+++ b/aim/web/ui/src/components/ImagesList/ImageBox.tsx
@@ -1,4 +1,5 @@
-import React, { memo, useEffect } from 'react';
+import React, { memo, MouseEvent, useEffect, useRef } from 'react';
+import { isEqual } from 'lodash-es';
 
 import { Skeleton } from '@material-ui/lab';
 
@@ -9,8 +10,11 @@ const ImageBox = ({
   imagesBlobs,
   addUriToList,
   imageHeight,
+  focusedState,
+  syncHoverState,
 }: any): React.FunctionComponentElement<React.ReactNode> => {
   const { format, blob_uri } = data;
+  const boxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let timeoutID = setTimeout(() => addUriToList(blob_uri), 900);
@@ -21,9 +25,50 @@ const ImageBox = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  function safeSyncHoverState(args: any): void {
+    if (typeof syncHoverState === 'function') {
+      syncHoverState(args);
+    }
+  }
+
+  function onClick(e: MouseEvent<HTMLDivElement>): void {
+    if (e?.currentTarget) {
+      e.stopPropagation();
+      const clientRect = e.currentTarget.getBoundingClientRect();
+      safeSyncHoverState({
+        activePoint: { clientRect, key: data.key, seqKey: data.seqKey },
+        focusedStateActive: true,
+      });
+    }
+  }
+
+  function onMouseEnter(e: MouseEvent<HTMLDivElement>): void {
+    if (e?.currentTarget && !focusedState?.active) {
+      const clientRect = e.currentTarget.getBoundingClientRect();
+      safeSyncHoverState({
+        activePoint: { clientRect, key: data.key, seqKey: data.seqKey },
+      });
+    }
+  }
+
+  function onMouseLeave(e: MouseEvent<HTMLDivElement>): void {
+    if (!focusedState?.active) {
+      safeSyncHoverState({ activePoint: null });
+    }
+  }
+
   return (
     <div key={index} className='ImagesSet__container__imagesBox__imageBox'>
-      <div style={style}>
+      <div
+        ref={boxRef}
+        style={style}
+        className={
+          focusedState?.active && focusedState.key === data.key ? 'active' : ''
+        }
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         {imagesBlobs?.[blob_uri] ? (
           <img
             src={`data:image/${format};base64, ${imagesBlobs?.[blob_uri]}`}

--- a/aim/web/ui/src/components/ImagesList/ImageBox.tsx
+++ b/aim/web/ui/src/components/ImagesList/ImageBox.tsx
@@ -16,7 +16,6 @@ const ImageBox = ({
   syncHoverState,
 }: any): React.FunctionComponentElement<React.ReactNode> => {
   const { format, blob_uri } = data;
-  const boxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let timeoutID = setTimeout(() => addUriToList(blob_uri), batchCollectDelay);
@@ -34,14 +33,15 @@ const ImageBox = ({
   }
 
   function onClick(e: MouseEvent<HTMLDivElement>): void {
-    if (e?.currentTarget) {
-      e.stopPropagation();
-      const clientRect = e.currentTarget.getBoundingClientRect();
-      safeSyncHoverState({
-        activePoint: { clientRect, key: data.key, seqKey: data.seqKey },
-        focusedStateActive: true,
-      });
-    }
+    // TODO need to add focused image logic
+    // if (e?.currentTarget) {
+    //   e.stopPropagation();
+    //   const clientRect = e.currentTarget.getBoundingClientRect();
+    //   safeSyncHoverState({
+    //     activePoint: { clientRect, key: data.key, seqKey: data.seqKey },
+    //     focusedStateActive: true,
+    //   });
+    // }
   }
 
   function onMouseEnter(e: MouseEvent<HTMLDivElement>): void {
@@ -62,7 +62,6 @@ const ImageBox = ({
   return (
     <div key={index} className='ImagesSet__container__imagesBox__imageBox'>
       <div
-        ref={boxRef}
         style={style}
         className={
           focusedState?.active && focusedState.key === data.key ? 'active' : ''

--- a/aim/web/ui/src/components/ImagesList/ImagesList.tsx
+++ b/aim/web/ui/src/components/ImagesList/ImagesList.tsx
@@ -10,6 +10,8 @@ function ImagesList({
   imageSetWrapperWidth,
   addUriToList,
   imageHeight,
+  focusedState,
+  syncHoverState,
 }: any): React.FunctionComponentElement<React.ReactNode> {
   return (
     <List
@@ -31,6 +33,8 @@ function ImagesList({
           imagesBlobs={imagesBlobs}
           addUriToList={addUriToList}
           imageHeight={imageHeight}
+          focusedState={focusedState}
+          syncHoverState={syncHoverState}
         />
       )}
     </List>

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.d.ts
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.d.ts
@@ -1,5 +1,12 @@
 import React from 'react';
 
+import { ResizeModeEnum } from 'config/enums/tableEnums';
+
+import {
+  IFocusedState,
+  ITooltipContent,
+} from 'types/services/models/metrics/metricsAppModel';
+
 export interface IImagesPanelProps {
   imagesData: any;
   imagesBlobs: { [key: string]: value };
@@ -18,5 +25,9 @@ export interface IImagesPanelProps {
   panelResizing: boolean;
   imageWrapperOffsetHeight: number;
   imageWrapperOffsetWidth: number;
-  controls: React.ReactNode;
+  controls?: React.ReactNode;
+  resizeMode: ResizeModeEnum;
+  tooltip: ITooltipContent;
+  focusedState: IFocusedState;
+  onActivePointChange?: (activePoint: any, focusedStateActive: boolean) => void;
 }

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.d.ts
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.d.ts
@@ -18,4 +18,5 @@ export interface IImagesPanelProps {
   panelResizing: boolean;
   imageWrapperOffsetHeight: number;
   imageWrapperOffsetWidth: number;
+  controls: React.ReactNode;
 }

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.scss
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.scss
@@ -1,11 +1,12 @@
 @use 'src/styles/abstracts' as *;
 
-.ImagesPanel {
+.ImagesPanel__Container {
   width: calc(100vw - 4.6875rem);
   height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
   &__resizing {
     display: flex;
     width: 100%;
@@ -16,10 +17,21 @@
     background-color: $primary-color-5;
     user-select: none;
   }
-  &__imagesContainer {
-    overflow-x: auto;
-    height: calc(100% - 2.25rem);
-    padding-left: 1.25rem;
-    padding-top: 0.25rem;
+
+  .ImagesPanel {
+    display: flex;
+    flex: 1;
+    &__imagesSetContainer {
+      overflow-x: auto;
+      padding-left: 1.25rem;
+      padding-top: 0.25rem;
+      border-right: 0.0625rem solid #dceafb;
+      flex: 1;
+    }
+    &__controls {
+      width: 3.75rem;
+      max-height: 100%;
+      overflow-y: auto;
+    }
   }
 }

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
@@ -30,6 +30,7 @@ function ImagesPanel({
   imageWrapperOffsetHeight,
   imageWrapperOffsetWidth,
   isRangePanelShow,
+  controls,
 }: IImagesPanelProps): React.FunctionComponentElement<React.ReactNode> {
   let timeoutID = useRef(0);
   let blobUriArray: string[] = [];
@@ -83,26 +84,29 @@ function ImagesPanel({
       loaderComponent={<ChartLoader controlsCount={0} />}
     >
       {panelResizing ? (
-        <div className='ImagesPanel__resizing'>
+        <div className='ImagesPanel__Container__resizing'>
           <Text size={14} color='info'>
             Release to resize
           </Text>
         </div>
       ) : (
         <>
-          <div className='ImagesPanel'>
+          <div className='ImagesPanel__Container'>
             {!isEmpty(imagesData) ? (
-              <div className='ImagesPanel__imagesContainer'>
-                <ImagesSet
-                  data={imagesData}
-                  title={'root'}
-                  imagesBlobs={imagesBlobs}
-                  onScroll={onScroll}
-                  addUriToList={addUriToList}
-                  imagesSetKey={imagesSetKey}
-                  imageSetWrapperHeight={imageWrapperOffsetHeight - 36}
-                  imageSetWrapperWidth={imageWrapperOffsetWidth}
-                />
+              <div className='ImagesPanel'>
+                <div className='ImagesPanel__imagesSetContainer'>
+                  <ImagesSet
+                    data={imagesData}
+                    title={'root'}
+                    imagesBlobs={imagesBlobs}
+                    onScroll={onScroll}
+                    addUriToList={addUriToList}
+                    imagesSetKey={imagesSetKey}
+                    imageSetWrapperHeight={imageWrapperOffsetHeight - 36}
+                    imageSetWrapperWidth={imageWrapperOffsetWidth}
+                  />
+                </div>
+                <div className='ImagesPanel__controls'>{controls}</div>
               </div>
             ) : (
               <EmptyComponent

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import _, { isEmpty, isEqual } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 
 import { PopoverPosition } from '@material-ui/core';
 
@@ -149,6 +149,11 @@ function ImagesPanel({
                 //     focusedStateActive: false,
                 //   });
                 // }}
+                onMouseLeave={() => {
+                  if (!focusedState?.active) {
+                    setPopoverPosition(null);
+                  }
+                }}
               >
                 <div className='ImagesPanel__imagesSetContainer'>
                   <ImagesSet

--- a/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
+++ b/aim/web/ui/src/components/ImagesPanel/ImagesPanel.tsx
@@ -76,54 +76,28 @@ function ImagesPanel({
   const syncHoverState = React.useCallback(
     (args: any): void => {
       const { activePoint, focusedStateActive = false } = args;
-      // if (!activePointRef.current) {
-      setTimeout(() => {
-        activePointRef.current = activePoint;
-        debugger;
-        console.log('syncHoverState', focusedStateActive);
-        // on MouseEnter
-        if (activePoint !== null) {
-          if (onActivePointChange) {
-            onActivePointChange(activePoint, focusedStateActive);
-          }
-          if (activePoint.clientRect) {
-            setPopoverPosition({
-              top: activePoint.clientRect.top,
-              left: activePoint.clientRect.left + activePoint.clientRect.width,
-            });
-          } else {
-            setPopoverPosition(null);
-          }
+      activePointRef.current = activePoint;
+      // on MouseEnter
+      if (activePoint !== null) {
+        if (onActivePointChange) {
+          onActivePointChange(activePoint, focusedStateActive);
         }
-        // on MouseLeave
-        else {
+        if (activePoint.clientRect) {
+          setPopoverPosition({
+            top: activePoint.clientRect.top,
+            left: activePoint.clientRect.left + activePoint.clientRect.width,
+          });
+        } else {
           setPopoverPosition(null);
         }
-      }, 50);
-      // }
+      }
+      // on MouseLeave
+      else {
+        setPopoverPosition(null);
+      }
     },
     [onActivePointChange, setPopoverPosition],
   );
-
-  function onContainerScroll() {
-    debugger;
-    if (popoverPosition) {
-      if (activePointRef.current && containerRef.current) {
-        debugger;
-        setPopoverPosition({
-          top:
-            activePointRef.current.clientRect.top -
-            containerRef.current.scrollTop,
-          left:
-            activePointRef.current.clientRect.left +
-            activePointRef.current.clientRect.width -
-            containerRef.current.scrollLeft,
-        });
-      } else {
-        setPopoverPosition(null);
-      }
-    }
-  }
 
   const imagesSetKey = useMemo(
     () => Date.now(),
@@ -147,16 +121,6 @@ function ImagesPanel({
     };
   }, []);
 
-  useEffect(() => {
-    const debouncedScroll = _.debounce(onContainerScroll, 100);
-    const containerNode = containerRef.current;
-    containerNode?.addEventListener('scroll', debouncedScroll);
-    return () => {
-      containerNode?.removeEventListener('scroll', debouncedScroll);
-    };
-  }, [containerRef?.current]);
-
-  console.log('======----===', tooltip);
   return (
     <BusyLoaderWrapper
       isLoading={isLoading}
@@ -177,13 +141,14 @@ function ImagesPanel({
               <div
                 className='ImagesPanel'
                 ref={containerRef}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  syncHoverState({
-                    activePoint: activePointRef.current,
-                    focusedStateActive: false,
-                  });
-                }}
+                // TODO
+                // onClick={(e) => {
+                //   e.stopPropagation();
+                //   syncHoverState({
+                //     activePoint: activePointRef.current,
+                //     focusedStateActive: false,
+                //   });
+                // }}
               >
                 <div className='ImagesPanel__imagesSetContainer'>
                   <ImagesSet

--- a/aim/web/ui/src/components/ImagesSet/ImageSet.scss
+++ b/aim/web/ui/src/components/ImagesSet/ImageSet.scss
@@ -47,6 +47,23 @@
         img {
           height: calc(100% - 0.625rem);
           width: calc(100% - 0.625rem);
+          margin-top: toRem(5px);
+          margin-left: toRem(5px);
+        }
+
+        span {
+          margin-top: toRem(5px);
+          margin-left: toRem(5px);
+        }
+
+        img:hover, span:hover {
+          box-shadow: 0px 0px 3px 3px rgb(0 0 0 / 15%);
+        }
+
+        .active {
+          img, span {
+            box-shadow: 0px 0px 0px 3px rgb(0 0 0 / 24%);
+          }
         }
       }
     }

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
@@ -1,3 +1,5 @@
+import { IFocusedState } from '../../types/services/models/metrics/metricsAppModel';
+
 export interface IImageSetProps {
   data: any;
   imagesBlobs: object;
@@ -8,4 +10,6 @@ export interface IImageSetProps {
   imageSetWrapperHeight?: number;
   imageSetWrapperWidth?: number;
   imageHeight: number;
+  syncHoverState?: (args: any) => void;
+  focusedState: IFocusedState;
 }

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.d.ts
@@ -1,4 +1,4 @@
-import { IFocusedState } from '../../types/services/models/metrics/metricsAppModel';
+import { IFocusedState } from 'types/services/models/metrics/metricsAppModel';
 
 export interface IImageSetProps {
   data: any;

--- a/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
+++ b/aim/web/ui/src/components/ImagesSet/ImagesSet.tsx
@@ -23,6 +23,8 @@ const ImagesSet = ({
   imageSetWrapperHeight,
   imageSetWrapperWidth,
   imageHeight,
+  focusedState,
+  syncHoverState,
 }: IImageSetProps): React.FunctionComponentElement<React.ReactNode> => {
   let content: [string[], []][] = []; // the actual items list to be passed to virtualized list component
   let keysMap: { [key: string]: number } = {}; // cache for checking whether the group title is already added to list
@@ -73,6 +75,8 @@ const ImagesSet = ({
         index,
         imagesSetKey,
         imageHeight,
+        focusedState,
+        syncHoverState,
       }}
     >
       {ImagesGroupedList}
@@ -84,7 +88,10 @@ function propsComparator(
   prevProps: IImageSetProps,
   nextProps: IImageSetProps,
 ): boolean {
-  if (prevProps.imagesSetKey !== nextProps.imagesSetKey) {
+  if (
+    prevProps.imagesSetKey !== nextProps.imagesSetKey ||
+    prevProps.focusedState !== nextProps.focusedState
+  ) {
     return false;
   }
 
@@ -133,6 +140,8 @@ const ImagesGroupedList = React.memo(function ImagesGroupedList(props: any) {
               addUriToList={data.addUriToList}
               imageSetWrapperWidth={data.imageSetWrapperWidth}
               imageHeight={data.imageHeight}
+              focusedState={data.focusedState}
+              syncHoverState={data.syncHoverState}
             />
           </div>
         )}

--- a/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
@@ -24,6 +24,7 @@ import * as analytics from 'services/analytics';
 import imagesExploreAppModel from 'services/models/imagesExplore/imagesExploreAppModel';
 
 import {
+  IFocusedState,
   IGroupingSelectOption,
   IPanelTooltip,
 } from 'types/services/models/metrics/metricsAppModel';
@@ -192,6 +193,7 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
               isLoading={imagesExploreData?.requestIsPending}
               applyButtonDisabled={imagesExploreData?.applyButtonDisabled}
               panelResizing={panelResizing}
+              resizeMode={imagesExploreData?.config?.table.resizeMode}
               imageWrapperOffsetHeight={offsetHeight || 0}
               imageWrapperOffsetWidth={offsetWidth || 0}
               isRangePanelShow={
@@ -200,6 +202,13 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
                 (!!getStateFromUrl('select')?.advancedQuery &&
                   !!getStateFromUrl('select')?.advancedMode)
               }
+              focusedState={
+                imagesExploreData?.config?.images?.focusedState as IFocusedState
+              }
+              tooltip={
+                imagesExploreData?.config?.images?.tooltip as IPanelTooltip
+              }
+              onActivePointChange={imagesExploreAppModel.onActivePointChange}
               controls={
                 <Controls
                   selectOptions={

--- a/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
@@ -18,9 +18,15 @@ import useResizeObserver from 'hooks/window/useResizeObserver';
 
 import SelectForm from 'pages/ImagesExplore/components/SelectForm/SelectForm';
 import Grouping from 'pages/Metrics/components/Grouping/Grouping';
+import Controls from 'pages/ImagesExplore/components/Controls/Controls';
 
 import * as analytics from 'services/analytics';
 import imagesExploreAppModel from 'services/models/imagesExplore/imagesExploreAppModel';
+
+import {
+  IGroupingSelectOption,
+  IPanelTooltip,
+} from 'types/services/models/metrics/metricsAppModel';
 
 import getStateFromUrl from 'utils/getStateFromUrl';
 
@@ -193,6 +199,17 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
                 !isEmpty(getStateFromUrl('select')?.images) ||
                 (!!getStateFromUrl('select')?.advancedQuery &&
                   !!getStateFromUrl('select')?.advancedMode)
+              }
+              controls={
+                <Controls
+                  selectOptions={
+                    imagesExploreData?.groupingSelectOptions as IGroupingSelectOption[]
+                  }
+                  tooltip={
+                    imagesExploreData?.config?.images?.tooltip as IPanelTooltip
+                  }
+                  onChangeTooltip={imagesExploreAppModel?.onChangeTooltip}
+                />
               }
             />
           </div>

--- a/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.scss
+++ b/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.scss
@@ -1,0 +1,88 @@
+@use "src/styles/abstracts" as *;
+
+.Controls__container {
+  padding: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+
+  & > div {
+    margin-bottom: 0.375rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.Controls__icon {
+  color: $pico-70;
+  font-size: 1.125rem;
+  &.active {
+    color: $primary-color;
+  }
+}
+
+.Controls__anchor {
+  height: 2.25rem;
+  width: 2.25rem;
+  display: flex;
+  cursor: pointer;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.18s ease-out;
+  border: 0.0625rem solid transparent;
+  border-radius: $border-radius-main;
+
+  &.active {
+    background-color: $primary-color-10;
+
+    &.outlined {
+      border: $border-main-active;
+    }
+  }
+
+  &.disabled {
+    cursor: initial;
+    i {
+      color: $pico-50;
+    }
+    &:hover {
+      background-color: transparent;
+    }
+  }
+
+  &:hover {
+    background-color: $pico-5;
+
+    .icon-arrow-left {
+      opacity: 1;
+    }
+  }
+}
+
+.Controls__anchor__arrow {
+  width: 0.6875rem;
+  height: 100%;
+  position: absolute;
+  left: -0.8125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .icon-arrow-left {
+    opacity: 0;
+    font-size: 0.45rem;
+    transition: all 0.18s ease-out;
+    color: $pico-30;
+  }
+}
+
+.Controls__anchor__arrow__opened {
+  .icon-arrow-left {
+    //opacity: 1;
+    transform: rotate(180deg);
+  }
+}

--- a/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { Tooltip } from '@material-ui/core';
+
+import ControlPopover from 'components/ControlPopover/ControlPopover';
+import TooltipContentPopover from 'components/TooltipContentPopover/TooltipContentPopover';
+import { Icon } from 'components/kit';
+
+import { IControlProps } from 'types/pages/imagesExplore/components/Controls/Controls';
+
+import './Controls.scss';
+
+function Controls(
+  props: IControlProps,
+): React.FunctionComponentElement<React.ReactNode> {
+  return (
+    <div className='Controls__container ScrollBar__hidden'>
+      <div>
+        <ControlPopover
+          title='Display In Tooltip'
+          anchor={({ onAnchorClick, opened }) => (
+            <Tooltip title='Tooltip Params'>
+              <div
+                onClick={onAnchorClick}
+                className={`Controls__anchor ${opened ? 'active' : ''}`}
+              >
+                <Icon
+                  className={`Controls__icon ${opened ? 'active' : ''}`}
+                  name='cursor'
+                />
+              </div>
+            </Tooltip>
+          )}
+          component={
+            <TooltipContentPopover
+              selectOptions={props.selectOptions}
+              selectedParams={props.tooltip.selectedParams}
+              displayTooltip={props.tooltip.display}
+              onChangeTooltip={props.onChangeTooltip}
+            />
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Controls;

--- a/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.tsx
@@ -60,7 +60,7 @@ function SelectForm({
   function handleSearch(e: React.ChangeEvent<any>): void {
     e.preventDefault();
 
-    searchMetricsRef.current = imagesExploreAppModel.getImagesData();
+    searchMetricsRef.current = imagesExploreAppModel.getImagesData(true);
     searchMetricsRef.current.call();
   }
 

--- a/aim/web/ui/src/pages/Metrics/Metrics.scss
+++ b/aim/web/ui/src/pages/Metrics/Metrics.scss
@@ -58,12 +58,6 @@
   max-height: 6rem;
 }
 
-.Metrics__controls__container {
-  width: 3.75rem;
-  max-height: 100%;
-  overflow-y: auto;
-}
-
 .Metrics__table__aggregationColumn__cell {
   display: flex;
   flex: 1;

--- a/aim/web/ui/src/pages/Metrics/MetricsContainer.tsx
+++ b/aim/web/ui/src/pages/Metrics/MetricsContainer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useRouteMatch, useHistory } from 'react-router-dom';
-import { isEmpty } from 'lodash-es';
 
 import { HighlightEnum } from 'components/HighlightModesPopover/HighlightModesPopover';
 
@@ -24,7 +23,7 @@ import {
   IAlignmentConfig,
   IAppData,
   IChartTitleData,
-  IChartTooltip,
+  IPanelTooltip,
   IChartZoom,
   IFocusedState,
   IGroupingSelectOption,
@@ -161,7 +160,7 @@ function MetricsContainer(): React.FunctionComponentElement<React.ReactNode> {
       smoothingFactor={metricsData?.config?.chart?.smoothingFactor as number}
       focusedState={metricsData?.config?.chart?.focusedState as IFocusedState}
       notifyData={metricsData?.notifyData as IMetricAppModelState['notifyData']}
-      tooltip={metricsData?.config?.chart?.tooltip as IChartTooltip}
+      tooltip={metricsData?.config?.chart?.tooltip as IPanelTooltip}
       aggregationConfig={
         metricsData?.config?.chart?.aggregationConfig as IAggregationConfig
       }

--- a/aim/web/ui/src/pages/Metrics/components/Grouping/Grouping.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Grouping/Grouping.tsx
@@ -16,7 +16,7 @@ const groupingPopovers = (singleGrouping: boolean) =>
         {
           title: 'Select Fields For Grouping',
           advancedTitle: 'Color Advanced Options',
-          groupName: 'groupBy',
+          groupName: 'group',
           groupDisplayName: 'group',
           AdvancedComponent: null,
         },

--- a/aim/web/ui/src/pages/Metrics/components/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/GroupingItem/GroupingItem.tsx
@@ -12,7 +12,7 @@ import './GroupingItem.scss';
 const icons = {
   stroke: 'line-style',
   chart: 'chart-group',
-  groupBy: 'image-group',
+  group: 'image-group',
   color: 'coloring',
 };
 

--- a/aim/web/ui/src/pages/Params/Params.scss
+++ b/aim/web/ui/src/pages/Params/Params.scss
@@ -59,9 +59,3 @@
   min-height: 6rem;
   max-height: 6rem;
 }
-
-.Metrics__controls__container {
-  width: 3.75rem;
-  max-height: 100%;
-  overflow-y: auto;
-}

--- a/aim/web/ui/src/pages/Params/ParamsContainer.tsx
+++ b/aim/web/ui/src/pages/Params/ParamsContainer.tsx
@@ -12,7 +12,7 @@ import * as analytics from 'services/analytics';
 
 import {
   IChartTitleData,
-  IChartTooltip,
+  IPanelTooltip,
   IGroupingSelectOption,
 } from 'types/services/models/metrics/metricsAppModel';
 import {
@@ -115,7 +115,7 @@ function ParamsContainer(): React.FunctionComponentElement<React.ReactNode> {
       }
       sortFields={paramsData?.config?.table?.sortFields!}
       curveInterpolation={paramsData?.config?.chart?.curveInterpolation}
-      tooltip={paramsData?.config?.chart?.tooltip as IChartTooltip}
+      tooltip={paramsData?.config?.chart?.tooltip as IPanelTooltip}
       chartTitleData={paramsData?.chartTitleData as IChartTitleData}
       groupingSelectOptions={
         paramsData?.groupingSelectOptions as IGroupingSelectOption[]

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -54,7 +54,7 @@ import {
   GroupNameType,
   IChartZoom,
   IAggregationConfig,
-  IChartTooltip,
+  IPanelTooltip,
   ITooltipData,
   IGroupingSelectOption,
 } from 'types/services/models/metrics/metricsAppModel';
@@ -487,7 +487,6 @@ function createAppModel({
             model.setState({
               requestIsPending: false,
               queryIsEmpty: true,
-
               ...state,
             });
           } else {
@@ -924,6 +923,7 @@ function createAppModel({
         processedData: data,
         paramKeys: params,
         groupingSelectOptions,
+        groupingItems: ['color', 'stroke', 'chart'],
         model,
       });
       const tableData = getDataAsTableRows(
@@ -999,6 +999,7 @@ function createAppModel({
         processedData: data,
         paramKeys: params,
         groupingSelectOptions,
+        groupingItems: ['color', 'stroke', 'chart'],
         model,
       });
       const tableData = getDataAsTableRows(
@@ -1813,7 +1814,7 @@ function createAppModel({
         onAlignmentTypeChange(type: AlignmentOptionsEnum): void {
           onAlignmentTypeChange({ type, model, appName, updateModelData });
         },
-        onChangeTooltip(tooltip: Partial<IChartTooltip>): void {
+        onChangeTooltip(tooltip: Partial<IPanelTooltip>): void {
           onChangeTooltip({ tooltip, tooltipData, model, appName });
         },
         onDensityTypeChange(type: DensityOptions): Promise<void> {
@@ -3253,6 +3254,7 @@ function createAppModel({
           processedData: data,
           paramKeys: params,
           groupingSelectOptions,
+          groupingItems: ['color', 'stroke', 'chart'],
           model,
         });
 
@@ -3632,6 +3634,7 @@ function createAppModel({
           processedData: data,
           paramKeys: params,
           groupingSelectOptions,
+          groupingItems: ['color', 'stroke', 'chart'],
           model,
         });
         const tableData = getDataAsTableRows(
@@ -3855,7 +3858,7 @@ function createAppModel({
       }
       if (components?.charts?.[0]) {
         Object.assign(methods, {
-          onChangeTooltip(tooltip: Partial<IChartTooltip>): void {
+          onChangeTooltip(tooltip: Partial<IPanelTooltip>): void {
             onChangeTooltip({ tooltip, tooltipData, model, appName });
           },
           onColorIndicatorChange(): void {

--- a/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
+++ b/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
@@ -387,6 +387,21 @@ function setModelData(rawData: any[], configData: IImagesExploreAppConfig) {
     groupingItems: ['group'],
     model,
   });
+  if (configData.images.focusedState.key) {
+    configData = {
+      ...configData,
+      images: {
+        ...configData.images,
+        tooltip: {
+          ...configData.images.tooltip,
+          content: filterTooltipContent(
+            tooltipData[configData.images.focusedState.key],
+            configData?.images.tooltip.selectedParams,
+          ),
+        },
+      },
+    };
+  }
   const tableData = getDataAsTableRows(
     data,
     params,
@@ -468,6 +483,23 @@ function updateModelData(
     groupingItems: ['group'],
     model,
   });
+
+  if (configData.images.focusedState.key) {
+    configData = {
+      ...configData,
+      images: {
+        ...configData.images,
+        tooltip: {
+          ...configData.images.tooltip,
+          content: filterTooltipContent(
+            tooltipData[configData.images.focusedState.key],
+            configData?.images.tooltip.selectedParams,
+          ),
+        },
+      },
+    };
+  }
+
   const tableData = getDataAsTableRows(
     data,
     params,
@@ -492,22 +524,6 @@ function updateModelData(
 
   if (shouldURLUpdate) {
     updateURL(configData);
-  }
-
-  if (configData.images.focusedState.key) {
-    configData = {
-      ...configData,
-      images: {
-        ...configData.images,
-        tooltip: {
-          ...configData.images.tooltip,
-          content: filterTooltipContent(
-            tooltipData[configData.images.focusedState.key],
-            configData?.images.tooltip.selectedParams,
-          ),
-        },
-      },
-    };
   }
 
   model.setState({
@@ -647,7 +663,6 @@ function onGroupingSelectChange({
   const configData: IImagesExploreAppConfig | undefined =
     model.getState()?.config;
   if (configData?.grouping) {
-    debugger;
     configData.grouping = { ...configData.grouping, [groupName]: list };
     updateModelData(configData, true);
   }
@@ -824,14 +839,6 @@ function onActivePointChange(
     }
   }
   let configData = config;
-  console.log(
-    'content',
-    filterTooltipContent(
-      tooltipData[activePoint.key],
-      configData?.images.tooltip.selectedParams,
-    ),
-  );
-  debugger;
   if (configData?.images) {
     configData = {
       ...configData,

--- a/aim/web/ui/src/types/components/ChartPanel/ChartPanel.d.ts
+++ b/aim/web/ui/src/types/components/ChartPanel/ChartPanel.d.ts
@@ -7,7 +7,7 @@ import { IActivePoint } from 'types/utils/d3/drawHoverAttributes';
 import { IProcessedData } from 'types/utils/d3/processData';
 import {
   IAggregationConfig,
-  IChartTooltip,
+  IPanelTooltip,
   IFocusedState,
   IAlignmentConfig,
   IChartZoom,
@@ -22,7 +22,7 @@ export interface IChartPanelProps {
   data: ILine[][] | any;
   panelResizing?: boolean;
   focusedState: IFocusedState;
-  tooltip: IChartTooltip;
+  tooltip: IPanelTooltip;
   aggregationConfig?: IAggregationConfig;
   alignmentConfig?: IAlignmentConfig;
   zoom?: Partial<IChartZoom>;

--- a/aim/web/ui/src/types/components/GroupingPopover/GroupingPopover.d.ts
+++ b/aim/web/ui/src/types/components/GroupingPopover/GroupingPopover.d.ts
@@ -9,7 +9,7 @@ import {
 
 export interface IGroupingPopoverProps {
   groupName: GroupNameType;
-  groupingData: IMetricAppConfig['grouping'];
+  groupingData: any;
   advancedComponent?: React.FunctionComponentElement<React.ReactNode> | null;
   groupingSelectOptions: IGroupingSelectOption[];
   onSelect: IMetricProps['onGroupingSelectChange'];

--- a/aim/web/ui/src/types/components/TooltipContentPopover/TooltipContentPopover.d.ts
+++ b/aim/web/ui/src/types/components/TooltipContentPopover/TooltipContentPopover.d.ts
@@ -1,5 +1,5 @@
 import {
-  IChartTooltip,
+  IPanelTooltip,
   IGroupingSelectOption,
 } from 'types/services/models/metrics/metricsAppModel';
 
@@ -7,5 +7,5 @@ export interface ITooltipContentPopoverProps {
   selectOptions: IGroupingSelectOption[];
   selectedParams: string[];
   displayTooltip: boolean;
-  onChangeTooltip: (tooltip: Partial<IChartTooltip>) => void;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
 }

--- a/aim/web/ui/src/types/pages/imagesExplore/components/Controls/Controls.d.ts
+++ b/aim/web/ui/src/types/pages/imagesExplore/components/Controls/Controls.d.ts
@@ -1,0 +1,8 @@
+import { IPanelTooltip } from 'services/models/metrics/metricsAppModel';
+import { IGroupingSelectOption } from 'services/models/imagesExplore/imagesExploreAppModel';
+
+export interface IControlProps {
+  selectOptions: IGroupingSelectOption[];
+  tooltip: IPanelTooltip;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
+}

--- a/aim/web/ui/src/types/pages/imagesExplore/components/SelectForm/SelectForm.d.ts
+++ b/aim/web/ui/src/types/pages/imagesExplore/components/SelectForm/SelectForm.d.ts
@@ -1,5 +1,4 @@
 export interface ISelectFormProps {
-  //   selectedMetricsData: IMetricAppConfig['select'];
   selectedImagesData: any;
   onImagesExploreSelectChange: (metrics: ISelectMetricsOption[]) => void;
   onSelectRunQueryChange: (query: string) => void;

--- a/aim/web/ui/src/types/pages/metrics/Metrics.d.ts
+++ b/aim/web/ui/src/types/pages/metrics/Metrics.d.ts
@@ -19,7 +19,7 @@ import {
   IAggregationConfig,
   IAggregatedData,
   IAlignmentConfig,
-  IChartTooltip,
+  IPanelTooltip,
   IChartTitleData,
   IGroupingSelectOption,
   IChartZoom,
@@ -60,7 +60,7 @@ export interface IMetricProps extends Partial<RouteChildrenProps> {
   highlightMode: HighlightEnum;
   groupingData: IMetricAppConfig['grouping'];
   notifyData: IMetricAppModelState['notifyData'];
-  tooltip: IChartTooltip;
+  tooltip: IPanelTooltip;
   aggregationConfig: IAggregationConfig;
   alignmentConfig: IAlignmentConfig;
   selectedMetricsData: IMetricAppConfig['select'];
@@ -72,7 +72,7 @@ export interface IMetricProps extends Partial<RouteChildrenProps> {
   projectsDataMetrics: IProjectParamsMetrics['metric'];
   requestIsPending: boolean;
   resizeMode: ResizeModeEnum;
-  onChangeTooltip: (tooltip: Partial<IChartTooltip>) => void;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
   onIgnoreOutliersChange: () => void;
   onZoomChange: (zoom: Partial<IChartZoom>) => void;
   onActivePointChange?: (

--- a/aim/web/ui/src/types/pages/metrics/components/Controls/Controls.d.ts
+++ b/aim/web/ui/src/types/pages/metrics/components/Controls/Controls.d.ts
@@ -8,7 +8,7 @@ import { IAxesScaleState } from 'types/components/AxesScalePopover/AxesScalePopo
 import {
   IAggregationConfig,
   IAlignmentConfig,
-  IChartTooltip,
+  IPanelTooltip,
   IChartZoom,
   IGroupingSelectOption,
 } from 'types/services/models/metrics/metricsAppModel';
@@ -20,7 +20,7 @@ import { CurveEnum } from 'utils/d3';
 
 export interface IControlProps {
   selectOptions: IGroupingSelectOption[];
-  tooltip: IChartTooltip;
+  tooltip: IPanelTooltip;
   ignoreOutliers: boolean;
   zoom?: IChartZoom;
   highlightMode: HighlightEnum;
@@ -32,7 +32,7 @@ export interface IControlProps {
   alignmentConfig: IAlignmentConfig;
   densityType: DensityOptions;
   projectsDataMetrics: IProjectParamsMetrics['metric'];
-  onChangeTooltip: (tooltip: Partial<IChartTooltip>) => void;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
   onIgnoreOutliersChange: () => void;
   onHighlightModeChange: (mode: number) => void;
   onDensityTypeChange: (type: DensityOptions) => void;

--- a/aim/web/ui/src/types/pages/metrics/components/GroupingItem/GroupingItem.d.ts
+++ b/aim/web/ui/src/types/pages/metrics/components/GroupingItem/GroupingItem.d.ts
@@ -12,7 +12,7 @@ export interface IGroupingItemProps extends IGroupingPopoverProps {
   advancedTitle?: string;
   groupName: GroupNameType;
   groupDisplayName: string;
-  groupingData: IMetricAppConfig['grouping'];
+  groupingData: any;
   advancedComponent: React.FunctionComponentElement<React.ReactNode> | null;
   groupingSelectOptions: IGroupingSelectOption[];
   onReset: () => void;

--- a/aim/web/ui/src/types/pages/params/Params.d.ts
+++ b/aim/web/ui/src/types/pages/params/Params.d.ts
@@ -8,7 +8,7 @@ import { ResizeModeEnum } from 'config/enums/tableEnums';
 import {
   GroupNameType,
   IChartTitleData,
-  IChartTooltip,
+  IPanelTooltip,
   IFocusedState,
   IGroupingSelectOption,
   IMetricAppConfig,
@@ -40,7 +40,7 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   sortFields: [string, 'asc' | 'desc' | boolean][];
   focusedState: IFocusedState;
   isVisibleColorIndicator: boolean;
-  tooltip: IChartTooltip;
+  tooltip: IPanelTooltip;
   chartTitleData: IChartTitleData;
   selectedParamsData: IParamsAppConfig['select'];
   onRowHeightChange: any;
@@ -74,7 +74,7 @@ export interface IParamsProps extends Partial<RouteChildrenProps> {
   onBookmarkUpdate: (id: string) => void;
   onNotificationAdd: (notification: INotification) => void;
   onResetConfigData: () => void;
-  onChangeTooltip: (tooltip: Partial<IChartTooltip>) => void;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
   onExportTableData: (e: React.ChangeEvent<any>) => void;
   onColumnsVisibilityChange: (order: any) => void;
   onTableDiffShow: () => void;

--- a/aim/web/ui/src/types/pages/params/components/Controls/Controls.d.ts
+++ b/aim/web/ui/src/types/pages/params/components/Controls/Controls.d.ts
@@ -1,7 +1,7 @@
 import { CurveEnum } from 'utils/d3';
 
 import {
-  IChartTooltip,
+  IPanelTooltip,
   IGroupingSelectOption,
 } from '/types/services/models/metrics/metricsAppModel';
 
@@ -9,8 +9,8 @@ export interface IControlProps {
   curveInterpolation: CurveEnum;
   isVisibleColorIndicator: boolean;
   selectOptions: IGroupingSelectOption[];
-  tooltip: IChartTooltip;
+  tooltip: IPanelTooltip;
   onColorIndicatorChange: () => void;
   onCurveInterpolationChange: () => void;
-  onChangeTooltip: (tooltip: Partial<IChartTooltip>) => void;
+  onChangeTooltip: (tooltip: Partial<IPanelTooltip>) => void;
 }

--- a/aim/web/ui/src/types/services/models/imagesExplore/imagesExploreAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/imagesExplore/imagesExploreAppModel.d.ts
@@ -1,13 +1,16 @@
 import { ITableRef } from 'types/components/Table/Table';
 import { INotification } from 'types/components/NotificationContainer/NotificationContainer';
+
+import { IPanelTooltip } from '../metrics/metricsAppModel';
+
 export interface IImagesExploreAppConfig {
   grouping: {
-    groupBy: [];
+    group: [];
     reverseMode: {
-      groupBy: boolean;
+      group: boolean;
     };
     isApplied: {
-      groupBy: boolean;
+      group: boolean;
     };
   };
   images: {
@@ -18,6 +21,11 @@ export interface IImagesExploreAppConfig {
     recordDensity?: string;
     indexDensity?: string;
     calcRanges: boolean;
+    tooltip: IPanelTooltip;
+    focusedState: {
+      key: string | null;
+      active: boolean;
+    };
   };
   select: {
     images: ISelectMetricsOption[];

--- a/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
@@ -144,7 +144,7 @@ export interface IMetricAppConfig {
     aggregationConfig: IAggregationConfig;
     densityType: DensityOptions;
     alignmentConfig: IAlignmentConfig;
-    tooltip: IChartTooltip;
+    tooltip: IPanelTooltip;
   };
   select?: {
     metrics: ISelectMetricsOption[];
@@ -182,7 +182,7 @@ export interface IChartZoom {
   }[];
 }
 
-export interface IChartTooltip {
+export interface IPanelTooltip {
   content: ITooltipContent;
   display: boolean;
   selectedParams: string[];
@@ -248,7 +248,7 @@ export interface IGetGroupingPersistIndex {
   groupName: 'color' | 'stroke';
 }
 
-export type GroupNameType = 'color' | 'stroke' | 'chart';
+export type GroupNameType = 'color' | 'stroke' | 'chart' | 'group';
 export interface IGroupingSelectOption {
   label: string;
   group: string;

--- a/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
@@ -205,9 +205,9 @@ export interface IAggregationConfig {
 export interface IFocusedState {
   active: boolean;
   key: string | null;
-  xValue: number | string | null;
-  yValue: number | null;
-  chartIndex: number | null;
+  xValue?: number | string | null;
+  yValue?: number | null;
+  chartIndex?: number | null;
 }
 
 export interface IMetricTableRowData {

--- a/aim/web/ui/src/types/services/models/params/paramsAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/params/paramsAppModel.d.ts
@@ -1,6 +1,6 @@
 import {
   IGroupingSelectOption,
-  IChartTooltip,
+  IPanelTooltip,
   IFocusedState,
 } from 'metrics/metricsAppModel';
 
@@ -83,7 +83,7 @@ export interface IParamsAppConfig {
     curveInterpolation: CurveEnum;
     isVisibleColorIndicator: boolean;
     focusedState: IFocusedState;
-    tooltip: IChartTooltip;
+    tooltip: IPanelTooltip;
   };
   select?: {
     params: any; // ISelectMetricsOption[];

--- a/aim/web/ui/src/utils/app/getGroupConfig.ts
+++ b/aim/web/ui/src/utils/app/getGroupConfig.ts
@@ -10,16 +10,20 @@ import { IModel, State } from 'types/services/models/model';
 import getValueByField from '../getValueByField';
 
 export default function getGroupConfig<D, M extends State>({
-  metricsCollection,
+  collection,
   groupingSelectOptions,
+  groupingItems = [],
   model,
 }: {
-  metricsCollection: IMetricsCollection<D>;
+  collection: IMetricsCollection<D>;
   groupingSelectOptions: IGroupingSelectOption[];
+  groupingItems: GroupNameType[];
   model: IModel<M>;
 }) {
-  const groupingItems: GroupNameType[] = ['color', 'stroke', 'chart'];
+  console.log('groupingSelectOptions', groupingSelectOptions);
   const configData = model.getState()?.config;
+  debugger;
+  console.log('configData', configData);
   let groupConfig: { [key: string]: {} } = {};
 
   for (let groupItemKey of groupingItems) {
@@ -28,7 +32,7 @@ export default function getGroupConfig<D, M extends State>({
       groupConfig[groupItemKey] = groupItem.reduce((acc, paramKey) => {
         Object.assign(acc, {
           [getValueByField(groupingSelectOptions || [], paramKey)]: _.get(
-            metricsCollection.config,
+            collection.config,
             paramKey,
           ),
         });

--- a/aim/web/ui/src/utils/app/getGroupConfig.ts
+++ b/aim/web/ui/src/utils/app/getGroupConfig.ts
@@ -20,10 +20,7 @@ export default function getGroupConfig<D, M extends State>({
   groupingItems: GroupNameType[];
   model: IModel<M>;
 }) {
-  console.log('groupingSelectOptions', groupingSelectOptions);
   const configData = model.getState()?.config;
-  debugger;
-  console.log('configData', configData);
   let groupConfig: { [key: string]: {} } = {};
 
   for (let groupItemKey of groupingItems) {

--- a/aim/web/ui/src/utils/app/getTooltipData.ts
+++ b/aim/web/ui/src/utils/app/getTooltipData.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash-es';
 
 import {
+  GroupNameType,
   IGroupingSelectOption,
   IMetricsCollection,
   ITooltipData,
@@ -13,31 +14,34 @@ export default function getTooltipData<D, M extends State>({
   processedData,
   paramKeys,
   groupingSelectOptions,
+  groupingItems = [],
   model,
 }: {
   processedData: IMetricsCollection<D>[];
   paramKeys: string[];
   groupingSelectOptions: IGroupingSelectOption[];
+  groupingItems: GroupNameType[];
   model: IModel<M>;
 }): ITooltipData {
   const data: ITooltipData = {};
 
-  for (let metricsCollection of processedData) {
+  for (let collection of processedData) {
     const groupConfig = getGroupConfig({
-      metricsCollection,
+      collection,
       groupingSelectOptions,
+      groupingItems,
       model,
     });
 
-    for (let metric of metricsCollection.data as any) {
-      data[metric.key] = {
-        runHash: metric.run.hash,
-        metricName: metric.name,
-        metricContext: metric.context,
+    console.log('----', groupConfig, paramKeys);
+    for (let itemData of collection.data as any) {
+      console.log(itemData);
+      data[itemData.key] = {
+        ...itemData,
         groupConfig,
         params: paramKeys.reduce((acc, paramKey) => {
           Object.assign(acc, {
-            [paramKey]: _.get(metric, `run.params.${paramKey}`),
+            [paramKey]: _.get(itemData, `run.params.${paramKey}`),
           });
           return acc;
         }, {}),

--- a/aim/web/ui/src/utils/app/getTooltipData.ts
+++ b/aim/web/ui/src/utils/app/getTooltipData.ts
@@ -33,9 +33,7 @@ export default function getTooltipData<D, M extends State>({
       model,
     });
 
-    console.log('----', groupConfig, paramKeys);
     for (let itemData of collection.data as any) {
-      console.log(itemData);
       data[itemData.key] = {
         ...itemData,
         groupConfig,

--- a/aim/web/ui/src/utils/app/onChangeTooltip.ts
+++ b/aim/web/ui/src/utils/app/onChangeTooltip.ts
@@ -1,7 +1,7 @@
 import * as analytics from 'services/analytics';
 
 import {
-  IChartTooltip,
+  IPanelTooltip,
   ITooltipData,
 } from 'types/services/models/metrics/metricsAppModel';
 import { IModel, State } from 'types/services/models/model';
@@ -16,7 +16,7 @@ export default function onChangeTooltip<M extends State>({
   model,
   appName,
 }: {
-  tooltip: Partial<IChartTooltip>;
+  tooltip: Partial<IPanelTooltip>;
   tooltipData: ITooltipData;
   model: IModel<M>;
   appName: string;

--- a/aim/web/ui/src/utils/d3/drawArea.ts
+++ b/aim/web/ui/src/utils/d3/drawArea.ts
@@ -113,14 +113,14 @@ function drawArea(props: IDrawAreaProps): void {
   const keys = Object.keys(chartTitle);
   const titleText = keys
     ? `${keys
-        .map((key) => {
-          let splitValue = chartTitle[key].split('"')[1];
-          return `${key}=${
-            isSystemMetric(splitValue)
-              ? formatSystemMetricName(splitValue)
-              : chartTitle[key]
-          }`;
-        })
+        .map(
+          (key) =>
+            `${key}=${
+              isSystemMetric(chartTitle[key])
+                ? formatSystemMetricName(chartTitle[key])
+                : chartTitle[key]
+            }`,
+        )
         .join(', ')}`
     : '';
 


### PR DESCRIPTION
- Add tooltip to image explore.
- Open tooltip with image data inside on hovering on the image and close it on mouse leave.
- Add tooltip data controller in the controls section for tooltip content changing.
- Add hide/show switcher in tooltip control popover.