### PR TITLE
[feat] Improve number formatting by setting precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements:
 
+- Improve formatting of numbers by setting maximum precision (KaroMourad)
 - Add LightGBM integration example (gorarakelyan)
 - Add descriptive document titles for pages (KaroMourad)
 - Implement unit-tests for aim SDK utils (yeghiakoronian)
@@ -13,7 +14,7 @@
 ### Fixes:
 
 - Change zooming default option to multiple (VkoHov)
-- Changed grouped rows' min and max values names to `Group Min` and `Group Max` (VkoHov)
+- Change grouped rows' min and max values names to `Group Min` and `Group Max` (VkoHov)
 - Preserve the search input value of the grouping dropdown (VkoHov)
 - Fix params duplication in dropdowns (VkoHov)
 - Resolve typing latency issue in the query search input (arsengit)

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -54,7 +54,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                     {contextToString(context)}
                   </Text>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.yValue ?? '--'}
+                    {formatValue(focusedState?.yValue)}
                   </Text>
                 </span>
               </div>
@@ -96,7 +96,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 {context || null}
               </div>
               <div className='PopoverContent__value'>
-                Value: {focusedState?.yValue ?? '--'}
+                Value: {formatValue(focusedState?.yValue)}
               </div>
             </div>
           </ErrorBoundary>
@@ -132,7 +132,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 <Text>Y: </Text>
                 <span className='PopoverContent__headerValue'>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.yValue ?? '--'}
+                    {formatValue(focusedState?.yValue)}
                   </Text>
                 </span>
               </div>
@@ -140,7 +140,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 <Text>X: </Text>
                 <span className='PopoverContent__headerValue'>
                   <Text component='p' className='PopoverContent__axisValue'>
-                    {focusedState?.xValue ?? '--'}
+                    {formatValue(focusedState?.xValue)}
                   </Text>
                 </span>
               </div>

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -852,34 +852,40 @@ function createAppModel(appConfig: IAppInitialConfig) {
             if (metricsCollection.config !== null && closestIndex !== null) {
               rows[groupKey!].data.aggregation = {
                 area: {
-                  min: metricsCollection.aggregation!.area.min?.yValues[
-                    closestIndex
-                  ],
-                  max: metricsCollection.aggregation!.area.max?.yValues[
-                    closestIndex
-                  ],
+                  min: formatValue(
+                    metricsCollection.aggregation!.area.min?.yValues[
+                      closestIndex
+                    ],
+                  ),
+                  max: formatValue(
+                    metricsCollection.aggregation!.area.max?.yValues[
+                      closestIndex
+                    ],
+                  ),
                 },
-                line: metricsCollection.aggregation!.line?.yValues[
-                  closestIndex
-                ],
+                line: formatValue(
+                  metricsCollection.aggregation!.line?.yValues[closestIndex],
+                ),
               };
               if (
                 config.chart?.aggregationConfig?.methods.area ===
                 AggregationAreaMethods.STD_DEV
               ) {
-                rows[groupKey!].data.aggregation.area.stdDevValue =
+                rows[groupKey!].data.aggregation.area.stdDevValue = formatValue(
                   metricsCollection.aggregation!.area.stdDevValue?.yValues[
                     closestIndex
-                  ];
+                  ],
+                );
               }
               if (
                 config.chart?.aggregationConfig?.methods.area ===
                 AggregationAreaMethods.STD_ERR
               ) {
-                rows[groupKey!].data.aggregation.area.stdErrValue =
+                rows[groupKey!].data.aggregation.area.stdErrValue = formatValue(
                   metricsCollection.aggregation!.area.stdErrValue?.yValues[
                     closestIndex
-                  ];
+                  ],
+                );
               }
             }
 

--- a/aim/web/ui/src/utils/formatByAlignment.ts
+++ b/aim/web/ui/src/utils/formatByAlignment.ts
@@ -7,6 +7,7 @@ import { IAlignmentConfig } from 'types/services/models/metrics/metricsAppModel'
 import shortEnglishHumanizer from 'utils/shortEnglishHumanizer';
 
 import { AlignmentKeysEnum, AlignmentOptionsEnum } from './d3';
+import { formatValue } from './formatValue';
 
 function formatValueByAlignment({
   xAxisTickValue,
@@ -17,22 +18,27 @@ function formatValueByAlignment({
   type?: AlignmentOptionsEnum;
   humanizerConfig?: {};
 }) {
+  let formatted: string | number | null = xAxisTickValue;
+
   if (xAxisTickValue || xAxisTickValue === 0) {
     switch (type) {
       case AlignmentOptionsEnum.EPOCH:
-        return Math.floor(xAxisTickValue);
+        formatted = Math.floor(xAxisTickValue);
+        break;
       case AlignmentOptionsEnum.RELATIVE_TIME:
-        return shortEnglishHumanizer(Math.round(xAxisTickValue), {
+        formatted = shortEnglishHumanizer(Math.round(xAxisTickValue), {
           ...humanizerConfig,
           maxDecimalPoints: 2,
         });
+        break;
       case AlignmentOptionsEnum.ABSOLUTE_TIME:
-        return moment(xAxisTickValue).format(DATE_CHART_TICK);
+        formatted = moment(xAxisTickValue).format(DATE_CHART_TICK);
+        break;
       default:
-        return xAxisTickValue;
+        formatted = xAxisTickValue;
     }
   }
-  return xAxisTickValue || '--';
+  return formatValue(formatted);
 }
 
 function getKeyByAlignment(alignmentConfig?: IAlignmentConfig): string {

--- a/aim/web/ui/src/utils/formatValue.ts
+++ b/aim/web/ui/src/utils/formatValue.ts
@@ -1,5 +1,8 @@
 import { format_bytes } from './encoder/format_bytes';
 
+const NUMBER_PRECISION = 8;
+const UNDEFINED_VALUE = '--';
+
 const FORMATTERS: Record<string, Function> = {
   undefined: format_undefined,
   number: format_number,
@@ -10,7 +13,7 @@ const FORMATTERS: Record<string, Function> = {
 
 function format_undefined(
   value: undefined,
-  undefinedValue: string = '-',
+  undefinedValue: string = UNDEFINED_VALUE,
 ): string {
   return undefinedValue;
 }
@@ -23,7 +26,7 @@ function format_number(value: number): string {
     return value > 0 ? 'Inf' : '-Inf';
   }
 
-  return JSON.stringify(value);
+  return JSON.stringify(parseFloat(value.toFixed(NUMBER_PRECISION)));
 }
 
 function format_str(value: string): string {
@@ -34,7 +37,10 @@ function format_bool(value: boolean): string {
   return value ? 'True' : 'False';
 }
 
-function format_list(value: unknown[], undefinedValue: string = '-'): string {
+function format_list(
+  value: unknown[],
+  undefinedValue: string = UNDEFINED_VALUE,
+): string {
   const pieces = [];
   for (let i = 0; i < value.length; i++) {
     const piece = formatValue(value[i], undefinedValue);
@@ -45,7 +51,7 @@ function format_list(value: unknown[], undefinedValue: string = '-'): string {
 
 function format_dict(
   value: Record<string, unknown>,
-  undefinedValue: string = '-',
+  undefinedValue: string = UNDEFINED_VALUE,
 ): string {
   const pieces = [];
   const keys = Object.keys(value);
@@ -61,7 +67,7 @@ function format_dict(
 
 function format_object(
   value: Record<string, unknown>,
-  undefinedValue: string = '-',
+  undefinedValue: string = UNDEFINED_VALUE,
 ): string {
   if (value === null) {
     return 'None';
@@ -74,7 +80,10 @@ function format_object(
   }
 }
 
-export function formatValue(value: any, undefinedValue: string = '-'): string {
+export function formatValue(
+  value: unknown,
+  undefinedValue: string = UNDEFINED_VALUE,
+): string {
   let formatter = FORMATTERS[typeof value];
   return formatter(value, undefinedValue);
 }


### PR DESCRIPTION
Round floating-point numbers to a maximum of 8 digits.
Improve `format_number` function used in the `formatValue` function.

Use the `formatValue` function
- for aggregated data in the table
- for visualization tooltip content