### PR TITLE
Fix compatibility with PL v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-### Enhancements
+### Enhancements:
 - Add `--log-level` argument for aim up/server commands (mihran113)
 - Add notes backend api interface (devfox-se)
+
+### Fixes:
+- Fix compatibility with pytorch-lightning v1.6.0 (mihran113)
 
 ## 3.8.1 Apr 6, 2022
 

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -45,6 +45,17 @@ class AimLogger(LightningLoggerBase):
         self._run = None
         self._run_hash = None
 
+    @staticmethod
+    def _convert_params(params: Union[Dict[str, Any], Namespace]) -> Dict[str, Any]:
+        # in case converting from namespace
+        if isinstance(params, Namespace):
+            params = vars(params)
+
+        if params is None:
+            params = {}
+
+        return params
+
     @property
     @rank_zero_experiment
     def experiment(self) -> Run:


### PR DESCRIPTION
Have a copy of removed staticmethod `_convert_params()` on `AimLogger` class itself