### PR TITLE
[fix] Use specific version of node during packaging.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Use node v16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
       - name: Build UI
         working-directory: ./aim/web/ui
         run: |
@@ -57,6 +62,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      - name: Use node v16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Build UI
         working-directory: ./aim/web/ui


### PR DESCRIPTION
Node versions < v16 do not support certain features required for UI build.