### PR TITLE
Cython Bindings / Slotify

### DIFF
--- a/aim/storage/context.py
+++ b/aim/storage/context.py
@@ -6,7 +6,7 @@ from aim.storage.types import AimObject, AimObjectKey
 
 
 class Context:
-    __slots__ = ['_context', '_hash']
+    __slots__ = ('_context', '_hash')
 
     def __init__(
         self,
@@ -53,7 +53,7 @@ class Context:
 class SequenceDescriptor:
     Selector = Tuple[int, str]
 
-    __slots__ = ['_name', '_context', '_hash', '_sequence_hash']
+    __slots__ = ('_name', '_context', '_hash', '_sequence_hash')
 
     def __init__(
         self,

--- a/aim/storage/proxy.py
+++ b/aim/storage/proxy.py
@@ -67,6 +67,9 @@ class _ObjectProxyMetaType(type):
 
 
 class Eager1:
+
+    __slots__ = ('name', 'wrapped')
+
     def __init__(self, wrapped, name):
         self.wrapped = lru_cache()(wrapped)
         self.name = name
@@ -88,6 +91,9 @@ class Eager1:
 
 
 class Eager2:
+
+    __slots__ = ('view', 'name')
+
     def __init__(self, view, name):
         self.view = view
         self.name = name
@@ -109,6 +115,9 @@ class Eager2:
 
 
 class Eager3:
+
+    __slots__ = ('wrapped', 'key')
+
     def __init__(self, wrapped, key):
         self.wrapped = lru_cache()(wrapped)
         self.key = key
@@ -126,6 +135,9 @@ class Eager3:
 
 
 class Eager4:
+
+    __slots__ = ('view', 'key')
+
     def __init__(self, view, key):
         self.view = view
         self.key = key
@@ -143,6 +155,8 @@ class Eager4:
 
 
 class AimObjectProxy(with_metaclass(_ObjectProxyMetaType)):
+
+    __slots__ = ('__wrapped__', '__view__')
 
     @property
     def __name__(self):

--- a/aim/storage/query.py
+++ b/aim/storage/query.py
@@ -70,6 +70,9 @@ logger = logging.getLogger(__name__)
 
 
 class Query:
+
+    __slots__ = ('__weakref__', 'expr')
+
     def __init__(
         self,
         expr: str
@@ -145,6 +148,9 @@ def query_add_default_expr(query: str) -> str:
 
 
 class RestrictedPythonQuery(Query):
+
+    __slots__ = ('_checker', 'run_metadata_cache')
+
     allowed_params = {'run', 'metric', 'images', 'audios', 'distributions', 'figures', 'texts'}
 
     def __init__(


### PR DESCRIPTION
Not so-much-cythonic thing, but I would like to use this opportunity to add `__slots__` to small classes.
This will reduce the memory footprint and improve performance a little bit.