### PR TITLE
[fix] Remove type annotation from xgboost callback `after_iteration`

### DIFF
--- a/aim/sdk/adapters/xgboost.py
+++ b/aim/sdk/adapters/xgboost.py
@@ -54,7 +54,7 @@ class AimCallback(TrainingCallback):
         self.setup()
         return model
 
-    def after_iteration(self, model, epoch: int, evals_log: TrainingCallback.EvalsLog) -> bool:
+    def after_iteration(self, model, epoch: int, evals_log) -> bool:
         if not evals_log:
             return False
 


### PR DESCRIPTION
The type annotation was copied from base class callback, and causes
issues with certaain version of xgboost installed.