### PR TITLE
Allowing more system metrics, potentially GPU stats

### DIFF
--- a/aim/ext/resource/tracker.py
+++ b/aim/ext/resource/tracker.py
@@ -2,15 +2,16 @@ from psutil import Process, cpu_percent
 from threading import Thread
 import time
 import weakref
+from typing import Union
 
 from aim.ext.resource.stat import Stat
 from aim.ext.resource.configs import AIM_RESOURCE_METRIC_PREFIX
 
 
 class ResourceTracker(object):
-    STAT_INTERVAL_MIN = 1
-    STAT_INTERVAL_MAX = 3600 * 24
-    STAT_INTERVAL_DEFAULT = 60
+    STAT_INTERVAL_MIN = 1.0
+    STAT_INTERVAL_MAX = 24 * 60 * 60.0
+    STAT_INTERVAL_DEFAULT = 60.0
 
     reset_cpu_cycle = False
 
@@ -22,7 +23,7 @@ class ResourceTracker(object):
         """
         cpu_percent(0.0)
 
-    def __init__(self, track, interval: int = STAT_INTERVAL_DEFAULT):
+    def __init__(self, track, interval: Union[int, float] = STAT_INTERVAL_DEFAULT):
         self._track_func = weakref.WeakMethod(track)
         self.interval = interval
 

--- a/aim/ext/resource/tracker.py
+++ b/aim/ext/resource/tracker.py
@@ -9,7 +9,7 @@ from aim.ext.resource.configs import AIM_RESOURCE_METRIC_PREFIX
 
 
 class ResourceTracker(object):
-    STAT_INTERVAL_MIN = 1.0
+    STAT_INTERVAL_MIN = 0.1
     STAT_INTERVAL_MAX = 24 * 60 * 60.0
     STAT_INTERVAL_DEFAULT = 60.0
 

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -337,8 +337,8 @@ class Run(StructuredRunMixin):
     def _collect(self, key, strict: bool = True):
         return self.meta_run_attrs_tree.collect(key, strict=strict)
 
-    def _prepare_resource_tracker(self, tracking_interval: int):
-        if not self.read_only and tracking_interval and isinstance(tracking_interval, int) and tracking_interval > 0:
+    def _prepare_resource_tracker(self, tracking_interval: Union[int, float] = None):
+        if not self.read_only and tracking_interval and isinstance(tracking_interval, (int, float)) and tracking_interval > 0:
             try:
                 self._system_resource_tracker = ResourceTracker(self.track, tracking_interval)
             except ValueError:

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -338,7 +338,7 @@ class Run(StructuredRunMixin):
         return self.meta_run_attrs_tree.collect(key, strict=strict)
 
     def _prepare_resource_tracker(self, tracking_interval: Union[int, float] = None):
-        if not self.read_only and tracking_interval and isinstance(tracking_interval, (int, float)) and tracking_interval > 0:
+        if not self.read_only and isinstance(tracking_interval, (int, float)) and tracking_interval > 0:
             try:
                 self._system_resource_tracker = ResourceTracker(self.track, tracking_interval)
             except ValueError:

--- a/tests/sdk/test_resource_tracker.py
+++ b/tests/sdk/test_resource_tracker.py
@@ -18,10 +18,11 @@ class TestRunResourceTracker(TestBase):
         del run
 
         metrics = list(self.repo.query_metrics(f'run.hash == "{run_hash}" and metric.name.startswith("__")'))
-        self.assertEqual(4, len(metrics))
         expected_metrics = {'__system__cpu', '__system__disk_percent',
                             '__system__memory_percent', '__system__p_memory_percent'}
-        self.assertSetEqual(expected_metrics, set(m.name for m in metrics))
+        metric_names = set(m.name for m in metrics)
+        for name in expected_metrics:
+            self.assertIn(name, metric_names)
 
     def test_custom_tracking_interval(self):
         run = Run(system_tracking_interval=1)
@@ -31,10 +32,11 @@ class TestRunResourceTracker(TestBase):
         del run
 
         metrics = list(self.repo.query_metrics(f'run.hash == "{run_hash}" and metric.name.startswith("__")'))
-        self.assertEqual(4, len(metrics))
         expected_metrics = {'__system__cpu', '__system__disk_percent',
                             '__system__memory_percent', '__system__p_memory_percent'}
-        self.assertSetEqual(expected_metrics, set(m.name for m in metrics))
+        metric_names = set(m.name for m in metrics)
+        for name in expected_metrics:
+            self.assertIn(name, metric_names)
         for metric in metrics:
             # 3 sec. runtime, 1 sec. interval
             self.assertGreaterEqual(len(metric.values), 3)


### PR DESCRIPTION
Previously we've had system tracker tests requiring strictly
```{'__system__cpu', '__system__disk_percent', '__system__memory_percent', '__system__p_memory_percent'}```
while working on machine with GPUs, `aim` will automatically track GPU stats as well, resulting in extra metrics.

This PR checks whether the resulting metrics is superset of expected metrics instead of checking equality.