### PR TITLE
[feat] Improve chart lines rendering performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements:
 
+- Increase the scalability of rendering lines in charts (KaroMourad)
 - Change font-family to monospace in the Table component (arsengit)
 - Add info massage for single value sliders (VkoHov)
 - Add `--log-level` argument for aim up/server commands (mihran113)

--- a/aim/web/ui/src/components/ChartPanel/ChartGrid/ChartGrid.tsx
+++ b/aim/web/ui/src/components/ChartPanel/ChartGrid/ChartGrid.tsx
@@ -5,8 +5,7 @@ import { Grid, GridSize } from '@material-ui/core';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import { CHART_TYPES_CONFIG } from 'components/ChartPanel/config';
 
-import CHART_GRID_PATTERN from 'config/chart-grid-pattern/chartGridPattern';
-import { GRID_SIZE } from 'config/chart-grid-pattern/chartGridPattern';
+import { GRID_SIZE, CHART_GRID_PATTERN } from 'config/charts';
 
 import { IChartGridProps } from './ChartGrid.d';
 

--- a/aim/web/ui/src/components/HighPlot/HighPlot.scss
+++ b/aim/web/ui/src/components/HighPlot/HighPlot.scss
@@ -122,6 +122,11 @@
 
   .Lines {
     overflow: hidden;
+    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+      &.optimizeRendering {
+        shape-rendering: optimizeSpeed;
+      }
+    }
   }
 
   .Line {

--- a/aim/web/ui/src/components/HighPlot/HighPlot.tsx
+++ b/aim/web/ui/src/components/HighPlot/HighPlot.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
+import { RENDER_LINES_OPTIMIZED_LIMIT } from 'config/charts';
+
 import useResizeObserver from 'hooks/window/useResizeObserver';
 
 import { IFocusedState } from 'types/services/models/metrics/metricsAppModel';
@@ -53,7 +55,7 @@ const HighPlot = React.forwardRef(function HighPlot(
   // d3 node elements
   const svgNodeRef = React.useRef<any>(null);
   const bgRectNodeRef = React.useRef(null);
-  const plotNodeRef = React.useRef(null);
+  const plotNodeRef = React.useRef<any>(null);
   const axesNodeRef = React.useRef<any>(null);
   const linesNodeRef = React.useRef<any>(null);
   const attributesNodeRef = React.useRef(null);
@@ -110,6 +112,14 @@ const HighPlot = React.forwardRef(function HighPlot(
       });
 
       linesRef.current.data = data.data;
+
+      // render lines with low quality if lines count are more than 'RENDER_LINES_OPTIMIZED_LIMIT'
+      if (!readOnly && linesNodeRef.current) {
+        const linesCount = linesNodeRef.current.selectChildren().size();
+        if (linesCount > RENDER_LINES_OPTIMIZED_LIMIT) {
+          linesNodeRef.current.classed('optimizeRendering', true);
+        }
+      }
 
       if (!readOnly) {
         drawParallelHoverAttributes({

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -84,6 +84,11 @@
 
   .Lines {
     overflow: hidden;
+    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+      &.optimizeRendering {
+        shape-rendering: optimizeSpeed;
+      }
+    }
   }
 
   .Line {

--- a/aim/web/ui/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui/src/components/LineChart/LineChart.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import * as d3 from 'd3';
+import classNames from 'classnames';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import { RENDER_LINES_OPTIMIZED_LIMIT } from 'config/charts';
 
 import useResizeObserver from 'hooks/window/useResizeObserver';
 
@@ -71,7 +74,7 @@ const LineChart = React.forwardRef(function LineChart(
   const bgRectNodeRef = React.useRef(null);
   const plotNodeRef = React.useRef(null);
   const axesNodeRef = React.useRef(null);
-  const linesNodeRef = React.useRef(null);
+  const linesNodeRef = React.useRef<any>(null);
   const attributesNodeRef = React.useRef(null);
   const xAxisLabelNodeRef = React.useRef(null);
   const yAxisLabelNodeRef = React.useRef(null);
@@ -124,7 +127,7 @@ const LineChart = React.forwardRef(function LineChart(
       if (visAreaRef.current && !readOnly) {
         d3.select(visAreaRef.current)
           .append('text')
-          .attr('class', 'LineChart__emptyData')
+          .classed('LineChart__emptyData', true)
           .text('No Data');
       }
       return;
@@ -159,6 +162,14 @@ const LineChart = React.forwardRef(function LineChart(
       aggregationConfig,
       processedAggrData,
     });
+
+    // render lines with low quality if lines count are more than 'RENDER_LINES_OPTIMIZED_LIMIT'
+    if (!readOnly && linesNodeRef.current) {
+      const linesCount = linesNodeRef.current.selectChildren().size();
+      if (linesCount > RENDER_LINES_OPTIMIZED_LIMIT) {
+        linesNodeRef.current.classed('optimizeRendering', true);
+      }
+    }
 
     if (!readOnly) {
       drawHoverAttributes({
@@ -281,7 +292,9 @@ const LineChart = React.forwardRef(function LineChart(
     <ErrorBoundary>
       <div
         ref={parentRef}
-        className={`LineChart ${!readOnly && zoom?.active ? 'zoomMode' : ''}`}
+        className={classNames('LineChart', {
+          zoomMode: !readOnly && zoom?.active,
+        })}
       >
         <div ref={visAreaRef} />
       </div>

--- a/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
+++ b/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
@@ -94,7 +94,7 @@ const ScatterPlot = React.forwardRef(function ScatterPlot(
       if (visAreaRef.current && !readOnly) {
         d3.select(visAreaRef.current)
           .append('text')
-          .attr('class', 'ScatterPlot__emptyData')
+          .classed('ScatterPlot__emptyData', true)
           .text('No Data');
       }
       return;

--- a/aim/web/ui/src/config/charts/index.ts
+++ b/aim/web/ui/src/config/charts/index.ts
@@ -1,3 +1,5 @@
+export const RENDER_LINES_OPTIMIZED_LIMIT = 100;
+
 export const GRID_SIZE = {
   S: 4,
   M: 6,
@@ -6,7 +8,7 @@ export const GRID_SIZE = {
 
 const { S, M, L } = GRID_SIZE;
 // Chart grid pattern based on a 12-column grid layout
-const CHART_GRID_PATTERN: { [key: number]: number[] } = {
+export const CHART_GRID_PATTERN: { [key: number]: number[] } = {
   1: [L],
   2: [M, M],
   3: [S, S, S],
@@ -17,5 +19,3 @@ const CHART_GRID_PATTERN: { [key: number]: number[] } = {
   8: [S, S, S, S, S, S, M, M],
   9: [S, S, S, S, S, S, S, S, S],
 };
-
-export default CHART_GRID_PATTERN;

--- a/aim/web/ui/src/config/dash-arrays/dashArrays.ts
+++ b/aim/web/ui/src/config/dash-arrays/dashArrays.ts
@@ -1,5 +1,5 @@
 const DASH_ARRAYS: string[] = [
-  '5 0',
+  'none',
   '5 5',
   '10 5 5 5',
   '10 5 5 5 5 5',

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -984,7 +984,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
               ...trace,
               run: createRunModel(_.omit(run, 'traces') as IRun<IMetricTrace>),
               key: metricKey,
-              dasharray: '0',
+              dasharray: 'none',
               color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
               isHidden: configData?.table?.hiddenMetrics!.includes(metricKey),
               data: {

--- a/aim/web/ui/src/utils/app/getAggregatedData.ts
+++ b/aim/web/ui/src/utils/app/getAggregatedData.ts
@@ -34,7 +34,7 @@ export default function getAggregatedData<M extends State>({
       color:
         metricsCollection.color ||
         COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-      dasharray: metricsCollection.dasharray || '0',
+      dasharray: metricsCollection.dasharray || 'none',
     });
   });
 

--- a/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
@@ -11,10 +11,7 @@ import {
   ISyncHoverStateArgs,
 } from 'types/utils/d3/drawHoverAttributes';
 import { IAxisScale } from 'types/utils/d3/getAxisScale';
-import {
-  ILine,
-  IUpdateFocusedChartArgs,
-} from 'types/components/LineChart/LineChart';
+import { IUpdateFocusedChartArgs } from 'types/components/LineChart/LineChart';
 
 import { AggregationAreaMethods } from 'utils/aggregateGroupData';
 import getRoundedValue from 'utils/roundValue';

--- a/aim/web/ui/src/utils/d3/drawParallelLines.ts
+++ b/aim/web/ui/src/utils/d3/drawParallelLines.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, isNil } from 'lodash-es';
+import _ from 'lodash-es';
 
 import {
   IDrawParallelLinesArgs,
@@ -35,6 +35,7 @@ function drawParallelLines({
     return;
   }
   const keysOfDimensions: string[] = Object.keys(dimensions);
+
   linesRenderer({
     index,
     nameKey,
@@ -45,6 +46,7 @@ function drawParallelLines({
     attributesRef,
     isVisibleColorIndicator,
   });
+
   linesRef.current.updateLines = function (updatedData: ILineDataType[]) {
     linesNodeRef.current?.selectAll('*')?.remove();
     attributesNodeRef.current?.selectAll('*')?.remove();
@@ -72,16 +74,18 @@ function linesRenderer({
   isVisibleColorIndicator,
 }: ILineRendererArgs) {
   data.forEach(({ values: line, key, color, dasharray }: ILineDataType) => {
-    const arrayOfPathData: InitialPathDataType[] = [cloneDeep(initialPathData)];
+    const arrayOfPathData: InitialPathDataType[] = [
+      _.cloneDeep(initialPathData),
+    ];
     let pathDataArrayIndex: number = 0;
     for (let i = 0; i < keysOfDimensions.length; i++) {
       const keyOfDimension: string = keysOfDimensions[i];
-      if (isNil(line[keyOfDimension])) {
+      if (_.isNil(line[keyOfDimension])) {
         if (i === 0) continue;
         let nextStep: number = 1;
         while (
           keysOfDimensions[i + nextStep] &&
-          isNil(line[keysOfDimensions[i + nextStep]])
+          _.isNil(line[keysOfDimensions[i + nextStep]])
         ) {
           nextStep++;
         }
@@ -103,7 +107,8 @@ function linesRenderer({
             isEmpty: false,
             isDotted: true,
           };
-          arrayOfPathData[pathDataArrayIndex + 2] = cloneDeep(initialPathData);
+          arrayOfPathData[pathDataArrayIndex + 2] =
+            _.cloneDeep(initialPathData);
           pathDataArrayIndex = pathDataArrayIndex + 2;
         }
         i = i + nextStep - 1;
@@ -159,6 +164,7 @@ function drawParallelLine({
   if (!linesNodeRef.current) {
     return;
   }
+
   linesNodeRef.current
     .append('path')
     .lower()

--- a/aim/web/ui/src/utils/d3/processLineChartData.ts
+++ b/aim/web/ui/src/utils/d3/processLineChartData.ts
@@ -57,7 +57,7 @@ function processLineChartData({
 
     tupleLineChartData.push({
       color: '#000',
-      dasharray: '0',
+      dasharray: 'none',
       ...line,
       data: tupleData,
     });


### PR DESCRIPTION
- use `shape-rendering: optimizeSpeed` CSS property in HighPlot and LineChart components when the display is small with high `dpi` and  the lines count is more than `limit`
- replace meaningless `stroke-dasharray: '5 0'` to `stroke-dasharray: 'none'` which is default value to improve rendering