### PR TITLE
[feat] Add ability to adjust the density of the visible content in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements:
 
+- Add ability to adjust the density of the visible content in tables (roubkar)
 - Optimize stream decoding performance on UI (mahnerak)
 - Add support for animated image formats to Aim Image object (devfox-se)
 - Add `AimLogger` for Catboost (devfox-se)

--- a/aim/web/ui/src/components/CustomTable/Table.scss
+++ b/aim/web/ui/src/components/CustomTable/Table.scss
@@ -309,7 +309,7 @@ $border-radius: 0.2rem;
 
   &.Table__group__config__column__cell {
     border-right: none;
-    padding-left: 2.2rem;
+    padding-left: 2.1875rem;
 
     .Table__cell__rowMeta {
       display: flex;

--- a/aim/web/ui/src/components/CustomTable/Table.scss
+++ b/aim/web/ui/src/components/CustomTable/Table.scss
@@ -5,8 +5,9 @@ $box-shadow: 0 3px 9px rgba(0, 0, 0, 0.1);
 $border-radius: 0.2rem;
 
 :root {
-  --cell-height: 32px;
-  --group-margin: 6px;
+  --cell-height: 28px;
+  --group-margin: 4px;
+  --cell-font-size: 0.875rem;
 }
 
 .Table {
@@ -25,17 +26,20 @@ $border-radius: 0.2rem;
     box-sizing: border-box;
     background: #fff;
     &--small {
-      --cell-height: 28px;
-      --group-margin: 4px;
+      --cell-height: 22px;
+      --group-margin: 2px;
+      --cell-font-size: 0.75rem;
     }
     &--medium {
-      --cell-height: 32px;
-      --group-margin: 6px;
+      --cell-height: 28px;
+      --group-margin: 4px;
+      --cell-font-size: 0.875rem;
     }
 
     &--large {
-      --cell-height: 36px;
-      --group-margin: 8px;
+      --cell-height: 32px;
+      --group-margin: 6px;
+      --cell-font-size: 0.875rem;
     }
   }
   &__groupsColumn__cell {
@@ -153,6 +157,7 @@ $border-radius: 0.2rem;
   &.Table__column--actions {
     .Table__cell {
       padding: 0;
+      justify-content: center;
     }
   }
   &.Table__column--selection {
@@ -168,8 +173,8 @@ $border-radius: 0.2rem;
     }
   }
   &__selectCheckbox {
-    width: toRem(32px);
-    height: toRem(32px);
+    width: 32px;
+    height: var(--cell-height);
     border-radius: unset;
     padding: 0.5rem;
   }
@@ -253,7 +258,7 @@ $border-radius: 0.2rem;
 .Table__cell {
   display: flex;
   align-items: center;
-  font-size: $text-md;
+  font-size: var(--cell-font-size);
   padding: 0 $space-unit;
   border-bottom: 1px solid $border-color;
   border-right: 1px solid $border-color;
@@ -304,7 +309,7 @@ $border-radius: 0.2rem;
 
   &.Table__group__config__column__cell {
     border-right: none;
-    padding-left: toRem(39px);
+    padding-left: 2.2rem;
 
     .Table__cell__rowMeta {
       display: flex;
@@ -382,7 +387,7 @@ $border-radius: 0.2rem;
     margin-right: 0.25rem;
     &.Table__column__selectCheckbox {
       flex: unset;
-      margin-left: toRem(30px);
+      margin-left: calc(20px + var(--group-margin));
       margin-right: toRem(14px);
     }
   }

--- a/aim/web/ui/src/components/CustomTable/Table.tsx
+++ b/aim/web/ui/src/components/CustomTable/Table.tsx
@@ -284,6 +284,7 @@ function Table(props) {
                   onRowClick={props.onRowClick}
                   selectedRows={props.selectedRows}
                   firstColumn={true}
+                  rowHeightMode={props.rowHeightMode}
                   width={
                     color
                       ? COLORED_SELECTION_COLUMN_WIDTH
@@ -341,6 +342,7 @@ function Table(props) {
                     multiSelect={props.multiSelect}
                     paneFirstColumn={index === 0}
                     paneLastColumn={index === leftPane.length - 1}
+                    rowHeightMode={props.rowHeightMode}
                     moveColumn={(dir) =>
                       moveColumn(col.key, 'left', index, dir)
                     }
@@ -406,6 +408,7 @@ function Table(props) {
                     ) === -1
                   }
                   sortByColumn={(order) => props.onSort(col.sortableKey, order)}
+                  rowHeightMode={props.rowHeightMode}
                   onRowHover={props.onRowHover}
                   onRowClick={props.onRowClick}
                   columnOptions={col.columnOptions}
@@ -443,6 +446,7 @@ function Table(props) {
                     columnsColorScales={props.columnsColorScales}
                     updateColumnWidth={props.updateColumnsWidths}
                     headerMeta={props.headerMeta}
+                    rowHeightMode={props.rowHeightMode}
                     isAlwaysVisible={props.alwaysVisibleColumns?.includes(
                       col.key,
                     )}

--- a/aim/web/ui/src/components/CustomTable/Table.tsx
+++ b/aim/web/ui/src/components/CustomTable/Table.tsx
@@ -14,6 +14,7 @@ import {
   ROW_CELL_SIZE_CONFIG,
   COLORED_SELECTION_COLUMN_WIDTH,
   SELECTION_COLUMN_WIDTH,
+  RowHeightSize,
 } from 'config/table/tableConfigs';
 
 import Column from './TableColumn';
@@ -216,7 +217,8 @@ function Table(props) {
       <div
         className={classNames('Table__container', {
           [`Table__container--${
-            ROW_CELL_SIZE_CONFIG[props.rowHeightMode].name
+            ROW_CELL_SIZE_CONFIG[props.rowHeightMode]?.name ??
+            ROW_CELL_SIZE_CONFIG[RowHeightSize.md].name
           }`]: true,
         })}
       >

--- a/aim/web/ui/src/components/CustomTable/TableColumn.tsx
+++ b/aim/web/ui/src/components/CustomTable/TableColumn.tsx
@@ -262,7 +262,7 @@ function Column({
                     <div>
                       <Button
                         withOnlyIcon
-                        size='small'
+                        size='xSmall'
                         onClick={onAnchorClick}
                         color='secondary'
                       >
@@ -441,7 +441,8 @@ function Column({
                   style={
                     col.key === '#' && data[groupKey].data.meta.color
                       ? {
-                          borderLeft: 'none',
+                          borderTopLeftRadius: '0.375rem',
+                          borderBottomLeftRadius: '0.375rem',
                           '--color-indicator': data[groupKey].data.meta.color,
                           '--extended-group-background-color':
                             BGColorLighten[data[groupKey].data.meta.color] ??
@@ -689,9 +690,9 @@ function GroupConfig({
     <ErrorBoundary>
       <div className='Table__group__config' onClick={() => expand(groupKey)}>
         <Button
-          size='small'
-          withOnlyIcon={true}
+          size='xSmall'
           className='Table__group__config_expandButton'
+          withOnlyIcon={true}
         >
           <Text className='flex'>
             <Icon name={expanded[groupKey] ? 'arrow-up' : 'arrow-down'} />
@@ -747,7 +748,7 @@ function GroupConfig({
               >
                 <div>
                   <Button
-                    size='small'
+                    size='xSmall'
                     className='Table__group__config__popover'
                     onClick={onAnchorClick}
                     withOnlyIcon={true}
@@ -802,7 +803,12 @@ function GroupActions({ expand, expanded, groupKeys, groupKey }) {
         anchor={({ onAnchorClick }) => (
           <Tooltip title='Expand options'>
             <div>
-              <Button color='secondary' withOnlyIcon onClick={onAnchorClick}>
+              <Button
+                size='xSmall'
+                color='secondary'
+                withOnlyIcon
+                onClick={onAnchorClick}
+              >
                 <Icon
                   className='Table__action__anchor'
                   name='more-horizontal'

--- a/aim/web/ui/src/components/CustomTable/TableColumn.tsx
+++ b/aim/web/ui/src/components/CustomTable/TableColumn.tsx
@@ -16,6 +16,7 @@ import {
   VIEW_PORT_OFFSET,
   TABLE_COLUMN_START_COLOR_SCALE,
   TABLE_COLUMN_END_COLOR_SCALE,
+  RowHeightSize,
 } from 'config/table/tableConfigs';
 
 import getColorFromRange from 'utils/d3/getColorFromRange';
@@ -52,6 +53,7 @@ function Column({
   onRowSelect,
   onToggleColumnsColorScales,
   columnsColorScales,
+  rowHeightMode,
 }) {
   const [maxWidth, setMaxWidth] = React.useState(width);
   const [isResizing, setIsResizing] = React.useState(false);
@@ -202,7 +204,12 @@ function Column({
             }}
           >
             {showTopHeaderContent && col.topHeader && (
-              <Text component='p' tint={100} size={14} weight={600}>
+              <Text
+                component='p'
+                tint={100}
+                size={rowHeightMode === RowHeightSize.sm ? 12 : 14}
+                weight={600}
+              >
                 {col.topHeader}
               </Text>
             )}
@@ -242,7 +249,11 @@ function Column({
               checked={!_.isEmpty(selectedRows)}
             />
           )}
-          <Text tint={100} size={14} weigh={600}>
+          <Text
+            tint={100}
+            size={rowHeightMode === RowHeightSize.sm ? 12 : 14}
+            weigh={600}
+          >
             {firstColumn ? headerMeta : null}
             {col.content}
           </Text>

--- a/aim/web/ui/src/components/Table/Table.tsx
+++ b/aim/web/ui/src/components/Table/Table.tsx
@@ -405,7 +405,9 @@ const Table = React.forwardRef(function Table(
       offsetHeight: tableContainerRef.current.offsetHeight,
       scrollHeight: tableContainerRef.current.scrollHeight,
       itemHeight: rowHeight,
-      groupMargin: ROW_CELL_SIZE_CONFIG[rowHeight].groupMargin,
+      groupMargin:
+        ROW_CELL_SIZE_CONFIG[rowHeight]?.groupMargin ??
+        ROW_CELL_SIZE_CONFIG[RowHeightSize.md].groupMargin,
     });
 
     startIndex.current = windowEdges.startIndex;
@@ -515,7 +517,9 @@ const Table = React.forwardRef(function Table(
         offsetHeight: tableContainerRef.current.offsetHeight,
         scrollHeight: tableContainerRef.current.scrollHeight,
         itemHeight: rowHeight,
-        groupMargin: ROW_CELL_SIZE_CONFIG[rowHeight].groupMargin,
+        groupMargin:
+          ROW_CELL_SIZE_CONFIG[rowHeight]?.groupMargin ??
+          ROW_CELL_SIZE_CONFIG[RowHeightSize.md].groupMargin,
       });
 
       startIndex.current = windowEdges.startIndex;
@@ -529,7 +533,9 @@ const Table = React.forwardRef(function Table(
           offsetHeight: target.offsetHeight,
           scrollHeight: target.scrollHeight,
           itemHeight: rowHeight,
-          groupMargin: ROW_CELL_SIZE_CONFIG[rowHeight].groupMargin,
+          groupMargin:
+            ROW_CELL_SIZE_CONFIG[rowHeight]?.groupMargin ??
+            ROW_CELL_SIZE_CONFIG[RowHeightSize.md].groupMargin,
         });
 
         startIndex.current = windowEdges.startIndex;

--- a/aim/web/ui/src/components/kit/Badge/Badge.scss
+++ b/aim/web/ui/src/components/kit/Badge/Badge.scss
@@ -96,7 +96,7 @@
   }
 
   &__xSmall {
-    height: 1.25rem;
+    height: 1.125rem;
   }
   &__medium {
     height: 1.5rem;

--- a/aim/web/ui/src/components/kit/Button/Button.tsx
+++ b/aim/web/ui/src/components/kit/Button/Button.tsx
@@ -23,7 +23,7 @@ const fontSizes = {
 };
 
 const withOnlyIconSizes = {
-  xSmall: '0.75rem',
+  xSmall: '1.5rem',
   small: '1.75rem',
   medium: '2rem',
   large: '2.25rem',

--- a/aim/web/ui/src/components/kit/DataList/DataList.scss
+++ b/aim/web/ui/src/components/kit/DataList/DataList.scss
@@ -57,7 +57,7 @@
         position: relative;
         min-height: 28px;
         max-height: 300px;
-        padding: 0 toRem(16px);
+        padding: 0 $space-unit;
         border-right: unset;
         border-bottom: $border-grey;
         display: flex;

--- a/aim/web/ui/src/components/kit/DataList/DataList.scss
+++ b/aim/web/ui/src/components/kit/DataList/DataList.scss
@@ -55,9 +55,9 @@
 
       &-cell {
         position: relative;
-        min-height: 32px;
+        min-height: 28px;
         max-height: 300px;
-        padding: toRem(7px) toRem(16px);
+        padding: 0 toRem(16px);
         border-right: unset;
         border-bottom: $border-grey;
         display: flex;

--- a/aim/web/ui/src/components/kit/DataList/DataList.tsx
+++ b/aim/web/ui/src/components/kit/DataList/DataList.tsx
@@ -28,7 +28,7 @@ function DataList({
   withSearchBar = true,
   searchableKeys,
   illustrationConfig,
-  rowHeight = 32,
+  rowHeight = 28,
   height = '100vh',
   tableClassName = '',
 }: IDataListProps): React.FunctionComponentElement<React.ReactNode> {
@@ -105,8 +105,8 @@ function DataList({
             )}
             isLoading={isLoading}
             hideHeaderActions
-            estimatedRowHeight={32}
-            headerHeight={32}
+            estimatedRowHeight={rowHeight}
+            headerHeight={rowHeight}
             illustrationConfig={illustrationConfig}
             height='100%'
             disableRowClick

--- a/aim/web/ui/src/config/enums/tableEnums.ts
+++ b/aim/web/ui/src/config/enums/tableEnums.ts
@@ -1,7 +1,7 @@
 enum RowHeightEnum {
-  small = 28,
-  medium = 32,
-  large = 36,
+  small = 22,
+  medium = 28,
+  large = 32,
 }
 
 enum HideRowsEnum {

--- a/aim/web/ui/src/config/table/tableConfigs.ts
+++ b/aim/web/ui/src/config/table/tableConfigs.ts
@@ -4,22 +4,22 @@ export const TABLE_COLUMN_START_COLOR_SCALE = '#F8EF42';
 export const TABLE_COLUMN_END_COLOR_SCALE = '#0FD64F';
 
 export enum RowHeightSize {
-  sm = 28,
-  md = 32,
-  lg = 36,
+  sm = 22,
+  md = 28,
+  lg = 32,
 }
 
 export const ROW_CELL_SIZE_CONFIG = {
+  22: {
+    groupMargin: 2,
+    name: 'small',
+  },
   28: {
     groupMargin: 4,
-    name: 'small',
+    name: 'medium',
   },
   32: {
     groupMargin: 6,
-    name: 'medium',
-  },
-  36: {
-    groupMargin: 8,
     name: 'large',
   },
 };

--- a/aim/web/ui/src/pages/ImagesExplore/components/ImagesExploreTableGrid/ImagesExploreTableGrid.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/ImagesExploreTableGrid/ImagesExploreTableGrid.tsx
@@ -240,14 +240,14 @@ function imagesExploreTableRowRenderer(
             rowData.context.length > 1 ? (
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={`${rowData.context.length} values`}
               />
             ) : (
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={rowData.context[0] || 'Empty Context'}
               />
@@ -315,7 +315,7 @@ function imagesExploreTableRowRenderer(
           content: (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={`${rowData[col].length} values`}
             />
@@ -344,14 +344,14 @@ function imagesExploreTableRowRenderer(
           rowData.context.length > 1 ? (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={`${rowData.context.length} values`}
             />
           ) : (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={rowData.context[0] || 'Empty Context'}
             />

--- a/aim/web/ui/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/MetricsTableGrid/MetricsTableGrid.tsx
@@ -378,7 +378,7 @@ function metricsTableRowRenderer(
             Array.isArray(rowData.metric) && rowData.metric.length > 1 ? (
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={`${rowData.context.length} values`}
               />
@@ -392,14 +392,14 @@ function metricsTableRowRenderer(
             rowData.context.length > 1 ? (
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={`${rowData.context.length} values`}
               />
             ) : (
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={rowData.context[0] || 'Empty Context'}
               />
@@ -475,7 +475,7 @@ function metricsTableRowRenderer(
           content: (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={`${rowData[col].length} values`}
             />
@@ -506,7 +506,7 @@ function metricsTableRowRenderer(
           <Badge
             monospace
             key={item}
-            size='small'
+            size='xSmall'
             color={COLORS[0][0]}
             label={item || 'Empty Context'}
           />

--- a/aim/web/ui/src/pages/Metrics/components/Table/RowHeightPopover/RowHeightPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/RowHeightPopover/RowHeightPopover.tsx
@@ -22,7 +22,7 @@ function RowHeightPopover({ rowHeight, onRowHeightChange, appName }: any) {
   return (
     <ErrorBoundary>
       <ControlPopover
-        title='Select Table Row Height'
+        title='Select Content Density Mode'
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',
@@ -52,19 +52,13 @@ function RowHeightPopover({ rowHeight, onRowHeightChange, appName }: any) {
               selected={rowHeight === RowHeightSize.sm}
               onClick={() => onRowHeightChange(RowHeightSize.sm)}
             >
-              Small
+              Compact
             </MenuItem>
             <MenuItem
               selected={rowHeight === RowHeightSize.md}
               onClick={() => onRowHeightChange(RowHeightSize.md)}
             >
-              Medium
-            </MenuItem>
-            <MenuItem
-              selected={rowHeight === RowHeightSize.lg}
-              onClick={() => onRowHeightChange(RowHeightSize.lg)}
-            >
-              Large
+              Normal
             </MenuItem>
           </div>
         }

--- a/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Params/components/ParamsTableGrid/ParamsTableGrid.tsx
@@ -175,7 +175,7 @@ function getParamsTableColumns(
           ) : (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={metricContext === '' ? 'Empty context' : metricContext}
             />
@@ -391,7 +391,7 @@ function paramsTableRowRenderer(
             <ErrorBoundary>
               <Badge
                 monospace
-                size='small'
+                size='xSmall'
                 color={COLORS[0][0]}
                 label={`${rowData[col].length} values`}
               />

--- a/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
@@ -84,7 +84,7 @@ function getRunsTableColumns(
           ) : (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={metricContext === '' ? 'Empty context' : metricContext}
             />
@@ -158,7 +158,7 @@ function runsTableRowRenderer(
           content: (
             <Badge
               monospace
-              size='small'
+              size='xSmall'
               color={COLORS[0][0]}
               label={`${rowData[col].length} values`}
             />


### PR DESCRIPTION
Following changes provide the ability to control the content density in Explorer tables

- Change row height sizes
- Rename row height modes names
- Decrease font size for compact mode
- Decrease `Badge` height for `xSmall` size