### PR TITLE
Fix text explorer url update

### DIFF
--- a/aim/web/ui/src/services/models/textExplorer/textExplorerAppModel.ts
+++ b/aim/web/ui/src/services/models/textExplorer/textExplorerAppModel.ts
@@ -71,6 +71,7 @@ const model = createModel<Partial<ITextExplorerAppModelState>>({
     suggestions: [],
   },
   notifyData: [],
+  config: getConfig(),
 });
 
 function getConfig(): ITextExplorerAppConfig {


### PR DESCRIPTION
Text Explorer URL forward/backward doesn't work

- fix URL updating issue: missing config state from model initial state