### PR TITLE
[feat] Split code in the single run page

### DIFF
--- a/aim/web/ui/src/components/kit/Card/Card.scss
+++ b/aim/web/ui/src/components/kit/Card/Card.scss
@@ -3,7 +3,7 @@
 .Card {
   display: flex;
   flex-direction: column;
-  padding: toRem(16px) toRem(24px);
+  padding: $space-lg;
   border: $border-grey;
   border-radius: $border-radius-lg;
   background: $white;

--- a/aim/web/ui/src/components/kit/Spinner/Spinner.d.ts
+++ b/aim/web/ui/src/components/kit/Spinner/Spinner.d.ts
@@ -1,0 +1,6 @@
+import { CircularProgressProps } from '@material-ui/core';
+
+export interface ISpinnerProps extends CircularProgressProps {
+  className?: string;
+  style?: React.StyleHTMLAttributes;
+}

--- a/aim/web/ui/src/components/kit/Spinner/Spinner.scss
+++ b/aim/web/ui/src/components/kit/Spinner/Spinner.scss
@@ -1,0 +1,9 @@
+@use 'src/styles/abstracts' as *;
+
+.Spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+}

--- a/aim/web/ui/src/components/kit/Spinner/Spinner.tsx
+++ b/aim/web/ui/src/components/kit/Spinner/Spinner.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { CircularProgress } from '@material-ui/core';
+
+import { ISpinnerProps } from './Spinner.d';
+
+import './Spinner.scss';
+
+function Spinner({
+  style = {},
+  className = '',
+  ...rest
+}: ISpinnerProps): React.FunctionComponentElement<React.ReactNode> {
+  return (
+    <div style={style} className={`Spinner ${className}`}>
+      <CircularProgress {...rest} />
+    </div>
+  );
+}
+
+Spinner.displayName = 'Spinner';
+
+export default React.memo<ISpinnerProps>(Spinner);

--- a/aim/web/ui/src/components/kit/Spinner/index.tsx
+++ b/aim/web/ui/src/components/kit/Spinner/index.tsx
@@ -1,0 +1,5 @@
+import Spinner from './Spinner';
+
+export * from './Spinner.d';
+
+export default Spinner;

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -72,19 +72,22 @@
           font-weight: 500;
           text-transform: unset;
           min-height: 40px;
+          transition: all 0.18s ease-out;
+          &:hover {
+            color: $pico;
+            background-color: $cuddle-30;
+          }
           .MuiTab-wrapper {
             line-height: 1.05;
           }
           &.MuiTab-root {
-            padding: 11px 16px;
+            padding: 0.625rem $space-unit;
             min-width: auto !important;
             border-right: 1px solid transparent;
             text-transform: capitalize;
           }
           &.Mui-selected {
             color: $pico;
-            font-family: 'Inter', sans-serif;
-            font-weight: 600;
             position: relative;
             // border-right: none;
             &::before {

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -207,24 +207,20 @@
       }
     }
 
-    &__btn__archive,
-    &__btn__unarchive {
-      border-color: $pico-50;
-
-      &:hover {
-        border-color: $pico-50;
-      }
-    }
-
     &__btn__archive {
-      color: $pico-50;
+      color: $pico-80;
+      border-color: $pico-80;
+      &:hover {
+        border-color: $pico-80;
+      }
     }
 
     &__btn__unarchive {
       background-color: $pico-50;
+      border-color: $pico-50;
       color: $white;
-
       &:hover {
+        border-color: $pico-50;
         background-color: $pico-50;
       }
     }

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
@@ -54,7 +54,7 @@ function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
   const { pathname } = useLocation();
   const [activeTab, setActiveTab] = React.useState(pathname);
 
-  const tabs = [
+  const tabs: string[] = [
     'overview',
     'parameters',
     'metrics',

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useRef, useState } from 'react';
+import React from 'react';
 import {
   Link,
   Redirect,
@@ -19,6 +19,7 @@ import StatusLabel from 'components/StatusLabel';
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import BusyLoaderWrapper from 'components/BusyLoaderWrapper/BusyLoaderWrapper';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+import Spinner from 'components/kit/Spinner';
 
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
@@ -27,25 +28,31 @@ import useModel from 'hooks/model/useModel';
 import runDetailAppModel from 'services/models/runs/runDetailAppModel';
 import * as analytics from 'services/analytics';
 
-import RunDetailSettingsTab from './RunDetailSettingsTab';
-import RunDetailMetricsAndSystemTab from './RunDetailMetricsAndSystemTab';
-import RunDetailParamsTab from './RunDetailParamsTab';
 import RunSelectPopoverContent from './RunSelectPopoverContent';
-import TraceVisualizationContainer from './TraceVisualizationContainer';
-import RunOverviewTab from './RunOverviewTab';
 
 import './RunDetail.scss';
+
+const RunDetailParamsTab = React.lazy(() => import('./RunDetailParamsTab'));
+const RunDetailSettingsTab = React.lazy(() => import('./RunDetailSettingsTab'));
+const RunDetailMetricsAndSystemTab = React.lazy(
+  () => import('./RunDetailMetricsAndSystemTab'),
+);
+const TraceVisualizationContainer = React.lazy(
+  () => import('./TraceVisualizationContainer'),
+);
+const RunOverviewTab = React.lazy(() => import('./RunOverviewTab'));
 
 function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
   let runsOfExperimentRequestRef: any = null;
   const runData = useModel(runDetailAppModel);
-  const containerRef = useRef<HTMLDivElement | any>(null);
-  const [dateNow, setDateNow] = useState(Date.now());
-  const [isRunSelectDropdownOpen, setIsRunSelectDropdownOpen] = useState(false);
+  const containerRef = React.useRef<HTMLDivElement | any>(null);
+  const [dateNow, setDateNow] = React.useState(Date.now());
+  const [isRunSelectDropdownOpen, setIsRunSelectDropdownOpen] =
+    React.useState(false);
   const { runHash } = useParams<{ runHash: string }>();
   const { url } = useRouteMatch();
   const { pathname } = useLocation();
-  const [activeTab, setActiveTab] = useState(pathname);
+  const [activeTab, setActiveTab] = React.useState(pathname);
 
   const tabs = [
     'overview',
@@ -60,7 +67,6 @@ function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
     'settings',
   ];
 
-  // TODO: add code splitting(lazy loading)
   const tabContent: { [key: string]: JSX.Element } = {
     overview: <RunOverviewTab runHash={runHash} runData={runData} />,
     parameters: (
@@ -282,7 +288,9 @@ function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
                 <Route path={`${url}/${tab}`} key={tab}>
                   <ErrorBoundary>
                     <div className='RunDetail__runDetailContainer__tabPanel container'>
-                      {tabContent[tab]}
+                      <React.Suspense fallback={<Spinner />}>
+                        {tabContent[tab]}
+                      </React.Suspense>
                     </div>
                   </ErrorBoundary>
                 </Route>
@@ -302,4 +310,4 @@ function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
   );
 }
 
-export default memo(RunDetail);
+export default React.memo(RunDetail);

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.scss
@@ -2,9 +2,9 @@
 .RunOverviewTab {
   display: flex;
   height: 100%;
+  overflow-y: auto;
   &__content {
     flex: 1 100%;
-    overflow-y: auto;
   }
   &__cardBox {
     margin-bottom: $space-lg;

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.scss
@@ -11,6 +11,9 @@
     &:first-child {
       margin-top: $space-lg;
     }
+    &:last-child {
+      display: inline-block;
+    }
     &__tableTitleCount {
       margin-left: $space-xxxs;
     }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import _ from 'lodash-es';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+import IllustrationBlock from 'components/IllustrationBlock/IllustrationBlock';
 
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
 import * as analytics from 'services/analytics';
-
-import { getValue } from 'utils/helper';
 
 import useRunMetricsBatch from '../hooks/useRunMetricsBatch';
 
@@ -34,55 +34,85 @@ function RunOverviewTab({ runData, runHash }: IRunOverviewTabProps) {
     );
   }, []);
 
+  const cardsData: Record<any, any> = React.useMemo(() => {
+    const data: any = {};
+    const systemParams = runData.runParams.__system_params;
+    if (!_.isEmpty(runData?.runParams)) {
+      data.runParams = runData.runParams;
+    }
+    if (!_.isEmpty(runData?.runMetricsBatch)) {
+      data.runMetricsBatch = runData.runMetricsBatch;
+    }
+    if (!_.isEmpty(runData?.runSystemBatch)) {
+      data.runSystemBatch = runData.runSystemBatch;
+    }
+    if (!_.isEmpty(systemParams.arguments)) {
+      data.cliArguments = systemParams.arguments;
+    }
+    if (!_.isEmpty(systemParams.env_variables)) {
+      data.envVariables = systemParams.env_variables;
+    }
+    if (!_.isEmpty(systemParams.packages)) {
+      data.packages = systemParams.packages;
+    }
+    if (!_.isEmpty(systemParams.packages)) {
+      data.gitInfo = systemParams.git_info;
+    }
+    return data;
+  }, [runData]);
+
   return (
     <ErrorBoundary>
       <section className='RunOverviewTab'>
         <div className='RunOverviewTab__content'>
-          <RunOverviewTabMetricsCard
-            isLoading={runData?.isRunBatchLoading}
-            type='metric'
-            runBatch={runData?.runMetricsBatch}
-          />
-          <RunOverviewTabParamsCard
-            runParams={runData?.runParams}
-            isRunInfoLoading={runData?.isRunInfoLoading}
-          />
-          <RunOverviewTabMetricsCard
-            isLoading={runData?.isRunBatchLoading}
-            type='systemMetric'
-            runBatch={runData?.runSystemBatch}
-          />
-          <RunOverviewTabCLIArgumentsCard
-            cliArguments={getValue(runData, [
-              'runParams',
-              '__system_params',
-              'arguments',
-            ])}
-            isRunInfoLoading={runData?.isRunInfoLoading}
-          />
-          <RunOverviewTabEnvVariablesCard
-            envVariables={getValue(runData, [
-              'runParams',
-              '__system_params',
-              'env_variables',
-            ])}
-            isRunInfoLoading={runData?.isRunInfoLoading}
-          />
-          <RunOverviewTabPackagesCard
-            packages={getValue(runData, [
-              'runParams',
-              '__system_params',
-              'packages',
-            ])}
-            isRunInfoLoading={runData?.isRunInfoLoading}
-          />
-          <GitInfoCard
-            data={getValue(
-              runData,
-              ['runParams', '__system_params', 'git_info'],
-              null,
-            )}
-          />
+          {_.isEmpty(cardsData) ? (
+            <IllustrationBlock size='large' title='No Results' />
+          ) : (
+            <>
+              {_.isEmpty(cardsData?.runParams) ? null : (
+                <RunOverviewTabParamsCard
+                  runParams={cardsData?.runParams}
+                  isRunInfoLoading={runData?.isRunInfoLoading}
+                />
+              )}
+              {_.isEmpty(cardsData?.runMetricsBatch) ? null : (
+                <RunOverviewTabMetricsCard
+                  isLoading={runData?.isRunBatchLoading}
+                  type='metric'
+                  runBatch={cardsData?.runMetricsBatch}
+                />
+              )}
+
+              {_.isEmpty(cardsData?.runSystemBatch) ? null : (
+                <RunOverviewTabMetricsCard
+                  isLoading={runData?.isRunBatchLoading}
+                  type='systemMetric'
+                  runBatch={cardsData?.runSystemBatch}
+                />
+              )}
+              {_.isEmpty(cardsData.arguments) ? null : (
+                <RunOverviewTabCLIArgumentsCard
+                  cliArguments={cardsData.arguments}
+                  isRunInfoLoading={runData?.isRunInfoLoading}
+                />
+              )}
+              {_.isEmpty(cardsData.envVariables) ? null : (
+                <RunOverviewTabEnvVariablesCard
+                  envVariables={cardsData.envVariables}
+                  isRunInfoLoading={runData?.isRunInfoLoading}
+                />
+              )}
+              {_.isEmpty(cardsData.packages) ? null : (
+                <RunOverviewTabPackagesCard
+                  packages={cardsData.packages}
+                  isRunInfoLoading={runData?.isRunInfoLoading}
+                />
+              )}
+              {_.isEmpty(cardsData.gitInfo) ? null : (
+                <GitInfoCard data={cardsData.gitInfo} />
+              )}
+            </>
+          )}
         </div>
         <RunOverviewSidebar
           runHash={runHash}

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/RunOverviewTab.tsx
@@ -36,7 +36,7 @@ function RunOverviewTab({ runData, runHash }: IRunOverviewTabProps) {
 
   const cardsData: Record<any, any> = React.useMemo(() => {
     const data: any = {};
-    const systemParams = runData.runParams.__system_params;
+    const systemParams = runData?.runParams?.__system_params;
     if (!_.isEmpty(runData?.runParams)) {
       data.runParams = runData.runParams;
     }
@@ -46,17 +46,19 @@ function RunOverviewTab({ runData, runHash }: IRunOverviewTabProps) {
     if (!_.isEmpty(runData?.runSystemBatch)) {
       data.runSystemBatch = runData.runSystemBatch;
     }
-    if (!_.isEmpty(systemParams.arguments)) {
-      data.cliArguments = systemParams.arguments;
-    }
-    if (!_.isEmpty(systemParams.env_variables)) {
-      data.envVariables = systemParams.env_variables;
-    }
-    if (!_.isEmpty(systemParams.packages)) {
-      data.packages = systemParams.packages;
-    }
-    if (!_.isEmpty(systemParams.packages)) {
-      data.gitInfo = systemParams.git_info;
+    if (systemParams) {
+      if (!_.isEmpty(systemParams.arguments)) {
+        data.cliArguments = systemParams.arguments;
+      }
+      if (!_.isEmpty(systemParams.env_variables)) {
+        data.envVariables = systemParams.env_variables;
+      }
+      if (!_.isEmpty(systemParams.packages)) {
+        data.packages = systemParams.packages;
+      }
+      if (!_.isEmpty(systemParams.packages)) {
+        data.gitInfo = systemParams.git_info;
+      }
     }
     return data;
   }, [runData]);

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/CLIArgumentsCard/RunOverviewTabCLIArgumentsCard.d.ts
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/CLIArgumentsCard/RunOverviewTabCLIArgumentsCard.d.ts
@@ -1,4 +1,4 @@
 export interface IRunOverviewTabCLIArgumentsCardProps {
-  cliArguments: undefined | string[];
+  cliArguments: string[];
   isRunInfoLoading: boolean;
 }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/CLIArgumentsCard/RunOverviewTabCLIArgumentsCard.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/CLIArgumentsCard/RunOverviewTabCLIArgumentsCard.tsx
@@ -4,7 +4,6 @@ import { Card } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import BusyLoaderWrapper from 'components/BusyLoaderWrapper/BusyLoaderWrapper';
 import CodeBlock from 'components/CodeBlock/CodeBlock';
-import IllustrationBlock from 'components/IllustrationBlock/IllustrationBlock';
 
 import { IRunOverviewTabCLIArgumentsCardProps } from './RunOverviewTabCLIArgumentsCard.d';
 
@@ -25,11 +24,7 @@ function RunOverviewTabCLIArgumentsCard({
           title='CLI Arguments'
           className='RunOverviewTabCLIArgumentsCard RunOverviewTab__cardBox'
         >
-          {code ? (
-            <CodeBlock code={code} />
-          ) : (
-            <IllustrationBlock size='large' title='No Results' />
-          )}
+          <CodeBlock code={code} />
         </Card>
       </BusyLoaderWrapper>
     </ErrorBoundary>

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/EnvVariablesCard/RunOverviewTabEnvVariablesCard.d.ts
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/EnvVariablesCard/RunOverviewTabEnvVariablesCard.d.ts
@@ -1,4 +1,4 @@
 export interface IRunOverviewTabEnvVariablesCardProps {
-  envVariables: undefined | { [key: string]: string };
+  envVariables: { [key: string]: string };
   isRunInfoLoading: boolean;
 }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/EnvVariablesCard/RunOverviewTabEnvVariablesCard.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/EnvVariablesCard/RunOverviewTabEnvVariablesCard.tsx
@@ -5,6 +5,8 @@ import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import BusyLoaderWrapper from 'components/BusyLoaderWrapper/BusyLoaderWrapper';
 import { ICardProps } from 'components/kit/Card/Card.d';
 
+import { formatValue } from 'utils/formatValue';
+
 import { IRunOverviewTabEnvVariablesCardProps } from './RunOverviewTabEnvVariablesCard.d';
 
 function RunOverviewTabEnvVariablesCard({
@@ -14,10 +16,10 @@ function RunOverviewTabEnvVariablesCard({
   const tableData = React.useMemo(
     () =>
       Object.entries(envVariables || {}).map(
-        ([key = '', value = '']: string[], index: number) => ({
+        ([key = '', value]: string[], index: number) => ({
           key: index,
           name: key,
-          value: value,
+          value: formatValue(value),
         }),
       ),
     [envVariables],

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/GitInfoCard/index.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/GitInfoCard/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import _ from 'lodash-es';
 
 import { Text, Card, Icon } from 'components/kit';
-import IllustrationBlock from 'components/IllustrationBlock/IllustrationBlock';
 
 import { DATE_GIT_COMMIT } from 'config/dates/dates';
 
@@ -14,102 +12,98 @@ import './GitInfoCard.scss';
 function GitInfoCard(props: IGitInfoCardProps) {
   return (
     <Card title='Git Info Card' className='GitInfoCard RunOverviewTab__cardBox'>
-      {_.isEmpty(props.data) ? (
-        <IllustrationBlock size='large' title='No Results' />
-      ) : (
-        <div className='InfoSection ScrollBar__hidden flex fjb'>
-          <div className='InfoCard flex fdc'>
+      <div className='InfoSection ScrollBar__hidden flex fjb'>
+        <div className='InfoCard flex fdc'>
+          <Text
+            className='InfoCardLabel'
+            weight={400}
+            tint={50}
+            size={12}
+            color='primary'
+          >
+            Branch
+          </Text>
+          <div className='InfoCardValue flex fac'>
+            <Icon name='branch' fontSize={14} />
             <Text
-              className='InfoCardLabel'
-              weight={400}
-              tint={50}
+              className='InfoCardValueText'
+              weight={500}
               size={12}
               color='primary'
             >
-              Branch
+              {props.data?.branch}
             </Text>
-            <div className='InfoCardValue flex fac'>
-              <Icon name='branch' fontSize={14} />
-              <Text
-                className='InfoCardValueText'
-                weight={500}
-                size={12}
-                color='primary'
-              >
-                {props.data?.branch}
-              </Text>
-            </div>
-          </div>
-          <div className='InfoCard flex fdc'>
-            <Text
-              className='InfoCardLabel'
-              weight={400}
-              tint={50}
-              size={12}
-              color='primary'
-            >
-              Author
-            </Text>
-            <div className='InfoCardValue flex fac'>
-              <Icon name='avatar' fontSize={14} />
-              <Text
-                className='InfoCardValueText'
-                weight={500}
-                size={12}
-                color='primary'
-              >
-                {props.data.commit?.author}
-              </Text>
-            </div>
-          </div>
-          <div className='InfoCard flex fdc'>
-            <Text
-              className='InfoCardLabel'
-              weight={400}
-              tint={50}
-              size={12}
-              color='primary'
-            >
-              Hash
-            </Text>
-            <div className='InfoCardValue flex fac'>
-              <Icon name='hash' fontSize={14} />
-              <Text
-                className='InfoCardValueText'
-                weight={500}
-                size={12}
-                color='primary'
-              >
-                {props.data.commit?.hash}
-              </Text>
-            </div>
-          </div>
-          <div className='InfoCard flex fdc'>
-            <Text
-              className='InfoCardLabel'
-              weight={400}
-              tint={50}
-              size={12}
-              color='primary'
-            >
-              Timestamp
-            </Text>
-            <div className='InfoCardValue flex fac'>
-              <Icon name='time' fontSize={14} />
-              <Text
-                className='InfoCardValueText'
-                weight={500}
-                size={12}
-                color='primary'
-              >
-                {`${moment(props.data.commit?.timestamp).format(
-                  DATE_GIT_COMMIT,
-                )}`}
-              </Text>
-            </div>
           </div>
         </div>
-      )}
+        <div className='InfoCard flex fdc'>
+          <Text
+            className='InfoCardLabel'
+            weight={400}
+            tint={50}
+            size={12}
+            color='primary'
+          >
+            Author
+          </Text>
+          <div className='InfoCardValue flex fac'>
+            <Icon name='avatar' fontSize={14} />
+            <Text
+              className='InfoCardValueText'
+              weight={500}
+              size={12}
+              color='primary'
+            >
+              {props.data.commit?.author}
+            </Text>
+          </div>
+        </div>
+        <div className='InfoCard flex fdc'>
+          <Text
+            className='InfoCardLabel'
+            weight={400}
+            tint={50}
+            size={12}
+            color='primary'
+          >
+            Hash
+          </Text>
+          <div className='InfoCardValue flex fac'>
+            <Icon name='hash' fontSize={14} />
+            <Text
+              className='InfoCardValueText'
+              weight={500}
+              size={12}
+              color='primary'
+            >
+              {props.data.commit?.hash}
+            </Text>
+          </div>
+        </div>
+        <div className='InfoCard flex fdc'>
+          <Text
+            className='InfoCardLabel'
+            weight={400}
+            tint={50}
+            size={12}
+            color='primary'
+          >
+            Timestamp
+          </Text>
+          <div className='InfoCardValue flex fac'>
+            <Icon name='time' fontSize={14} />
+            <Text
+              className='InfoCardValueText'
+              weight={500}
+              size={12}
+              color='primary'
+            >
+              {`${moment(props.data.commit?.timestamp).format(
+                DATE_GIT_COMMIT,
+              )}`}
+            </Text>
+          </div>
+        </div>
+      </div>
     </Card>
   );
 }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/MetricsCard/RunOverviewTabMetricsCard.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/MetricsCard/RunOverviewTabMetricsCard.tsx
@@ -10,6 +10,7 @@ import COLORS from 'config/colors/colors';
 import contextToString from 'utils/contextToString';
 import { isSystemMetric } from 'utils/isSystemMetric';
 import { formatSystemMetricName } from 'utils/formatSystemMetricName';
+import { formatValue } from 'utils/formatValue';
 
 function RunOverviewTabMetricsCard({
   isLoading,
@@ -26,7 +27,7 @@ function RunOverviewTabMetricsCard({
         return {
           key: index,
           name: isSystemMetric(name) ? formatSystemMetricName(name) : name,
-          value: `${_.last(values)}`,
+          value: formatValue(_.last(values)),
           context: context,
         };
       });

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.d.ts
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.d.ts
@@ -1,4 +1,4 @@
 export interface IRunOverviewTabPackagesCardProps {
-  packages: null | { [key: string]: string };
+  packages: { [key: string]: string };
   isRunInfoLoading: boolean;
 }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.d.ts
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.d.ts
@@ -1,4 +1,4 @@
 export interface IRunOverviewTabPackagesCardProps {
-  packages:  null | { [key: string]: string };
+  packages: null | { [key: string]: string };
   isRunInfoLoading: boolean;
 }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/Packages/RunOverviewTabPackagesCard.tsx
@@ -5,6 +5,8 @@ import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import BusyLoaderWrapper from 'components/BusyLoaderWrapper/BusyLoaderWrapper';
 import { ICardProps } from 'components/kit/Card/Card.d';
 
+import { formatValue } from 'utils/formatValue';
+
 import { IRunOverviewTabPackagesCardProps } from './RunOverviewTabPackagesCard.d';
 
 function RunOverviewTabPackagesCard({
@@ -13,10 +15,10 @@ function RunOverviewTabPackagesCard({
 }: IRunOverviewTabPackagesCardProps) {
   const tableData = React.useMemo(
     () =>
-      Object.entries(packages || {}).map(([key = '', value = ''], index) => ({
+      Object.entries(packages || {}).map(([key = '', value], index) => ({
         key: index,
         name: key,
-        value: value,
+        value: formatValue(value),
       })),
     [packages],
   );

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/RunOverviewSidebar/RunOverviewSidebar.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/RunOverviewSidebar/RunOverviewSidebar.scss
@@ -2,9 +2,10 @@
 
 .RunOverviewSidebar {
   margin-top: $space-lg;
-  max-width: 20rem;
+  min-width: 20rem;
   padding: $space-xs;
-
+  position: sticky;
+  top: $space-lg;
   h3 {
     margin-bottom: $space-sm;
   }

--- a/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/RunOverviewSidebar/RunOverviewSidebar.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunOverviewTab/components/RunOverviewSidebar/RunOverviewSidebar.scss
@@ -3,6 +3,8 @@
 .RunOverviewSidebar {
   margin-top: $space-lg;
   min-width: 20rem;
+  width: 20rem;
+  overflow: hidden;
   padding: $space-xs;
   position: sticky;
   top: $space-lg;

--- a/aim/web/ui/src/pages/RunDetail/TraceVisualizationContainer/TraceVisualizationContainer.tsx
+++ b/aim/web/ui/src/pages/RunDetail/TraceVisualizationContainer/TraceVisualizationContainer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Menu from 'components/kit/Menu/Menu';
 import { IValidationMetadata } from 'components/kit/Input';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+import Spinner from 'components/kit/Spinner';
 
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
@@ -12,17 +13,20 @@ import runTracesModel from 'services/models/runs/runTracesModel';
 import * as analytics from 'services/analytics';
 import { TraceType } from 'services/models/runs/types';
 
-import DistributionsVisualizer from '../DistributionsVisualizer';
-import TextsVisualizer from '../TextsVisualizer';
-import ImagesVisualizer from '../ImagesVisualizer';
-import PlotlyVisualizer from '../PlotlyVisualizer';
 import { ITraceVisualizationContainerProps } from '../types';
-import AudiosVisualizer from '../AudiosVisualizer';
 
 import RangePanel from './RangePanel';
 import withEmptyTraceCheck from './withEmptyTraceCheck';
 
 import './TraceVisualizationContainer.scss';
+
+const DistributionsVisualizer = React.lazy(
+  () => import('../DistributionsVisualizer'),
+);
+const ImagesVisualizer = React.lazy(() => import('../ImagesVisualizer'));
+const TextsVisualizer = React.lazy(() => import('../TextsVisualizer'));
+const PlotlyVisualizer = React.lazy(() => import('../PlotlyVisualizer'));
+const AudiosVisualizer = React.lazy(() => import('../AudiosVisualizer'));
 
 const traceTypeVisualization = {
   images: ImagesVisualizer,
@@ -85,11 +89,13 @@ function TraceVisualizationContainer({
           )}
         </div>
         <div className='VisualizerArea'>
-          <Visualizer
-            data={runTracesModelData?.data}
-            isLoading={runTracesModelData?.isTraceBatchLoading}
-            activeTraceContext={runTracesModelData?.menu?.activeItemName}
-          />
+          <React.Suspense fallback={<Spinner />}>
+            <Visualizer
+              data={runTracesModelData?.data}
+              isLoading={runTracesModelData?.isTraceBatchLoading}
+              activeTraceContext={runTracesModelData?.menu?.activeItemName}
+            />
+          </React.Suspense>
           {runTracesModelData?.data &&
             runTracesModelData?.config &&
             !runTracesModelData?.isTraceContextBatchLoading &&


### PR DESCRIPTION
- Used React `Lazy loading` to avoid large size chunk in single run page
- Fixed `RunOverViewSidebar` width
- Tuned `Archive/Unarchive` button styles in `settings tab`
- Added `Spinner` component
- Fixed `Card` component padding 