### PR TITLE
[fix] Fix issue with wrong URL caching for Explorer pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes:
 
+- Fix issue with wrong URL caching for Explorer pages (roubkar)
 - Fix issue with focusing on the chart active point while moving the cursor (KaroMourad)
 - Fix the image full view toggle icon visibility if the image has a white background (VkoHov)
 - Fix scroll to the end of the audio tab (VkoHov)

--- a/aim/web/ui/src/components/SideBar/SideBar.tsx
+++ b/aim/web/ui/src/components/SideBar/SideBar.tsx
@@ -17,39 +17,17 @@ import routes, { IRoute } from 'routes/routes';
 
 import { trackEvent } from 'services/analytics';
 
+import { getItem } from 'utils/storage';
+
 import './Sidebar.scss';
 
 function SideBar(): React.FunctionComponentElement<React.ReactNode> {
   function getPathFromStorage(route: PathEnum): PathEnum | string {
-    switch (route) {
-      case PathEnum.Metrics:
-        if (localStorage.getItem('metricsUrl')) {
-          return localStorage.getItem('metricsUrl') || '';
-        }
-        return route;
-      case PathEnum.Params:
-        if (localStorage.getItem('paramsUrl')) {
-          return localStorage.getItem('paramsUrl') || '';
-        }
-        return route;
-      case PathEnum.Runs:
-        if (localStorage.getItem('runsUrl')) {
-          return localStorage.getItem('runsUrl') || '';
-        }
-        return route;
-      case PathEnum.Images_Explore:
-        if (localStorage.getItem('imagesExploreUrl')) {
-          return localStorage.getItem('imagesExploreUrl') || '';
-        }
-        return route;
-      case PathEnum.Scatters:
-        if (localStorage.getItem('scattersUrl')) {
-          return localStorage.getItem('scattersUrl') || '';
-        }
-        return route;
-      default:
-        return route;
+    const path = getItem(`${route.slice(1)}Url`) ?? '';
+    if (path !== '' && path.startsWith(route)) {
+      return path;
     }
+    return route;
   }
 
   return (

--- a/aim/web/ui/src/utils/app/updateUrlParam.ts
+++ b/aim/web/ui/src/utils/app/updateUrlParam.ts
@@ -32,7 +32,9 @@ export default function updateUrlParam({
       fullURL = fullURL.replace((window as any).API_BASE_PATH, '');
     }
 
-    setItem(`${appName}Url`, fullURL);
+    if (fullURL.startsWith(`/${appName}?`)) {
+      setItem(`${appName}Url`, fullURL);
+    }
   }
 
   window.history.pushState(null, '', url);


### PR DESCRIPTION
- Do not allow saving URL if the currently opened page does not correspond to explorer path
- Do not allow navigating by a specific path that does not correspond to explorer route 