### PR TITLE
[fix] Retry docker image build when PyPI package is newly pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix issue with run single page tabs result caching (mihran113)
 - Fix git system param tracking (devfox-se)
 - Fix runs manual closing (mihran113)
+- Fix Docker image creation step in packaging workflow (alberttorosyan)
 
 ## 3.7.5 Mar 18, 2022
 

--- a/docker/create-docker-image.sh
+++ b/docker/create-docker-image.sh
@@ -2,10 +2,18 @@
 
 if [ "$UPDATE_TAG" = "latest" ] || [ "$UPDATE_TAG" = "nightly" ]
 then
-  docker image build --no-cache	 \
-    -t aimstack/aim:$AIM_VERSION -t aimstack/aim:$UPDATE_TAG --build-arg AIM_VERSION=$AIM_VERSION -f Dockerfile .
+  for i in {1..5}
+  do
+    docker image build --no-cache	 \
+      -t aimstack/aim:$AIM_VERSION -t aimstack/aim:$UPDATE_TAG --build-arg AIM_VERSION=$AIM_VERSION -f Dockerfile . \
+      && break || echo "retry attempt ${i}" && sleep 120
+  done
 else
-  docker image build --no-cache	\
-    -t aimstack/aim:$AIM_VERSION --build-arg AIM_VERSION=$AIM_VERSION -f Dockerfile .
+  for i in {1..5}
+  do
+    docker image build --no-cache	\
+      -t aimstack/aim:$AIM_VERSION --build-arg AIM_VERSION=$AIM_VERSION -f Dockerfile . \
+      && break || echo "retry attempt ${i}" && sleep 120
+  done
 fi
 docker image push --all-tags aimstack/aim


### PR DESCRIPTION
Added retry logic to docker image creation bash script.  Retry 5 times with 2 min. interval. Expected to pass after 2nd attempt, the rest are kept just in case