### PR TITLE
[fix] Remote run finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.8.1
 
 - Fix `RepoIndexManager` run's reference cleanup (mihran113)
+- Fix remote run finalization (mihran113)
 
 ## 3.8.0 Mar 26, 2022
 

--- a/aim/ext/transport/message_utils.py
+++ b/aim/ext/transport/message_utils.py
@@ -84,6 +84,9 @@ def build_exception(exception: Exception):
     )
 
 
+@CustomObject.alias('aim.resource')
 class ResourceObject(CustomObject):
+    AIM_NAME = 'aim.resource'
+
     def __init__(self, handler):
         self.storage['handler'] = handler

--- a/aim/ext/transport/rpc_queue.py
+++ b/aim/ext/transport/rpc_queue.py
@@ -9,38 +9,9 @@ from aim.ext.cleanup import AutoClean
 logger = logging.getLogger(__name__)
 
 
-class RpcQueueAutoClean(AutoClean):
-    PRIORITY = 100  # Priority of RpcQueueAutoClean should be higher than priority of RunAutoClean
-
-    def __init__(self, instance: 'RpcQueueWithRetry') -> None:
-        """
-        Prepare the `RpcQueueWithRetry` for automatic cleanup.
-
-        Args:
-            instance: The `RpcQueueWithRetry` instance to be cleaned up.
-        """
-        super().__init__(instance)
-        self._queue = None
-        self._shutdown = None
-        self._name = None
-
-    def _close(self):
-        """
-        Wait until rpc queue is empty
-        """
-        pending_task_count = self._queue.qsize()
-        if pending_task_count:
-            logger.warning(f'Processing {pending_task_count} pending tasks in the rpc queue \'{self._name}\'... '
-                           f'Please do not kill the process.')
-            self._queue.join()
-        logger.debug('No pending tasks left.')
-        self._shutdown = True
-
-
 class RpcQueueWithRetry(object):
     def __init__(self, name, max_queue_memory=0,
                  retry_count=0, retry_interval=0):
-        self._resources: RpcQueueAutoClean = None
 
         self.retry_count = retry_count or 1
         self.retry_interval = retry_interval
@@ -48,22 +19,13 @@ class RpcQueueWithRetry(object):
         self.max_memory_usage = max_queue_memory
         self.current_memory_usage = 0
 
-        self._resources = RpcQueueAutoClean(self)
-        self._resources._shutdown = False
-        self._resources._queue = queue.Queue()
-        self._resources._name = name
+        self._shutdown = False
+        self._queue = queue.Queue()
+        self._name = name
 
         self._thread = threading.Thread(target=self.worker)
         self._thread.daemon = True
         self._thread.start()
-
-    @property
-    def _queue(self):
-        return self._resources._queue
-
-    @property
-    def _shutdown(self):
-        return self._resources._shutdown
 
     def register_task(self, task_f, *args):
         if self._shutdown:
@@ -118,6 +80,15 @@ class RpcQueueWithRetry(object):
 
     def wait_for_finish(self):
         self._queue.join()
+
+    def stop(self):
+        pending_task_count = self._queue.qsize()
+        if pending_task_count:
+            logger.warning(f'Processing {pending_task_count} pending tasks in the rpc queue \'{self._name}\'... '
+                           f'Please do not kill the process.')
+            self._queue.join()
+        logger.debug('No pending tasks left.')
+        self._shutdown = True
 
     @staticmethod
     def _calculate_size(args):

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -91,6 +91,10 @@ class RunAutoClean(AutoClean['Run']):
             logger.debug('Stopping resource tracker')
             self._system_resource_tracker.stop()
 
+    def finalize_rpc_queue(self):
+        if self.repo.is_remote_repo:
+            self.repo._client.get_queue(self.hash).stop()
+
     def _close(self) -> None:
         """
         Close the `Run` instance resources and trigger indexing.
@@ -100,6 +104,7 @@ class RunAutoClean(AutoClean['Run']):
             return
         self.finalize_system_tracker()
         self.finalize_run()
+        self.finalize_rpc_queue()
 
 
 # TODO: [AT] generate automatically based on ModelMappedRun

--- a/aim/storage/container.py
+++ b/aim/storage/container.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aim.storage.treeview import TreeView
-    from aim.storage.types import BLOB
 
 ContainerKey = bytes
 ContainerValue = Union[bytes, 'BLOB[bytes]']
@@ -31,7 +30,7 @@ class Container:
         ...
 
     @abstractmethod
-    def finalize(self, *, index: 'Container'):
+    def finalize(self, index: 'Container'):
         """Finalize the Container.
 
         Perform operations of compactions, indexing, optimization, etc.

--- a/aim/storage/containertreeview.py
+++ b/aim/storage/containertreeview.py
@@ -26,7 +26,6 @@ class ContainerTreeView(TreeView):
 
     def finalize(
         self,
-        *,
         index: 'ContainerTreeView'
     ):
         self.container.finalize(index=index.container)

--- a/aim/storage/prefixview.py
+++ b/aim/storage/prefixview.py
@@ -55,7 +55,7 @@ class PrefixView(Container):
         """
         self.container.preload()
 
-    def finalize(self, *, index: Container):
+    def finalize(self, index: Container):
         """Finalize the Container.
 
         Perform operations of compactions, indexing, optimization, etc.

--- a/aim/storage/rockscontainer.pyx
+++ b/aim/storage/rockscontainer.pyx
@@ -153,7 +153,7 @@ class RocksContainer(Container):
             self._progress_path.touch(exist_ok=True)
         return db
 
-    def finalize(self, *, index: Container):
+    def finalize(self, index: Container):
         """Finalize the Container.
 
         Store the collection of `(key, value)` records in the :obj:`Container`

--- a/aim/storage/treeview.py
+++ b/aim/storage/treeview.py
@@ -15,7 +15,6 @@ class TreeView:
 
     def finalize(
         self,
-        *,
         index: 'TreeView'
     ):
         ...

--- a/aim/storage/treeviewproxy.py
+++ b/aim/storage/treeviewproxy.py
@@ -150,11 +150,9 @@ class ProxyTree(TreeView):
 
     def finalize(
         self,
-        *,
         index: 'ProxyTree'
     ):
-        self._rpc_client.run_instruction(
-            self._handler, 'finalize', (ResourceObject(index._handler),), is_write_only=True)
+        self._rpc_client.run_instruction(self._hash, self._handler, 'finalize', (ResourceObject(index._handler),))
 
 
 class SubtreeView(TreeView):
@@ -254,3 +252,9 @@ class SubtreeView(TreeView):
         path: Union[AimObjectKey, AimObjectPath] = ()
     ) -> Tuple[AimObjectKey, AimObject]:
         return self.tree.last(self.absolute_path(path))
+
+    def finalize(
+        self,
+        index: 'SubtreeView'
+    ):
+        self.tree.finalize(index=index.tree)


### PR DESCRIPTION
- Provide `.finalize()` method for `SubTreeView` class
- Make `finalize()` read instruction instead of write instruction
- Remove implicit RpcQueue cleanup and leave it to be handled by Run resource cleanup