### PR TITLE
[fix] Run reference cleanup from `RepoIndexManager` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.1
+
+- Fix `RepoIndexManager` run's reference cleanup (mihran113)
+
 ## 3.8.0 Mar 26, 2022
 
 ### Enhancements:

--- a/aim/cli/reindex/commands.py
+++ b/aim/cli/reindex/commands.py
@@ -20,7 +20,7 @@ def reindex(repo, finalize_only):
     if repo_status != RepoStatus.UPDATED:
         click.echo(f'\'{repo_path}\' is not updated. Cannot run indexing.')
     repo_inst = Repo.from_path(repo_path)
-    index_mng = RepoIndexManager.get_index_manager(repo_inst)
+    index_mng = RepoIndexManager.get_index_manager(repo_inst.path)
     if finalize_only:
         if not index_mng.reindex_needed:
             click.echo('Index is up to date.')

--- a/aim/cli/runs/commands.py
+++ b/aim/cli/runs/commands.py
@@ -43,13 +43,14 @@ def remove_runs(ctx, hashes):
         click.echo('Please specify at least one Run to delete.')
         exit(1)
     repo_path = ctx.obj['repo']
-    confirmed = click.confirm(f'This command will permanently delete {len(hashes)} runs from aim repo located at '
-                              f'\'{repo_path}\'. Do you want to proceed?')
-    if not confirmed:
-        return
     repo = Repo.from_path(repo_path)
 
     matched_hashes = match_runs(repo_path, hashes)
+    confirmed = click.confirm(f'This command will permanently delete {len(matched_hashes)} runs from aim repo '
+                              f'located at \'{repo_path}\'. Do you want to proceed?')
+    if not confirmed:
+        return
+
     success, remaining_runs = repo.delete_runs(matched_hashes)
     if success:
         click.echo(f'Successfully deleted {len(matched_hashes)} runs.')

--- a/aim/web/api/__init__.py
+++ b/aim/web/api/__init__.py
@@ -53,7 +53,7 @@ def create_app():
 
     # The indexing thread has to run in the same process as the uvicorn app itself.
     # This allows sharing state of indexing using memory instead of process synchronization methods.
-    index_mng = RepoIndexManager.get_index_manager(Project().repo)
+    index_mng = RepoIndexManager.get_index_manager(Project().repo.path)
     index_mng.start_indexing_thread()
 
     api_app = FastAPI()

--- a/aim/web/api/projects/views.py
+++ b/aim/web/api/projects/views.py
@@ -94,4 +94,4 @@ async def project_status_api():
     if not project.exists():
         raise HTTPException(status_code=404)
 
-    return RepoIndexManager.get_index_manager(project.repo).repo_status
+    return RepoIndexManager.get_index_manager(project.repo.path).repo_status

--- a/aim/web/middlewares/profiler/profiler.py
+++ b/aim/web/middlewares/profiler/profiler.py
@@ -60,7 +60,7 @@ class PyInstrumentProfilerMiddleware:
         profiler = self.profiler(interval=self._profiler_interval)
         try:
             profiler.start()
-        except:
+        except: # noqa
             skip_profiling = True
         else:
             skip_profiling = False


### PR DESCRIPTION
- Remove run reference from `RepoIndexManager` thread after explicitly finalizing the run instance
- Pass the repo path to index manager instead of repo instance to avoid infinitely alive reference on repo instance