### PR TITLE
Fix of Run class creates weird folder issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.1
+
+- Fix folder creation when tracking with remote tracker (aramaim)
+
 ## 3.5.0 Feb 3 2022
 
 ### Enhancements:


### PR DESCRIPTION
Avoid .aim folder creation for remote tracker when Repo object is created implicitly