### PR TITLE
Cython Bindings / Utils

### DIFF
--- a/aim/sdk/objects/image.py
+++ b/aim/sdk/objects/image.py
@@ -245,7 +245,7 @@ class Image(CustomObject):
             if self.storage[p] != other.storage[p]:
                 return False
 
-        return (self.storage['data'].data == other.storage['data'].data)
+        return (self.storage['data'].load() == other.storage['data'].load())
 
 
 def convert_to_aim_image_list(images, labels=None) -> List[Image]:

--- a/aim/storage/rockscontainer.pyx
+++ b/aim/storage/rockscontainer.pyx
@@ -9,7 +9,7 @@ from typing import Iterator, Optional, Tuple
 
 from aim.ext.cleanup import AutoClean
 from aim.ext.exception_resistant import exception_resistant
-from aim.storage.types import BLOB, BLOBLoader
+from aim.storage.types import BLOB
 from aim.storage.container import Container, ContainerKey, ContainerValue
 from aim.storage.prefixview import PrefixView
 from aim.storage.containertreeview import ContainerTreeView
@@ -231,7 +231,7 @@ class RocksContainer(Container):
     def _get_blob_loader(
         self,
         key: ContainerKey
-    ) -> BLOBLoader:
+    ):
         def loader() -> bytes:
             data = self[BLOB_DOMAIN + key]
             assert isinstance(data, bytes)
@@ -241,8 +241,8 @@ class RocksContainer(Container):
     def _get_blob(
         self,
         key: ContainerKey
-    ) -> BLOB[bytes]:
-        return BLOB[bytes](loader_fn=self._get_blob_loader(key))
+    ) -> BLOB:
+        return BLOB(loader_fn=self._get_blob_loader(key))
 
     def _put(
         self,

--- a/aim/storage/types.py
+++ b/aim/storage/types.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Tuple, Union
 
-from aim.storage.utils import BLOB
+from aim.storage.utils import BLOB  # noqa F401
 
 NoneType = type(None)
 

--- a/aim/storage/types.py
+++ b/aim/storage/types.py
@@ -1,6 +1,6 @@
-from typing import Callable, Dict, List, Tuple, Union, Generic, TypeVar
-from copy import deepcopy
+from typing import Dict, List, Tuple, Union
 
+from aim.storage.utils import BLOB
 
 NoneType = type(None)
 
@@ -65,60 +65,3 @@ class SafeNone(metaclass=Singleton):
 
 class CustomObjectBase:
     pass
-
-
-BLOBLoader = Callable[[], AimObjectPrimitive]
-T = TypeVar('T')
-
-
-class BLOB(Generic[T]):
-    def __init__(
-        self,
-        data: T = None,
-        loader_fn: 'BLOBLoader' = None
-    ):
-        self.data: T = data
-        self.loader_fn = loader_fn
-
-    def __bytes__(self):
-        return bytes(self.load())
-
-    def load(self) -> T:
-        if self.data is None:
-            assert self.loader_fn is not None
-            self.data = self.loader_fn()
-            self.loader_fn = None
-        return self.data
-
-    def __deepcopy__(self, memo):
-        data = self.load()
-        instance = self.__class__(data=deepcopy(data, memo=memo))
-        memo[id(self)] = instance
-        return instance
-
-    def transform(
-        self,
-        transform_fn: Callable[[AimObjectPrimitive], T]
-    ) -> 'BLOB':
-        if self.data is not None:
-            return self.__class__(transform_fn(self.data))
-
-        def loader():
-            return transform_fn(self.load())
-
-        return self.__class__(loader_fn=loader)
-
-
-__all__ = [
-    'NoneType',
-    'AimObjectKey',
-    'AimObjectPath',
-    'AimObjectPrimitive',
-    'AimObjectArray',
-    'AimObjectDict',
-    'AimObject',
-    'CustomObjectBase',
-    'SafeNone',
-    'BLOB',
-    'BLOBLoader',
-]

--- a/aim/storage/utils.pxd
+++ b/aim/storage/utils.pxd
@@ -1,0 +1,20 @@
+# distutils: language = c++
+# cython: language_level = 3
+
+cdef class ArrayFlagType:
+    pass
+
+cdef class ObjectFlagType:
+    pass
+
+cdef class CustomObjectFlagType:
+    cdef:
+        public str aim_name
+
+cdef class BLOB:
+    cdef:
+        object data
+        object loader_fn
+    cpdef bytes load(self)
+    # TODO closures inside cython functions are not supported yet
+    # cpdef object transform(self, object transform_fn)

--- a/aim/storage/utils.py
+++ b/aim/storage/utils.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 class ArrayFlagType:
     def __repr__(self):
         return "<ArrayFlag>"
@@ -34,8 +36,36 @@ class CustomObjectFlagType:
         return f"<CustomObjectFlag type={self.aim_name}>"
 
 
-__all__ = [
-    'ArrayFlag',
-    'ObjectFlag',
-    'CustomObjectFlagType',
-]
+class BLOB:
+    def __init__(
+        self,
+        data=None,
+        loader_fn=None
+    ):
+        self.data = data
+        self.loader_fn = loader_fn
+
+    def __bytes__(self):
+        return bytes(self.load())
+
+    def load(self):
+        if self.data is None:
+            assert self.loader_fn is not None
+            self.data = self.loader_fn()
+            self.loader_fn = None
+        return self.data
+
+    def __deepcopy__(self, memo):
+        data = self.load()
+        instance = self.__class__(data=deepcopy(data, memo=memo))
+        memo[id(self)] = instance
+        return instance
+
+    def transform(self, transform_fn):
+        if self.data is not None:
+            return self.__class__(transform_fn(self.data))
+
+        def loader():
+            return transform_fn(self.load())
+
+        return self.__class__(loader_fn=loader)

--- a/aim/storage/utils.py
+++ b/aim/storage/utils.py
@@ -1,5 +1,30 @@
 from copy import deepcopy
 
+
+class KeysIterator:
+    def __init__(self, items_iterator):
+        self.it = items_iterator
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        key, _ = next(self.it)
+        return key
+
+
+class ValuesIterator:
+    def __init__(self, items_iterator):
+        self.it = items_iterator
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        _, value = next(self.it)
+        return value
+
+
 class ArrayFlagType:
     def __repr__(self):
         return "<ArrayFlag>"

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,11 @@ setup(
             'aim.storage.union',
             ['aim/storage/union.pyx'],
             language='c++'
+        ),
+        Extension(
+            'aim.storage.utils',
+            ['aim/storage/utils.py'],
+            language='c++'
         )
     ]),
     entry_points={


### PR DESCRIPTION
* Moving everything else other than type annotations from `types.py` to `utils.pyx`,
* Removing some (generic) type annotations to make it easier to optimize with Cython,
* Wrapper classes for `KeysIterator` and `ValuesIterator`.