### PR TITLE
[fix] Params/Scatters explorers' row hiding functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `Notes Tab` to single run page (arsengit)
 - Add the run name to the batch delete and the batch archive modals (VkoHov)
 - Increase the scalability of rendering lines in charts (KaroMourad)
-- Increase live update requests delay to prevent performance issues  (rubenaprikyan)
+- Increase live update requests delay to prevent performance issues (rubenaprikyan)
 - Change font-family to monospace in the Table component (arsengit)
 - Add info massage for single value sliders (VkoHov)
 - Add `--log-level` argument for aim up/server commands (mihran113)
@@ -21,8 +21,9 @@
 - Fix compatibility with pytorch-lightning v1.6.0 (mihran113)
 - Fix the image's original size cropping (VkoHov)
 - Fix `PATH` related issues for `alembic` and `uvicorn` (mihran113)
-- Fix queries for custom object APIs (mihran113) 
+- Fix queries for custom object APIs (mihran113)
 - Fix chart height updating when resize mode changed (VkoHov)
+- Fix Params/Scatters explorers' row hiding functionality (VkoHov)
 
 ## 3.8.1 Apr 6, 2022
 

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -4055,11 +4055,12 @@ function createAppModel(appConfig: IAppInitialConfig) {
               [contextToString(trace.context) as string]: '-',
             };
           });
+          const paramKey = encode({ runHash: run.hash });
           runs.push({
             run,
-            isHidden: configData!.table.hiddenMetrics!.includes(run.hash),
+            isHidden: configData!.table.hiddenMetrics!.includes(paramKey),
             color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-            key: encode({ runHash: run.hash }),
+            key: paramKey,
             dasharray: DASH_ARRAYS[0],
           });
         });
@@ -5203,12 +5204,12 @@ function createAppModel(appConfig: IAppInitialConfig) {
               [contextToString(trace.context) as string]: '-',
             };
           });
-
+          const paramKey = encode({ runHash: run.hash });
           runs.push({
             run,
-            isHidden: configData!.table.hiddenMetrics!.includes(run.hash),
+            isHidden: configData!.table.hiddenMetrics!.includes(paramKey),
             color: COLORS[paletteIndex][index % COLORS[paletteIndex].length],
-            key: encode({ runHash: run.hash }),
+            key: paramKey,
             dasharray: DASH_ARRAYS[0],
           });
         });

--- a/aim/web/ui/src/utils/d3/drawArea.ts
+++ b/aim/web/ui/src/utils/d3/drawArea.ts
@@ -67,7 +67,6 @@ function drawArea(args: IDrawAreaArgs): void {
     .attr('id', `${nameKey}-svg-area-${index}`)
     .attr('width', `${width}px`)
     .attr('height', `${height}px`)
-    .attr('pointer-events', 'all')
     .attr('xmlns', 'http://www.w3.org/2000/svg')
     .style('fill', 'transparent');
 


### PR DESCRIPTION
- Replaced run hush with encoded key.
- Remove needless `pointer-events: all` from the area drawing method.