### PR TITLE
[fix] Fix chart active point focusing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes:
 
+- Fix issue with focusing on the chart active point while moving the cursor (KaroMourad)
 - Fix the image full view toggle icon visibility if the image has a white background (VkoHov)
 - Fix scroll to the end of the audio tab (VkoHov)
 - Add scrollbar to image full view mode content (VkoHov)

--- a/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartPanel.tsx
@@ -52,28 +52,34 @@ const ChartPanel = React.forwardRef(function ChartPanel(
 
   const syncHoverState = React.useCallback(
     (args: ISyncHoverStateArgs): void => {
-      const { activePoint, focusedStateActive, dataSelector } = args;
+      const { activePoint, focusedStateActive = false, dataSelector } = args;
       // on MouseHover
       activePointRef.current = activePoint;
       if (activePoint !== null) {
-        if (props.chartType === ChartTypeEnum.LineChart) {
-          chartRefs.forEach((chartRef, index) => {
-            if (index === activePoint.chartIndex) {
-              return;
-            }
-            chartRef.current?.updateHoverAttributes?.(
-              activePoint.xValue,
-              dataSelector,
-            );
+        chartRefs.forEach((chartRef, index) => {
+          chartRef.current?.setFocusedState?.({
+            active: focusedStateActive,
+            key: activePoint.key,
+            xValue: activePoint.xValue,
+            yValue: activePoint.yValue,
+            chartIndex: activePoint.chartIndex,
           });
-        } else if (props.chartType === ChartTypeEnum.HighPlot) {
-          chartRefs.forEach((chartRef, index) => {
-            if (index === activePoint.chartIndex) {
-              return;
-            }
-            chartRef.current?.clearHoverAttributes?.();
-          });
-        }
+          if (index === activePoint.chartIndex) {
+            return;
+          }
+          switch (props.chartType) {
+            case ChartTypeEnum.LineChart:
+              chartRef.current?.updateHoverAttributes?.(
+                activePoint.xValue,
+                dataSelector,
+              );
+              break;
+            case ChartTypeEnum.HighPlot:
+              chartRef.current?.clearHoverAttributes?.();
+              break;
+          }
+        });
+
         if (props.onActivePointChange) {
           props.onActivePointChange(activePoint, focusedStateActive);
         }

--- a/aim/web/ui/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui/src/components/LineChart/LineChart.tsx
@@ -22,6 +22,8 @@ import {
   drawHoverAttributes,
 } from 'utils/d3';
 
+import './LineChart.scss';
+
 const LineChart = React.forwardRef(function LineChart(
   props: ILineChartProps,
   ref,
@@ -170,7 +172,6 @@ const LineChart = React.forwardRef(function LineChart(
         linesNodeRef,
         highlightedNodeRef,
         aggregationConfig,
-        humanizerConfigRef,
         alignmentConfig,
       });
     }

--- a/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
+++ b/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
@@ -152,7 +152,6 @@ const ScatterPlot = React.forwardRef(function ScatterPlot(
         attributesNodeRef,
         linesNodeRef,
         highlightedNodeRef,
-        humanizerConfigRef,
         drawAxisLines: { x: false, y: false },
         drawAxisLabels: { x: false, y: false },
       });
@@ -252,7 +251,7 @@ const ScatterPlot = React.forwardRef(function ScatterPlot(
         <div ref={visAreaRef} />
         {yDimension.domainData[0] === '-' ||
         xDimension.domainData[0] === '-' ? (
-          <Text className='ScatterPlot__emptyData'> No Data</Text>
+          <Text className='ScatterPlot__emptyData'>No Data</Text>
         ) : null}
       </div>
     </ErrorBoundary>

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -291,10 +291,10 @@ function createAppModel(appConfig: IAppInitialConfig) {
                   CONTROLS_DEFAULT_CONFIG.metrics.tooltip.selectedParams,
               },
               focusedState: {
-                active: false,
                 key: null,
                 xValue: null,
                 yValue: null,
+                active: false,
                 chartIndex: null,
               },
             };

--- a/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
+++ b/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
@@ -34,7 +34,6 @@ export interface IDrawHoverAttributesArgs {
   highlightMode?: HighlightEnum;
   aggregationConfig?: IAggregationConfig;
   alignmentConfig?: IAlignmentConfig;
-  humanizerConfigRef: React.MutableRefObject<{}>;
   drawAxisLines?: { x: Boolean; y: Boolean };
   drawAxisLabels?: { x: Boolean; y: Boolean };
 }

--- a/aim/web/ui/src/utils/d3/drawAxes.ts
+++ b/aim/web/ui/src/utils/d3/drawAxes.ts
@@ -283,12 +283,12 @@ function drawAxes(args: IDrawAxesArgs): void {
     axesRef.current.xAxis
       .selectAll('.tick')
       .append('svg:title')
-      .text((d: number) => {
-        return formatValueByAlignment({
+      .text((d: number) =>
+        formatValueByAlignment({
           xAxisTickValue: d ?? null,
           type: alignmentConfig?.type,
-        });
-      });
+        }),
+      );
 
     axesRef.current.xAxis
       .selectAll('.tick line')


### PR DESCRIPTION
Expected behavior:
-  after focusing(clicking) on the active point, all charts should freeze(block mouse hovering on charts) before you unfocus the active point, it means before you don't click on one of the sibling charts 

Bug: 
- after focusing on the active point, it doesn’t focus

Solution: 
- on syncing hover state for charts, we immediately set the focused state for every sibling charts and itself

Improvement: 
- Improve d3 utils `drawHoverAttributes` function performance
    1. `drawAxisLabel` (create/remove/create changed to create/update)
    2. `drawHoverLine` (create/remove/create changed to create/update)