### PR TITLE
[fix] Fix issue with fetch on load more (infinite scroll) functionality in Runs Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.1
+
+- Fix issue with infinite loader of runs explorers' table (rubenaprikyan)
+
 ## 3.8.0 Mar 26, 2022
 
 ### Enhancements:

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -2325,7 +2325,6 @@ function createAppModel(appConfig: IAppInitialConfig) {
               }
               const { data, params, metricsColumns, selectedRows } =
                 processData(runsData);
-
               const tableData = getDataAsTableRows(
                 data,
                 metricsColumns,
@@ -2338,9 +2337,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
                 model.getState()?.config?.table.hiddenColumns!,
               );
               updateTableData(tableData, tableColumns, configData);
-              limit = isInitial
-                ? modelState?.config.pagination.limit
-                : modelState?.config.pagination.limit + 45;
+
               model.setState({
                 data,
                 selectedRows: shouldResetSelectedRows
@@ -2358,9 +2355,6 @@ function createAppModel(appConfig: IAppInitialConfig) {
                     ...modelState?.config.pagination,
                     isLatest:
                       !isInitial && count < modelState?.config.pagination.limit,
-                    limit: isInitial
-                      ? modelState?.config.pagination.limit
-                      : modelState?.config.pagination.limit + 45,
                   },
                 },
               });
@@ -2376,9 +2370,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
                 });
               }
             }
+            const rowDataLength = model.getState()?.tableData?.length || 0;
+            limit = rowDataLength >= 45 ? rowDataLength : 45;
             liveUpdateInstance?.start({
               q: query,
-              limit: limit || 0,
+              limit,
             });
           },
           abort: runsRequestRef.abort,
@@ -2852,6 +2848,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
               },
             },
           });
+
           return getRunsData(false, false, false);
         }
       }
@@ -2999,8 +2996,8 @@ function createAppModel(appConfig: IAppInitialConfig) {
 
         if (!liveUpdateConfig?.enabled && config.enabled) {
           const query = configData?.select?.query || '';
-          const pagination = configData?.pagination;
-
+          const rowDataLength = model.getState()?.tableData?.length || 0;
+          const limit = rowDataLength >= 45 ? rowDataLength : 45;
           liveUpdateInstance = new LiveUpdateService(
             appName,
             updateData,
@@ -3008,7 +3005,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
           );
           liveUpdateInstance.start({
             q: query,
-            limit: pagination.limit || 0,
+            limit,
           });
         } else {
           liveUpdateInstance?.clear();


### PR DESCRIPTION
There was a logic to update the request limit on state for live update, live update should get all data, but it shouldn't update the limit exactly on state, because the infinite scroll uses that limit, and it should always have constant value.
Now the I added a calculation logic for live update, and using it once the live updates' start function is called.

Please do your tests with live update enabled status and without it as well.