### PR TITLE
[fix] AimLogger deprecation issue with PyTorch Lightning v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Rename `PrefixView.container` to `PrefixView.parent` (mahnerak)
 - Reimplement `absolute_path` (mahnerak)
 - Cython bindings for `PrefixView`, `TreeView`, `Container`, `ArrayView` (mahnerak)
+- Fix `AimLogger` deprecation issues related to release of PyTorch Lightning v1.5 (arnauddhaene)
 
 ### Fixes:
 

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -117,15 +117,15 @@ class AimLogger(LightningLoggerBase):
             self.experiment.track(v, name=name, step=step, context=context)
 
     @rank_zero_only
-    def close(self) -> None:
-        super().close()
+    def finalize(self) -> None:
+        super().finalize()
         if self._run:
-            self._run.close()
+            self._run.finalize()
             del self._run
             self._run = None
 
     def __del__(self):
-        self.close()
+        self.finalize()
 
     @property
     def save_dir(self) -> str:

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -120,7 +120,7 @@ class AimLogger(LightningLoggerBase):
     def finalize(self) -> None:
         super().finalize()
         if self._run:
-            self._run.finalize()
+            self._run.close()
             del self._run
             self._run = None
 


### PR DESCRIPTION
switch from `LightningLoggerBase.close` (deprecated in PL v1.5) to `LightningLoggerBase.finalize`

Fixes issue #1742 