### PR TITLE
[fix] ToRem method in Calc method crush the ui

### DIFF
--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -133,7 +133,7 @@
     }
     &__tabPanel {
       overflow-y: auto;
-      height: calc(100vh - ToRem(98px));
+      height: calc(100vh - 98px);
       .MuiBox-root {
         height: 100%;
         .runDetailParamsTabLoader {


### PR DESCRIPTION
Sass `toRem` method used in css `calc` method crashed the ui