### PR TITLE
Added focused/hovered states style of search-inputs

### DIFF
--- a/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPopover/ChartPopover.tsx
@@ -60,7 +60,9 @@ function ChartPopover(props: IChartPopover): JSX.Element | null {
       key={`popover-${props.reCreatePopover}`}
       id={id}
       open={!!props.activePointRect && open}
-      disableEnforceFocus={true}
+      disableEnforceFocus={true} // the trap focus will not prevent focus from leaving the trap focus while open
+      disableAutoFocus={true} // the trap focus will not automatically shift focus to itself when it opens
+      disableRestoreFocus={true} // the trap focus will not restore focus to previously focused element once trap focus is hidden
       anchorReference='anchorPosition'
       anchorPosition={popoverPos || props.activePointRect || undefined}
       className={`ChartPopover ${className}`}

--- a/aim/web/ui/src/components/kit/Dropdown/Dropdown.scss
+++ b/aim/web/ui/src/components/kit/Dropdown/Dropdown.scss
@@ -42,4 +42,9 @@
   &:hover {
     background: #f2f5fa;
   }
+  & > span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/aim/web/ui/src/components/kit/Dropdown/DropdownCustomOption.tsx
+++ b/aim/web/ui/src/components/kit/Dropdown/DropdownCustomOption.tsx
@@ -18,6 +18,7 @@ function DropdownCustomOption(
       {...innerProps}
     >
       <Text
+        title={data.label}
         component='span'
         size={14}
         weight={400}

--- a/aim/web/ui/src/components/kit/ExpressionAutoComplete/ExpressionAutoComplete.scss
+++ b/aim/web/ui/src/components/kit/ExpressionAutoComplete/ExpressionAutoComplete.scss
@@ -70,6 +70,9 @@
     &::placeholder {
       color: $text-color-50;
     }
+    &:focus, &:hover {
+      border-color: $cuddle-110;
+    }
   }
 
   &__textarea {

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -4024,8 +4024,8 @@ function createAppModel(appConfig: IAppInitialConfig) {
           displayName: string;
           dimensionType: string;
         }[][] = [];
-        const chartData: IPoint[] = [];
-        processedData.forEach(
+
+        const chartData = processedData.map(
           ({ chartIndex, color, data }: IMetricsCollection<IParam>) => {
             if (!dimensionsByChartIndex[chartIndex]) {
               dimensionsByChartIndex[chartIndex] = [];
@@ -4083,7 +4083,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
                   },
                 );
 
-                chartData.push({
+                return {
                   chartIndex,
                   key: run.key,
                   groupKey: run.key,
@@ -4092,7 +4092,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
                     yValues: [values[0] ?? '-'],
                     xValues: [values[1] ?? '-'],
                   },
-                });
+                };
               });
           },
         );
@@ -4102,6 +4102,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
         );
 
         return dimensionsByChartIndex
+          .filter((dimension) => !_.isEmpty(dimension))
           .map((chartDimensions, i: number) => {
             const dimensions: IDimensionType[] = [];
             chartDimensions.forEach((dimension) => {
@@ -4130,10 +4131,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
               dimensions,
               data: groupedByChartIndex[i],
             };
-          })
-          .filter(
-            (data) => !_.isEmpty(data.data) && !_.isEmpty(data.dimensions),
-          );
+          });
       }
 
       function getDataAsTableRows(


### PR DESCRIPTION
When hovering over on table rows or chart, chart tooltip opens and Material UI Popover component changes focus on tooltip

Fix: 
- disable auto-focus on chart tooltip
- tuned Dropdown Component options style

Tested on browsers:  Chrome, Safari , Firefox