### PR TITLE
[fix] LineChart y-dimension margin calculation for negative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes:
 
+- Fix LineChart y-dimension margin calculation (KaroMourad)
 - Fix HighPlot lines partially rendering issue (KaroMourad)
 - Fix HighPlot axis ticks overlapping issue (KaroMourad)
 - Fix sorting Params/Scatters explorer axis ticks (KaroMourad)

--- a/aim/web/ui/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui/src/components/LineChart/LineChart.tsx
@@ -130,6 +130,10 @@ const LineChart = React.forwardRef(function LineChart(
           .append('text')
           .classed('LineChart__emptyData', true)
           .text('No Data');
+
+        if (attributesRef.current?.clearHoverAttributes) {
+          attributesRef.current.clearHoverAttributes();
+        }
       }
       return;
     }

--- a/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
+++ b/aim/web/ui/src/components/ScatterPlot/ScatterPlot.tsx
@@ -97,6 +97,10 @@ const ScatterPlot = React.forwardRef(function ScatterPlot(
           .append('text')
           .classed('ScatterPlot__emptyData', true)
           .text('No Data');
+
+        if (attributesRef.current?.clearHoverAttributes) {
+          attributesRef.current.clearHoverAttributes();
+        }
       }
       return;
     }

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -612,6 +612,7 @@ function createAppModel(appConfig: IAppInitialConfig) {
         p: configData?.chart?.densityType,
         ...(metric ? { x_axis: metric } : {}),
       });
+
       return {
         call: async () => {
           if (query === '()') {

--- a/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { isEqual } from 'lodash-es';
+import _ from 'lodash-es';
 
 import { HighlightEnum } from 'components/HighlightModesPopover/HighlightModesPopover';
 
@@ -136,7 +136,13 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       }
       const xValueByIndex = line.data.xValues[index];
       const yValueByIndex = line.data.yValues[index];
-      if (xValueByIndex !== '-' && yValueByIndex !== '-') {
+
+      if (
+        !_.isNil(xValueByIndex) &&
+        !_.isNil(yValueByIndex) &&
+        xValueByIndex !== '-' &&
+        yValueByIndex !== '-'
+      ) {
         const closestXPos = attributesRef.current.xScale(xValueByIndex) || 0;
         const closestYPos = attributesRef.current.yScale(yValueByIndex) || 0;
         const circle = {
@@ -146,8 +152,6 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
           y: closestYPos,
         };
         nearestCircles.push(circle);
-      } else {
-        safeSyncHoverState({ activePoint: null });
       }
     }
 
@@ -602,7 +606,7 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       circle.key !== attributesRef.current.activePoint?.key ||
       circle.x !== attributesRef.current.activePoint?.xPos ||
       circle.y !== attributesRef.current.activePoint?.yPos ||
-      !isEqual(attributesRef.current.nearestCircles, nearestCircles)
+      !_.isEqual(attributesRef.current.nearestCircles, nearestCircles)
     ) {
       setCirclesHighlightMode();
       drawCircles(nearestCircles);

--- a/aim/web/ui/src/utils/d3/processLineChartData.ts
+++ b/aim/web/ui/src/utils/d3/processLineChartData.ts
@@ -49,7 +49,6 @@ function processLineChartData({
     // supposed received x values are sorted by ascending order (y values are sorted by x)
     allXValues = allXValues.concat(xSyncedValues);
     allYValues = allYValues.concat(ySyncedValues);
-
     // find y bounds for lines to ignore "acceptable" outliers
     if (ignoreOutliers) {
       yBounds = yBounds.concat(minMaxOfArray(removeOutliers(yValues, 4)));
@@ -82,20 +81,18 @@ function processLineChartData({
     }
   }
 
-  let [yMin, yMax] = minMaxOfArray(
+  let [yMin = 0, yMax = 0] = minMaxOfArray(
     ignoreOutliers ? yBounds : _.uniq(allYValues),
   );
   let [xMin, xMax] = minMaxOfArray(_.uniq(allXValues));
 
-  // ADD margins for [yMin, yMax]
-  if (yMax === yMin) {
-    yMax += 1;
-    yMin -= 1;
-  } else {
-    const diff = yMax - yMin;
-    yMax += diff * 0.1;
-    yMin -= (diff * 0.05 >= yMin ? yMin : diff) * 0.05;
-  }
+  // ADD margin for y-dimension
+  const diff = yMax - yMin;
+  const portion = 0.05;
+  const yMargin = yMax !== yMin ? diff * portion : 1;
+  yMax += yMargin;
+  yMin -=
+    axesScaleType.yAxis === ScaleEnum.Log && yMin <= yMargin ? 0 : yMargin;
 
   const { width, height, margin } = visBoxRef.current;
 

--- a/aim/web/ui/src/utils/minMaxOfArray.ts
+++ b/aim/web/ui/src/utils/minMaxOfArray.ts
@@ -1,4 +1,7 @@
 export function minMaxOfArray(arr: number[]): number[] {
+  if (arr.length === 0) {
+    return [];
+  }
   let max: number = arr[0];
   let min: number = arr[0];
   for (let i = 1; i < arr.length; i++) {

--- a/aim/web/ui/src/utils/smoothingData.ts
+++ b/aim/web/ui/src/utils/smoothingData.ts
@@ -9,7 +9,7 @@ export function calculateExponentialMovingAverage(
   data: number[],
   smoothFactor: number,
 ): number[] {
-  const smoothedData = [data[0]];
+  const smoothedData = data.length ? [data[0]] : [];
   for (let i = 1; i < data.length; i++) {
     smoothedData.push(
       smoothedData[i - 1] * smoothFactor + data[i] * (1 - smoothFactor),


### PR DESCRIPTION
Fix: 
- margin calculation for negative and small values [0, 1]
- smoothing algorithm when empty `y` and `x` values 