### PR TITLE
Solve the issue when there is a proxy server  on front of the aim server

### DIFF
--- a/aim/web/api/__init__.py
+++ b/aim/web/api/__init__.py
@@ -50,9 +50,11 @@ def create_app():
     base_path = os.environ.get(AIM_UI_BASE_PATH, '')
 
     app.mount(f'{base_path}/api', api_app)
+    app.mount(f'/api', api_app)
     static_files_app = FastAPI()
 
     static_files_app.include_router(statics_router)
     app.mount(f'{base_path}/', static_files_app)
+    app.mount(f'/', static_files_app)
 
     return app


### PR DESCRIPTION
The main problem is when proxying on relative path i.e. `<instance>/proxy/8900/` the aim server couldn't recognize static files.
Aim UI setting its base_path as absolute path.
Step by step example
- aim up --base-path /proxy/43800

Proxying will go through `<instance>/proxy/43800`
Static files will try to get from `<instance>/proxy/43800` because UIs base path will be `--base-path`, but since the back-end starting from `<instance>/proxy/43800/` will need to call `<instance>/proxy/43800/proxy/43800/`, but the UIs base path known as `/proxy/43800` not `/proxy/43800/proxy/43800`