### PR TITLE
[fix] Remove example type substring from param name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.6.1
 
 - Fix PL.AimLogger save_dir AttributeError (GeeeekExplorer)
+- Remove example_type substring from param name (VkoHov)
 
 ## 3.6.0 Feb 22 2022
 

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -3253,7 +3253,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
           );
           paramPaths.forEach((paramPath, index) => {
             params.push({
-              label: paramPath,
+              label: paramPath.slice(0, paramPath.indexOf('.__example_type__')),
               group: 'Params',
               type: 'params',
               color: COLORS[0][index % COLORS[0].length],
@@ -5497,7 +5497,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
           );
           paramPaths.forEach((paramPath, index) => {
             data.push({
-              label: paramPath,
+              label: paramPath.slice(0, paramPath.indexOf('.__example_type__')),
               group: 'Params',
               type: 'params',
               color: COLORS[0][index % COLORS[0].length],


### PR DESCRIPTION
- Remove `__example_type__` substring from param names both in Params and Scatter explores