### PR TITLE
[fix] Preserve the search input value of the grouping dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Change zooming default option to multiple (VkoHov)
 - Changed grouped rows' min and max values names to `Group Min` and `Group Max` (VkoHov)
+- Preserve the search input value of the grouping dropdown (VkoHov)
 
 ## 3.10.1 May 18, 2022
 

--- a/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
+++ b/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
@@ -37,7 +37,6 @@ function GroupingPopover({
   function onChange(e: any, values: IGroupingSelectOption[]): void {
     if (e?.code !== 'Backspace') {
       handleSelect(values);
-      setInputValue('');
     } else {
       if (inputValue.length === 0) {
         handleSelect(values);


### PR DESCRIPTION
Preserve the search input value of the grouping dropdown