### PR TITLE
[fix] Render plotly figures properly in single run page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Rendering plotly figures properly in single run page (arsengit)
+- Render plotly figures properly in single run page (arsengit)
 
 ## 3.7.4 Mar 15, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Rendering plotly figures properly in single run page (arsengit)
+
 ## 3.7.4 Mar 15, 2022
 
 - Fix density min and max validation calculation (VkoHov)

--- a/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.scss
+++ b/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.scss
@@ -6,9 +6,5 @@
   overflow-y: auto;
   &__recordCnt {
     height: 100%;
-    &__plotWrapper {
-      width: 100%;
-      height: 100%;
-    }
   }
 }

--- a/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.scss
+++ b/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.scss
@@ -3,8 +3,9 @@
 .PlotlyVisualizer {
   height: 100%;
   padding: toRem(10px);
-  overflow-y: auto;
+  overflow: auto;
   &__recordCnt {
     height: 100%;
+    overflow: auto;
   }
 }

--- a/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.tsx
+++ b/aim/web/ui/src/pages/RunDetail/PlotlyVisualizer/PlotlyVisualizer.tsx
@@ -28,7 +28,6 @@ function PlotlyVisualizer(
                 data={props.data?.processedValue?.data}
                 layout={props.data?.processedValue?.layout}
                 frames={props.data?.processedValue?.frames}
-                className='PlotlyVisualizer__recordCnt__plotWrapper'
                 useResizeHandler={true}
               />
             </div>

--- a/docs/source/ui/pages/run_management.md
+++ b/docs/source/ui/pages/run_management.md
@@ -138,8 +138,10 @@ Use the bottom controllers to control the steps and the indices of the tracked t
 
 ### Figures
 
-Aim allows to track Plotly and matplotlib figures.
+Aim allows tracking Plotly and matplotlib figures.
 On the `Figures` tab you can view all the track figures over different contexts and steps.
+
+**Note:** Aim will render figures with passed or default dimensions. There will be scrolls if the size exceeds the plotly container space of the Figures tab.
 
 <img style="border-radius: 8px; border: 1px solid #E8F1FC" alt="Single Run page figures tab" src="https://docs-blobs.s3.us-east-2.amazonaws.com/images/ui/pages/run-single-page/figures_tab.png">
 


### PR DESCRIPTION
- Deleted unnecessary styles from `Plotly` wrapper
- Added additional documentation for `Figures` tab