### PR TITLE
Fix stalled runs deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add handler for matplotlib figures in Image and Figure custom objects (devfox-se)
 - Improve highlighting of table focused/hovered/selected row (VkoHov)
 - Fix background transparency in colab when using dark mode of system (rubenaprikyan)
+- Fix stalled runs deletion (mihran113)
 
 ## 3.4.1 Jan 23 2022
 

--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -427,7 +427,7 @@ class Repo:
                 logger.warning(f'Error while trying to delete run \'{run_hash}\'. {str(e)}.')
                 remaining_runs.append(run_hash)
 
-        if len(remaining_runs):
+        if remaining_runs:
             return False, remaining_runs
         else:
             return True, []
@@ -451,7 +451,7 @@ class Repo:
                 logger.warning(f'Error while trying to copy run \'{run_hash}\'. {str(e)}.')
                 remaining_runs.append(run_hash)
 
-        if len(remaining_runs):
+        if remaining_runs:
             return False, remaining_runs
         else:
             return True, []
@@ -476,7 +476,7 @@ class Repo:
                 logger.warning(f'Error while trying to move run \'{run_hash}\'. {str(e)}.')
                 remaining_runs.append(run_hash)
 
-        if len(remaining_runs):
+        if remaining_runs:
             return False, remaining_runs
         else:
             return True, []


### PR DESCRIPTION
Also added check to identify if run is still in progress and changed `repo` methods(delete, copy, move) to not stop execution in case of failure and try to handle remaining runs as well.