### PR TITLE
[fix] Changed the titles and placeholders in popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Change zooming default option to multiple (VkoHov)
 - Changed grouped rows' min and max values names to `Group Min` and `Group Max` (VkoHov)
 - Preserve the search input value of the grouping dropdown (VkoHov)
-- Fix params duplication in dropdowns (VkoHov)
+- Change the titles and placeholders in popovers (VkoHov)
 
 ## 3.10.1 May 18, 2022
 

--- a/aim/web/ui/src/components/AttachedTagsList/AttachedTagsList.scss
+++ b/aim/web/ui/src/components/AttachedTagsList/AttachedTagsList.scss
@@ -55,7 +55,6 @@
   }
 
   &__ControlPopover__title {
-    text-transform: uppercase;
     color: $pico-50;
     background: inherit;
     font-weight: 500;

--- a/aim/web/ui/src/components/ControlPopover/ControlPopover.scss
+++ b/aim/web/ui/src/components/ControlPopover/ControlPopover.scss
@@ -37,5 +37,4 @@
   padding: 0.5rem 1rem;
   border-bottom: $border-main;
   background: $primary-color-5;
-  text-transform: capitalize;
 }

--- a/aim/web/ui/src/components/ControlPopover/ControlPopover.tsx
+++ b/aim/web/ui/src/components/ControlPopover/ControlPopover.tsx
@@ -65,6 +65,7 @@ function ControlPopover({
               onClick={stopPropagation}
               className={`ControlPopover__title ${titleClassName}`}
             >
+              {console.log(title)}
               <Text component='h3' size={14} weight={700} tint={100}>
                 {title}
               </Text>

--- a/aim/web/ui/src/components/Grouping/Grouping.scss
+++ b/aim/web/ui/src/components/Grouping/Grouping.scss
@@ -2,8 +2,19 @@
 
 .Grouping {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: space-between;
   border-left: $border-main;
-  padding: 0 1.5em;
+  padding: toRem(7px) 1.5rem toRem(11px);
+  &__title {
+    .Text {
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+  }
+  &__content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }

--- a/aim/web/ui/src/components/Grouping/Grouping.tsx
+++ b/aim/web/ui/src/components/Grouping/Grouping.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+import { Text } from 'components/kit';
 
 import GroupingPopovers from 'config/grouping/GroupingPopovers';
 
@@ -26,44 +27,51 @@ function Grouping({
   return (
     <ErrorBoundary>
       <div className='Grouping'>
-        {groupingPopovers.map(
-          ({ title, groupName, AdvancedComponent, inputLabel }) => {
-            return (
-              <GroupingItem
-                key={groupName}
-                title={title}
-                inputLabel={inputLabel}
-                groupName={groupName as GroupNameType}
-                groupingData={groupingData}
-                groupingSelectOptions={groupingSelectOptions}
-                onSelect={onGroupingSelectChange}
-                onGroupingModeChange={onGroupingModeChange}
-                advancedComponent={
-                  AdvancedComponent && (
-                    <AdvancedComponent
-                      groupingData={groupingData}
-                      onPersistenceChange={onGroupingPersistenceChange}
-                      persistence={
-                        groupingData?.persistence[
-                          groupName as 'color' | 'stroke'
-                        ]
-                      }
-                      onShuffleChange={onShuffleChange}
-                      {...(groupName === 'color' && {
-                        onGroupingPaletteChange,
-                        paletteIndex: groupingData?.paletteIndex,
-                      })}
-                    />
-                  )
-                }
-                onReset={() => onGroupingReset(groupName as GroupNameType)}
-                onVisibilityChange={() =>
-                  onGroupingApplyChange(groupName as GroupNameType)
-                }
-              />
-            );
-          },
-        )}
+        <div className='Grouping__title'>
+          <Text size={12} weight={600}>
+            Group by
+          </Text>
+        </div>
+        <div className='Grouping__content'>
+          {groupingPopovers.map(
+            ({ title, inputLabel, groupName, AdvancedComponent }) => {
+              return (
+                <GroupingItem
+                  key={groupName}
+                  title={title}
+                  inputLabel={inputLabel}
+                  groupName={groupName as GroupNameType}
+                  groupingData={groupingData}
+                  groupingSelectOptions={groupingSelectOptions}
+                  onSelect={onGroupingSelectChange}
+                  onGroupingModeChange={onGroupingModeChange}
+                  advancedComponent={
+                    AdvancedComponent && (
+                      <AdvancedComponent
+                        groupingData={groupingData}
+                        onPersistenceChange={onGroupingPersistenceChange}
+                        persistence={
+                          groupingData?.persistence[
+                            groupName as 'color' | 'stroke'
+                          ]
+                        }
+                        onShuffleChange={onShuffleChange}
+                        {...(groupName === 'color' && {
+                          onGroupingPaletteChange,
+                          paletteIndex: groupingData?.paletteIndex,
+                        })}
+                      />
+                    )
+                  }
+                  onReset={() => onGroupingReset(groupName as GroupNameType)}
+                  onVisibilityChange={() =>
+                    onGroupingApplyChange(groupName as GroupNameType)
+                  }
+                />
+              );
+            },
+          )}
+        </div>
       </div>
     </ErrorBoundary>
   );

--- a/aim/web/ui/src/components/Grouping/Grouping.tsx
+++ b/aim/web/ui/src/components/Grouping/Grouping.tsx
@@ -27,12 +27,12 @@ function Grouping({
     <ErrorBoundary>
       <div className='Grouping'>
         {groupingPopovers.map(
-          ({ title, advancedTitle, groupName, AdvancedComponent }) => {
+          ({ title, groupName, AdvancedComponent, inputLabel }) => {
             return (
               <GroupingItem
                 key={groupName}
                 title={title}
-                advancedTitle={advancedTitle}
+                inputLabel={inputLabel}
                 groupName={groupName as GroupNameType}
                 groupingData={groupingData}
                 groupingSelectOptions={groupingSelectOptions}

--- a/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
@@ -21,13 +21,11 @@ function GroupingItem({
   title,
   groupName,
   groupingData,
-  advancedTitle,
+  inputLabel,
   advancedComponent,
   onSelect,
   onGroupingModeChange,
   groupingSelectOptions,
-  onReset,
-  onVisibilityChange,
 }: IGroupingItemProps): React.FunctionComponentElement<React.ReactNode> {
   return (
     <ErrorBoundary>
@@ -51,6 +49,7 @@ function GroupingItem({
         component={
           <GroupingPopover
             groupName={groupName}
+            inputLabel={inputLabel}
             groupingData={groupingData}
             groupingSelectOptions={groupingSelectOptions}
             advancedComponent={advancedComponent}

--- a/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
@@ -13,7 +13,7 @@ import './GroupingItem.scss';
 const icons = {
   stroke: 'line-style',
   chart: 'chart-group',
-  group: 'image-group',
+  row: 'image-group',
   color: 'coloring',
 };
 

--- a/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import _ from 'lodash-es';
+
+import { Tooltip } from '@material-ui/core';
 
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import GroupingPopover from 'components/GroupingPopover/GroupingPopover';
-import { Icon, Text } from 'components/kit';
+import { Icon } from 'components/kit';
 import { IconName } from 'components/kit/Icon';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
@@ -32,19 +35,20 @@ function GroupingItem({
       <ControlPopover
         title={title}
         anchor={({ onAnchorClick, opened }) => (
-          <div onClick={onAnchorClick} className={'GroupingItem'}>
-            <div
-              className={`GroupingItem__icon__box ${opened ? 'active' : ''} ${
-                groupingSelectOptions?.length &&
-                groupingData?.[groupName]?.length
-                  ? 'outlined'
-                  : ''
-              }`}
-            >
-              <Icon name={icons[groupName] as IconName} />
+          <Tooltip title={`Group by ${groupName}`}>
+            <div onClick={onAnchorClick} className={'GroupingItem'}>
+              <div
+                className={`GroupingItem__icon__box ${opened ? 'active' : ''} ${
+                  groupingSelectOptions?.length &&
+                  groupingData?.[groupName]?.length
+                    ? 'outlined'
+                    : ''
+                }`}
+              >
+                <Icon name={icons[groupName] as IconName} />
+              </div>
             </div>
-            <Text>{groupName}</Text>
-          </div>
+          </Tooltip>
         )}
         component={
           <GroupingPopover

--- a/aim/web/ui/src/components/GroupingPopover/GroupingPopover.scss
+++ b/aim/web/ui/src/components/GroupingPopover/GroupingPopover.scss
@@ -9,6 +9,11 @@
 
   &__container__select {
     padding: 1rem;
+    &__selectedFieldsContainer {
+      max-height: 110px;
+      overflow: auto;
+      width: 100%;
+    }
   }
 
   &__toggleMode__div {

--- a/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
+++ b/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
@@ -31,6 +31,7 @@ function GroupingPopover({
   groupingSelectOptions,
   onSelect,
   onGroupingModeChange,
+  inputLabel,
 }: IGroupingPopoverProps): React.FunctionComponentElement<React.ReactNode> {
   const [inputValue, setInputValue] = React.useState('');
 
@@ -108,7 +109,7 @@ function GroupingPopover({
               component='h3'
               className='GroupingPopover__subtitle'
             >
-              Select Fields for grouping by {groupName}
+              {inputLabel ?? `Select Fields for grouping by ${groupName}`}
             </Text>
             <Autocomplete
               size='small'
@@ -132,6 +133,7 @@ function GroupingPopover({
                       setInputValue(e.target?.value);
                     },
                   }}
+                  className='TextField__OutLined__Small'
                   variant='outlined'
                   placeholder='Select Fields'
                 />

--- a/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
+++ b/aim/web/ui/src/components/GroupingPopover/GroupingPopover.tsx
@@ -133,11 +133,11 @@ function GroupingPopover({
                     },
                   }}
                   variant='outlined'
-                  placeholder='Select Params'
+                  placeholder='Select Fields'
                 />
               )}
               renderTags={(value, getTagProps) => (
-                <div style={{ maxHeight: 110, overflow: 'auto' }}>
+                <div className='GroupingPopover__container__select__selectedFieldsContainer'>
                   {value.map((selected, i) => (
                     <Badge
                       key={i}

--- a/aim/web/ui/src/components/TooltipContentPopover/TooltipContentPopover.tsx
+++ b/aim/web/ui/src/components/TooltipContentPopover/TooltipContentPopover.tsx
@@ -95,7 +95,7 @@ function TooltipContentPopover({
             tint={50}
             className='TooltipContentPopover__subtitle'
           >
-            Parameters
+            Select Fields To Display In The Tooltip
           </Text>
           <Autocomplete
             id='select-params'
@@ -119,7 +119,7 @@ function TooltipContentPopover({
                   },
                 }}
                 variant='outlined'
-                placeholder='Select Params'
+                placeholder='Select Fields'
               />
             )}
             renderOption={(option, { selected }) => (

--- a/aim/web/ui/src/components/TooltipContentPopover/TooltipContentPopover.tsx
+++ b/aim/web/ui/src/components/TooltipContentPopover/TooltipContentPopover.tsx
@@ -118,6 +118,7 @@ function TooltipContentPopover({
                     setInputValue(e.target.value);
                   },
                 }}
+                className='TextField__OutLined__Small'
                 variant='outlined'
                 placeholder='Select Fields'
               />

--- a/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
+++ b/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
@@ -204,7 +204,7 @@ export const ANALYTICS_EVENT_KEYS = {
         '[ImagesExplorer][Table] Change metric visibility',
     },
     groupings: {
-      group: {
+      row: {
         modeChange: '[ImagesExplorer][Grouping][Group] mode change to reverse', //to reverse
         select: '[ImagesExplorer][Grouping][Group] Select group',
       },

--- a/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
+++ b/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
@@ -43,7 +43,7 @@ export const ANALYTICS_EVENT_KEYS = {
           changeTooltipContent:
             '[MetricsExplorer][Chart][Controls] Change tooltip content',
         },
-        exportChart: '[MetricsExplorer][Chart][Controls] Export Chart as Image',
+        exportChart: '[MetricsExplorer][Chart][Controls] Export chart as Image',
       },
     },
     groupings: {
@@ -166,7 +166,7 @@ export const ANALYTICS_EVENT_KEYS = {
             '[ScattersExplorer][Chart][Controls] Change tooltip content',
         },
         exportChart:
-          '[ScattersExplorer][Chart][Controls] Export Chart as Image',
+          '[ScattersExplorer][Chart][Controls] Export chart as Image',
       },
     },
     groupings: {

--- a/aim/web/ui/src/config/grouping/GroupingPopovers.ts
+++ b/aim/web/ui/src/config/grouping/GroupingPopovers.ts
@@ -7,23 +7,21 @@ const GroupingPopovers: IGroupingPopovers[] = [
   {
     groupName: 'color',
     title: 'Run Color Settings',
-    advancedTitle: 'Color Advanced Options',
     AdvancedComponent: ColorPopoverAdvanced,
   },
   {
     groupName: 'stroke',
     title: 'Select Fields For Grouping by stroke style',
-    advancedTitle: 'stroke style advanced options',
     AdvancedComponent: StrokePopoverAdvanced,
   },
   {
     groupName: 'chart',
     title: 'Select fields to divide into charts',
+    inputLabel: 'Select fields to divide into charts',
   },
   {
     groupName: 'row',
-    title: 'Select Fields For Grouping',
-    advancedTitle: 'Select Fields For Grouping',
+    title: 'Select Fields For Grouping By Row',
   },
 ];
 

--- a/aim/web/ui/src/config/grouping/GroupingPopovers.ts
+++ b/aim/web/ui/src/config/grouping/GroupingPopovers.ts
@@ -6,22 +6,22 @@ import { IGroupingPopovers } from 'types/pages/components/Grouping/Grouping';
 const GroupingPopovers: IGroupingPopovers[] = [
   {
     groupName: 'color',
-    title: 'Run Color Settings',
+    title: 'Group by color',
     AdvancedComponent: ColorPopoverAdvanced,
   },
   {
     groupName: 'stroke',
-    title: 'Select Fields For Grouping by stroke style',
+    title: 'Group by stroke style',
     AdvancedComponent: StrokePopoverAdvanced,
   },
   {
     groupName: 'chart',
-    title: 'Select fields to divide into charts',
+    title: 'Divide into charts',
     inputLabel: 'Select fields to divide into charts',
   },
   {
     groupName: 'row',
-    title: 'Select Fields For Grouping By Row',
+    title: 'Group by row',
   },
 ];
 

--- a/aim/web/ui/src/config/grouping/GroupingPopovers.ts
+++ b/aim/web/ui/src/config/grouping/GroupingPopovers.ts
@@ -21,7 +21,7 @@ const GroupingPopovers: IGroupingPopovers[] = [
     title: 'Select fields to divide into charts',
   },
   {
-    groupName: 'group',
+    groupName: 'row',
     title: 'Select Fields For Grouping',
     advancedTitle: 'Select Fields For Grouping',
   },

--- a/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
@@ -92,8 +92,8 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
       return { sortFieldsDict: {}, sortFields: [] };
     }
     const grouping = imagesExploreData?.config?.grouping;
-    const group: string[] = [...(grouping?.group || [])];
-    const groupFields = grouping?.reverseMode?.group
+    const group: string[] = [...(grouping?.row || [])];
+    const groupFields = grouping?.reverseMode?.row
       ? imagesExploreData?.groupingSelectOptions.filter(
           (option: IGroupingSelectOption) => !group.includes(option.value),
         )
@@ -113,7 +113,7 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
     sortGroupFields = sortGroupFields.concat(
       imagesExploreData?.config?.images?.sortFields
         .filter((field: SortField) => {
-          if (grouping?.reverseMode?.group) {
+          if (grouping?.reverseMode?.row) {
             return group.includes(field.value);
           } else {
             return !group.includes(field.value);

--- a/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/ImagesExplore.tsx
@@ -235,7 +235,7 @@ function ImagesExplore(): React.FunctionComponentElement<React.ReactNode> {
               />
               <Grouping
                 groupingPopovers={GroupingPopovers.filter(
-                  (g) => g.groupName === 'group',
+                  (g) => g.groupName === 'row',
                 )}
                 groupingData={imagesExploreData?.config?.grouping}
                 groupingSelectOptions={imagesExploreData?.groupingSelectOptions}

--- a/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
@@ -52,7 +52,7 @@ function Controls(
       <div className='Controls__container ScrollBar__hidden'>
         <div>
           <ControlPopover
-            title='Image Properties'
+            title='Image properties'
             anchor={({ onAnchorClick, opened }) => (
               <Tooltip title='Image Properties'>
                 <div
@@ -86,7 +86,7 @@ function Controls(
         </div>
         <div>
           <ControlPopover
-            title='Images Sorting'
+            title='Images sorting'
             anchor={({ onAnchorClick, opened }) => (
               <Tooltip title='Images Sorting'>
                 <div
@@ -144,9 +144,9 @@ function Controls(
         </Tooltip>
         <div>
           <ControlPopover
-            title='Display In Tooltip'
+            title='Display in tooltip'
             anchor={({ onAnchorClick, opened }) => (
-              <Tooltip title='Tooltip Params'>
+              <Tooltip title='Tooltip fields'>
                 <div
                   onClick={onAnchorClick}
                   className={`Controls__anchor ${

--- a/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/Controls/Controls.tsx
@@ -54,7 +54,7 @@ function Controls(
           <ControlPopover
             title='Image properties'
             anchor={({ onAnchorClick, opened }) => (
-              <Tooltip title='Image Properties'>
+              <Tooltip title='Image properties'>
                 <div
                   onClick={onAnchorClick}
                   className={`Controls__anchor ${
@@ -88,7 +88,7 @@ function Controls(
           <ControlPopover
             title='Images sorting'
             anchor={({ onAnchorClick, opened }) => (
-              <Tooltip title='Images Sorting'>
+              <Tooltip title='Images sorting'>
                 <div
                   onClick={onAnchorClick}
                   className={`Controls__anchor ${

--- a/aim/web/ui/src/pages/Metrics/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Controls/Controls.tsx
@@ -86,14 +86,14 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Select Aggregation Method'
+              title='Select aggregation method'
               open={props.aggregationConfig.isEnabled}
               anchor={({ onAnchorClick, opened }) => (
                 <Tooltip
                   title={
                     props.aggregationConfig.isApplied
-                      ? 'Deaggregate Metrics'
-                      : 'Aggregate Metrics'
+                      ? 'Deaggregate metrics'
+                      : 'Aggregate metrics'
                   }
                 >
                   <div
@@ -177,9 +177,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Axes Scale'
+              title='Axes scale'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Axes Scale'>
+                <Tooltip title='Axes scale'>
                   <div
                     onClick={onAnchorClick}
                     className={`Controls__anchor ${
@@ -211,9 +211,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Chart Smoothing Options'
+              title='Chart smoothing options'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Chart Smoothing Options'>
+                <Tooltip title='Chart smoothing options'>
                   <div
                     onClick={onAnchorClick}
                     className={`Controls__anchor ${
@@ -270,9 +270,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Highlight Modes'
+              title='Highlight modes'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Highlight Modes'>
+                <Tooltip title='Highlight modes'>
                   <div
                     className={`Controls__anchor ${
                       opened
@@ -304,9 +304,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Display In Tooltip'
+              title='Display in tooltip'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Tooltip Params'>
+                <Tooltip title='Tooltip fields'>
                   <div
                     onClick={onAnchorClick}
                     className={`Controls__anchor ${
@@ -340,9 +340,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Select Zoom Mode'
+              title='Select zoom mode'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Zoom In'>
+                <Tooltip title='Zoom in'>
                   <div
                     className={`Controls__anchor ${
                       props.zoom?.active ? 'active' : ''

--- a/aim/web/ui/src/pages/Metrics/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Controls/Controls.tsx
@@ -246,7 +246,7 @@ function Controls(
         </div>
         <Tooltip
           title={
-            props.ignoreOutliers ? 'Outliers Are Ignored' : 'Ignore Outliers'
+            props.ignoreOutliers ? 'Outliers are ignored' : 'Ignore outliers'
           }
         >
           <div
@@ -382,10 +382,10 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Select Option To Zoom Out'
+              title='Select option to zoom out'
               open={!!props.zoom?.history.length}
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Zoom Out'>
+                <Tooltip title='Zoom out'>
                   <div
                     className={`Controls__anchor ${
                       props.zoom?.history.length ? '' : 'disabled'
@@ -423,7 +423,7 @@ function Controls(
         </div>
         <ErrorBoundary>
           {/* TODO add ability to open modals in ControlPopover component and change the name of the ControlPopover to more general*/}
-          <Tooltip title='Export Chart'>
+          <Tooltip title='Export chart'>
             <div className='Controls__anchor' onClick={onToggleExportPreview}>
               <Icon className='Controls__icon' name='download' />
             </div>

--- a/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -193,7 +193,7 @@ function ManageColumnsPopover({
   return (
     <ErrorBoundary>
       <ControlPopover
-        title='Manage Table Columns'
+        title='Manage table columns'
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/aim/web/ui/src/pages/Metrics/components/Table/RowHeightPopover/RowHeightPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/RowHeightPopover/RowHeightPopover.tsx
@@ -22,7 +22,7 @@ function RowHeightPopover({ rowHeight, onRowHeightChange, appName }: any) {
   return (
     <ErrorBoundary>
       <ControlPopover
-        title='Select Content Density Mode'
+        title='Select content density mode'
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.scss
+++ b/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.scss
@@ -108,15 +108,14 @@
   margin-top: 0.5em;
   display: flex;
   justify-content: center;
-  color: $error-color;
   border-top: $border-main;
   padding-top: 0.5rem;
 
   button {
-    background-color: $error-color;
+    background-color: $pico-50;
     color: #fff;
     &:hover {
-      background-color: $error-color;
+      background-color: $pico-50;
     }
   }
 }

--- a/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.scss
+++ b/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.scss
@@ -11,7 +11,7 @@
     overflow: auto;
   }
   &__label {
-    margin-bottom: $space-xxxs;
+    margin-bottom: $space-sm;
     display: block;
   }
   &__selectBox {

--- a/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/SortPopover/SortPopover.tsx
@@ -78,7 +78,7 @@ function SortPopover({
     <ErrorBoundary>
       <div className='SortPopover__container'>
         <Text size={12} tint={50} className={'SortPopover__container__label'}>
-          SELECT FIELDS
+          SELECT FIELDS FOR SORTING
         </Text>
         <div className='SortPopover__container__selectBox'>
           <Autocomplete
@@ -106,8 +106,8 @@ function SortPopover({
                 }
                 placeholder={
                   sortFields.length > 0
-                    ? `${sortFields.length} Selected Items`
-                    : 'Select...'
+                    ? `${sortFields.length} Selected Fields`
+                    : ' Select Fields'
                 }
               />
             )}

--- a/aim/web/ui/src/pages/Params/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Params/components/Controls/Controls.tsx
@@ -29,7 +29,7 @@ function Controls(
   return (
     <ErrorBoundary>
       <div className='Params__Controls__container'>
-        <Tooltip title='Curve Interpolation'>
+        <Tooltip title='Curve interpolation'>
           <div
             className={`Params__Controls__anchor ${
               props.curveInterpolation === CurveEnum.Linear
@@ -46,7 +46,7 @@ function Controls(
             />
           </div>
         </Tooltip>
-        <Tooltip title='Color Indicator'>
+        <Tooltip title='Color indicator'>
           <div
             className={`Params__Controls__anchor ${
               props.isVisibleColorIndicator ? 'active outlined' : ''

--- a/aim/web/ui/src/pages/Params/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Params/components/Controls/Controls.tsx
@@ -64,9 +64,9 @@ function Controls(
         <div>
           <ErrorBoundary>
             <ControlPopover
-              title='Display in Tooltip'
+              title='Display in tooltip'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Tooltip Params'>
+                <Tooltip title='Tooltip fields'>
                   <div
                     onClick={onAnchorClick}
                     className={`Params__Controls__anchor ${

--- a/aim/web/ui/src/pages/Scatters/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Scatters/components/Controls/Controls.tsx
@@ -88,9 +88,9 @@ function Controls(
         <ErrorBoundary>
           <div>
             <ControlPopover
-              title='Display In Tooltip'
+              title='Display in tooltip'
               anchor={({ onAnchorClick, opened }) => (
-                <Tooltip title='Tooltip Params'>
+                <Tooltip title='Tooltip fields'>
                   <div
                     onClick={onAnchorClick}
                     className={`Controls__anchor ${

--- a/aim/web/ui/src/pages/Scatters/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/pages/Scatters/components/Controls/Controls.tsx
@@ -40,7 +40,7 @@ function Controls(
         <ErrorBoundary>
           <div>
             <ControlPopover
-              title='Select Trendline Options'
+              title='Select trendline options'
               anchor={({ onAnchorClick, opened }) => (
                 <Tooltip
                   title={
@@ -123,7 +123,7 @@ function Controls(
         </ErrorBoundary>
         <ErrorBoundary>
           {/* TODO add ability to open modals in ControlPopover component and change the name of the ControlPopover to more general*/}
-          <Tooltip title='Export Chart'>
+          <Tooltip title='Export chart'>
             <div className='Controls__anchor' onClick={onToggleExportPreview}>
               <Icon className='Controls__icon' name='download' />
             </div>

--- a/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
+++ b/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
@@ -102,12 +102,12 @@ let tooltipData: ITooltipData = {};
 function getConfig(): IImagesExploreAppConfig {
   return {
     grouping: {
-      group: [],
+      row: [],
       reverseMode: {
-        group: false,
+        row: false,
       },
       isApplied: {
-        group: true,
+        row: true,
       },
     },
     select: {
@@ -569,7 +569,7 @@ function setModelData(rawData: any[], configData: IImagesExploreAppConfig) {
     processedData: data,
     paramKeys: sortedParams,
     groupingSelectOptions,
-    groupingItems: ['group'],
+    groupingItems: ['row'],
     model,
   });
   if (configData.images.focusedState.key) {
@@ -715,7 +715,7 @@ function updateModelData(
     processedData: data,
     paramKeys: sortedParams,
     groupingSelectOptions,
-    groupingItems: ['group'],
+    groupingItems: ['row'],
     model,
   });
 
@@ -784,12 +784,12 @@ function getFilteredGroupingOptions(
     | undefined = model.getState()?.groupingSelectOptions;
   if (groupingSelectOptions) {
     const filteredOptions = [...groupingSelectOptions]
-      .filter((opt) => grouping['group'].indexOf(opt.value as never) === -1)
+      .filter((opt) => grouping['row'].indexOf(opt.value as never) === -1)
       .map((item) => item.value);
-    return isApplied['group']
-      ? reverseMode['group']
+    return isApplied['row']
+      ? reverseMode['row']
         ? filteredOptions
-        : grouping['group']
+        : grouping['row']
       : [];
   } else {
     return [];
@@ -918,8 +918,8 @@ function onGroupingSelectChange({
     updateModelData(configData, true);
     if (
       configData.images?.additionalProperties?.stacking &&
-      (_.isEmpty(configData.grouping.group) ||
-        configData.grouping.reverseMode.group)
+      (_.isEmpty(configData.grouping.row) ||
+        configData.grouping.reverseMode.row)
     ) {
       onStackingToggle();
     }
@@ -937,14 +937,14 @@ function onGroupingModeChange({ value }: IOnGroupingModeChangeParams): void {
       ...configData.grouping,
       reverseMode: {
         ...configData.grouping.reverseMode,
-        group: value,
+        row: value,
       },
     };
     updateModelData(configData, true);
     if (
       configData.images?.additionalProperties?.stacking &&
-      (_.isEmpty(configData.grouping.group) ||
-        configData.grouping.reverseMode.group)
+      (_.isEmpty(configData.grouping.row) ||
+        configData.grouping.reverseMode.row)
     ) {
       onStackingToggle();
     }
@@ -972,8 +972,8 @@ function onGroupingReset(groupName: GroupNameType) {
     updateModelData(configData, true);
     if (
       configData.images?.additionalProperties?.stacking &&
-      (_.isEmpty(configData.grouping.group) ||
-        configData.grouping.reverseMode.group)
+      (_.isEmpty(configData.grouping.row) ||
+        configData.grouping.reverseMode.row)
     ) {
       onStackingToggle();
     }
@@ -988,7 +988,7 @@ function onGroupingApplyChange(): void {
       ...configData.grouping,
       isApplied: {
         ...configData.grouping.isApplied,
-        group: !configData.grouping.isApplied['group'],
+        row: !configData.grouping.isApplied['row'],
       },
     };
     updateModelData(configData, true);
@@ -1093,10 +1093,10 @@ function getDataAsImageSet(
     const configData: IImagesExploreAppConfig | undefined =
       model.getState()?.config;
     const imageSetData: object = {};
-    const group: string[] = [...(configData?.grouping?.group || [])];
+    const group: string[] = [...(configData?.grouping?.row || [])];
     const groupFields =
       defaultGroupFields ||
-      (configData?.grouping?.reverseMode?.group
+      (configData?.grouping?.reverseMode?.row
         ? groupingSelectOptions
             .filter(
               (option: IGroupingSelectOption) => !group.includes(option.label),

--- a/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
+++ b/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
@@ -947,7 +947,7 @@ function onGroupingModeChange({ value }: IOnGroupingModeChangeParams): void {
   if (value) {
     analytics.trackEvent(
       // @ts-ignore
-      ANALYTICS_EVENT_KEYS.images.groupings.group.modeChange,
+      ANALYTICS_EVENT_KEYS.images.groupings.row.modeChange,
       //@TODO change group to dynamic groupName when adding grouping type
     );
   }

--- a/aim/web/ui/src/types/components/GroupingPopover/GroupingPopover.d.ts
+++ b/aim/web/ui/src/types/components/GroupingPopover/GroupingPopover.d.ts
@@ -15,6 +15,7 @@ export interface IGroupingPopoverProps {
   groupingSelectOptions: IGroupingSelectOption[];
   onSelect: IMetricProps['onGroupingSelectChange'];
   onGroupingModeChange: IMetricProps['onGroupingModeChange'];
+  inputLabel?: string;
 }
 
 export interface IGroupingPopoverAdvancedProps {

--- a/aim/web/ui/src/types/pages/components/Grouping/Grouping.d.ts
+++ b/aim/web/ui/src/types/pages/components/Grouping/Grouping.d.ts
@@ -26,7 +26,7 @@ export interface IGroupingProps {
 export interface IGroupingPopovers {
   groupName: GroupNameType;
   title: string;
-  advancedTitle?: string;
+  inputLabel?: string;
   AdvancedComponent?: (
     props: IGroupingPopoverAdvancedProps,
   ) => React.FunctionComponentElement<React.ReactNode>;

--- a/aim/web/ui/src/types/pages/components/GroupingItem/GroupingItem.d.ts
+++ b/aim/web/ui/src/types/pages/components/GroupingItem/GroupingItem.d.ts
@@ -9,7 +9,7 @@ import { IGroupingConfig } from 'types/services/models/explorer/createAppModel';
 
 export interface IGroupingItemProps extends IGroupingPopoverProps {
   title: string;
-  advancedTitle?: string;
+  inputLabel?: string;
   groupName: GroupNameType;
   groupingData: IGroupingConfig;
   advancedComponent?: React.FunctionComponentElement<React.ReactNode>;

--- a/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
@@ -59,18 +59,18 @@ export interface IGroupingConfig {
   color?: string[];
   stroke?: string[];
   chart?: string[];
-  group?: string[];
+  row?: string[];
   reverseMode?: {
     color?: boolean;
     stroke?: boolean;
     chart?: boolean;
-    group?: boolean;
+    row?: boolean;
   };
   isApplied?: {
     color?: boolean;
     stroke?: boolean;
     chart?: boolean;
-    group?: boolean;
+    row?: boolean;
   };
   persistence?: {
     color: boolean;

--- a/aim/web/ui/src/types/services/models/imagesExplore/imagesExploreAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/imagesExplore/imagesExploreAppModel.d.ts
@@ -14,12 +14,12 @@ import { SortFields } from 'utils/getSortedFields';
 
 export interface IImagesExploreAppConfig {
   grouping: {
-    group: string[];
+    row: string[];
     reverseMode: {
-      group: boolean;
+      row: boolean;
     };
     isApplied: {
-      group: boolean;
+      row: boolean;
     };
   };
   images: {

--- a/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/metrics/metricsAppModel.d.ts
@@ -191,7 +191,7 @@ export interface IGetGroupingPersistIndex {
   groupName: 'color' | 'stroke';
 }
 
-export type GroupNameType = 'color' | 'stroke' | 'chart' | 'group';
+export type GroupNameType = 'color' | 'stroke' | 'chart' | 'row';
 export interface IGroupingSelectOption {
   label: string;
   group: string;

--- a/aim/web/ui/src/utils/app/getDataAsMediaSetNestedObject.ts
+++ b/aim/web/ui/src/utils/app/getDataAsMediaSetNestedObject.ts
@@ -22,10 +22,10 @@ export function getDataAsMediaSetNestedObject<M extends State>({
     const configData = modelState?.config;
     const grouping = configData?.grouping;
     const mediaSetData: object = {};
-    const group: string[] = [...(grouping?.group || [])];
+    const group: string[] = [...(grouping?.row || [])];
     const groupFields =
       defaultGroupFields ||
-      (grouping?.reverseMode?.group
+      (grouping?.reverseMode?.row
         ? groupingSelectOptions
             .filter(
               (option: IGroupingSelectOption) => !group.includes(option.label),


### PR DESCRIPTION
-  Updated titles, labels, and tooltips of popovers
- Change the sort popover reset button color.
- Changed the size of the inputs in Tooltip popover and Grouping popovers.
- Added full width to selected fields container to have search input always visible.
- Redesign the grouping component.