### PR TITLE
Cython Bindings / Print Performance Baselines

### DIFF
--- a/performance_tests/conftest.py
+++ b/performance_tests/conftest.py
@@ -47,6 +47,14 @@ def pytest_sessionstart(session):
         os.chdir('/home/ubuntu/performance_logs/')
     time.sleep(10)
 
+def print_current_baseline():
+    print('==== CURRENT BASELINE ====')
+    with open(get_baseline_filename(), 'r') as f:
+        print(f.read())
+    print('==========================')
+
+def pytest_unconfigure(config):
+    print_current_baseline()
 
 def pytest_sessionfinish(session, exitstatus):
     if os.environ.get('AIM_LOCAL_PERFORMANCE_TEST'):

--- a/performance_tests/conftest.py
+++ b/performance_tests/conftest.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 from aim.sdk.configs import AIM_REPO_NAME
+from performance_tests.utils import get_baseline_filename
 
 TEST_REPO_PATHS = {
     'real_life_repo': '.aim_performance_repo_1',


### PR DESCRIPTION
Print performance baselines right before exiting.
This is supposed to be temporary change but I think we'll end up with printing summarized table of rows per test, something like:
`actual_time_min    actual_time_median    actual_time_max    baseline_min    baseline_median    baseline_max`
to get more helpful insights from the performance tests.