### PR TITLE
[fix] Encode run hash before including in CSS selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-### Fixes:
-
-- Fix CSS valid selector issue with Uncaught DOMException (Hamik25)
-
 ## 3.8.1
 
+- Encode run hash before including in CSS selectors (Hamik25)
 - Fix issue with URL state sync for bookmarks (roubkar)
 - Fix issue with displaying negative param values on Aim UI (roubkar)
 - Fix row hiding functionality (roubkar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixes:
+
+- Fix CSS valid selector issue with Uncaught DOMException (Hamik25)
+
 ## 3.8.1
 
 - Fix issue with URL state sync for bookmarks (roubkar)

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -2477,7 +2477,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
             run,
             isHidden: false,
             color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-            key: run.hash,
+            key: encode({ runHash: run.hash }),
             dasharray: DASH_ARRAYS[0],
           });
         });
@@ -4034,7 +4034,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
             run,
             isHidden: configData!.table.hiddenMetrics!.includes(run.hash),
             color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-            key: run.hash,
+            key: encode({ runHash: run.hash }),
             dasharray: DASH_ARRAYS[0],
           });
         });
@@ -5164,7 +5164,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
             run,
             isHidden: configData!.table.hiddenMetrics!.includes(run.hash),
             color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-            key: run.hash,
+            key: encode({ runHash: run.hash }),
             dasharray: DASH_ARRAYS[0],
           });
         });

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -1586,7 +1586,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
                 color: metricsCollection.color ?? metric.color,
                 dasharray: metricsCollection.dasharray ?? metric.color,
                 chartIndex: metricsCollection.chartIndex,
-                selectors: [metric.key, metric.key, metric.run.hash],
+                selectors: [
+                  metric.key,
+                  metric.key,
+                  encode({ runHash: metric.run.hash }),
+                ],
                 data: {
                   xValues: metric.data.xValues,
                   yValues: metric.data.yValues,


### PR DESCRIPTION
- Add encoding to key property whose value contains `run.hash` for explorers `processData` functions to avoid setting invalid CSS selectors on HTML tags. 
- Add encoding to selectors `run.hash` for metric lines.