### PR TITLE
[fix] Track converted value type instead of the input value type.

### DIFF
--- a/aim/sdk/num_utils.py
+++ b/aim/sdk/num_utils.py
@@ -89,6 +89,9 @@ def is_number(value):
     if is_py_number(value):
         return True
 
+    if is_numpy_array(value):
+        return True
+
     if is_numpy_number(value):
         return True
 

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -424,9 +424,9 @@ class Run(StructuredRunMixin):
         elif isinstance(value, (CustomObject, list, tuple)):
             val = value
         else:
-            raise ValueError(f"Input metric of type {type(value)} is neither python number nor AimObject")
+            raise ValueError(f'Input metric of type {type(value)} is neither python number nor AimObject')
 
-        dtype = get_object_typename(value)
+        dtype = get_object_typename(val)
 
         ctx = Context(context)
         sequence = SequenceDescriptor(name, ctx)

--- a/tests/sdk/test_run_metric_types.py
+++ b/tests/sdk/test_run_metric_types.py
@@ -1,0 +1,28 @@
+import pytest
+import numpy as np
+
+from tests.base import TestBase
+
+from aim.sdk import Repo, Run
+
+
+class TestRunMetricNumpyTypes(TestBase):
+    @pytest.mark.gh_1206
+    def test_numpy_scalar_types_track(self):
+        """covers https://github.com/aimhubio/aim/issues/1206"""
+
+        run = Run(system_tracking_interval=None)
+        run.track(np.array([1.0]), name='single_item_array')
+        run.track(np.array([[[1.0]]]), name='single_item_3d_array')
+        run.track(np.float64(1.0), name='numpy_float64')
+        run.track(np.float32(1.0), name='numpy_float32')
+
+        repo = Repo.default_repo()
+        metric_names = {metric.name for metric in repo.query_metrics()}
+        expected_metric_names = {'single_item_array', 'single_item_3d_array', 'numpy_float64', 'numpy_float32'}
+        self.assertSetEqual(expected_metric_names, metric_names)
+
+    def test_reject_non_scalar_arrays_track(self):
+        run = Run(system_tracking_interval=None)
+        with self.assertRaises(ValueError):
+            run.track(np.array([1.0, 2.0]), name='fail')


### PR DESCRIPTION
When saving tracked value type in run metadata, use the already
converted value instead of the original input value.
Added covering unit-test.