### PR TITLE
[fix] Run on-the-fly WAL flushes and other optimizations for union DB.

### DIFF
--- a/aim/cli/reindex/utils.py
+++ b/aim/cli/reindex/utils.py
@@ -42,7 +42,7 @@ def run_flushes_and_compactions(repo: 'Repo', runs_to_skip: set):
 
     def optimize_container(path, extra_options):
         rc = RocksContainer(path, read_only=True, **extra_options)
-        rc.optimize_db_for_read()
+        rc.optimize_for_read()
 
     meta_containers = [os.path.join(meta_dbs_path, db) for db in meta_dbs_names]
     for _ in tqdm.tqdm(

--- a/aim/storage/union.py
+++ b/aim/storage/union.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from aim.storage.encoding import encode_path
 from aim.storage.container import Container
 from aim.storage.prefixview import PrefixView
-from aim.storage.rockscontainer import RocksContainer
+from aim.storage.rockscontainer import RocksContainer, optimize_db_for_read
 
 from typing import Dict, List, NamedTuple, Tuple
 
@@ -158,6 +158,7 @@ class DB(object):
     ):
         db = cache.get(prefix)
         if db is None:
+            optimize_db_for_read(Path(path), self.opts)
             db = aimrocks.DB(path, opts=aimrocks.Options(**self.opts), read_only=True)
         if store is not None:
             store[prefix] = db


### PR DESCRIPTION
While the `RocksContainer` should run above-mentioned optimizations when db is accessed, this was not the case due to inheritance. This fix makes sure that WAL flush is run regardless how the `RocksContainer` is used; as a separate object or a part of union DB.