### PR TITLE
Add analytics to Run detail's tabs

### DIFF
--- a/aim/web/ui/src/components/ProjectWrapper/ProjectWrapper.tsx
+++ b/aim/web/ui/src/components/ProjectWrapper/ProjectWrapper.tsx
@@ -13,10 +13,6 @@ function ProjectWrapper() {
   const projectsData = useModel<IProjectsModelState>(projectsModel);
 
   React.useEffect(() => {
-    if (projectsData?.project?.path) {
-      document.title = `Aim: ${projectsData.project.path}`;
-    }
-
     return () => {
       projectDataRequestRef.abort();
     };

--- a/aim/web/ui/src/pages/RunDetail/TraceVisualizationContainer/TraceVisualizationContainer.tsx
+++ b/aim/web/ui/src/pages/RunDetail/TraceVisualizationContainer/TraceVisualizationContainer.tsx
@@ -6,6 +6,8 @@ import BusyLoaderWrapper from 'components/BusyLoaderWrapper/BusyLoaderWrapper';
 import useModel from 'hooks/model/useModel';
 
 import runTracesModel from 'services/models/runs/runTracesModel';
+import * as analytics from 'services/analytics';
+import { VisualizationMenuTitles } from 'services/models/runs/util';
 
 import DistributionsVisualizer from '../DistributionsVisualizer';
 import TextsVisualizer from '../TextsVisualizer';
@@ -48,6 +50,10 @@ function TraceVisualizationContainer({
   }, [runHash, traceInfo, traceType]);
 
   const Visualizer = traceTypeVisualization[traceType];
+
+  React.useEffect(() => {
+    analytics.pageView(`[RunDetail] [${VisualizationMenuTitles[traceType]}]`);
+  }, [traceType]);
 
   return (
     <div className='TraceVisualizationWrapper'>

--- a/aim/web/ui/src/services/models/runs/util.ts
+++ b/aim/web/ui/src/services/models/runs/util.ts
@@ -180,15 +180,6 @@ export function getContextObjFromMenuActiveKey(
 }
 
 export function getMenuData(traceType: TraceType, traces: TraceRawDataItem[]) {
-  const VisualizationMenuTitles = {
-    images: 'Images',
-    distributions: 'Distributions',
-    audios: 'Audios',
-    videos: 'Videos',
-    texts: 'Texts',
-    figures: 'Plotlies',
-  };
-
   let title = VisualizationMenuTitles[traceType];
 
   let defaultActiveKey = '';
@@ -381,3 +372,12 @@ export function processPlotlyData(data: Partial<IPlotlyData>) {
     originalValues,
   };
 }
+
+export const VisualizationMenuTitles = {
+  images: 'Images',
+  distributions: 'Distributions',
+  audios: 'Audios',
+  videos: 'Videos',
+  texts: 'Texts',
+  figures: 'Figures',
+};


### PR DESCRIPTION
- Add analytics tracking for newly added tabs on Run Detail page (Images, Distributions, Figures, Texts, Audio)