### PR TITLE
[fix] Chart focused point shadow styles support on safari

### DIFF
--- a/aim/web/ui/src/components/HighPlot/HighPlot.scss
+++ b/aim/web/ui/src/components/HighPlot/HighPlot.scss
@@ -85,8 +85,10 @@
     /* on click */
     &.focus {
       stroke-width: 2;
-      outline-width: 6px;
       clip-path: unset;
+      &__shadow {
+        stroke-width: 10;
+      }
     }
     /* on hover */
     &.active {

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -37,7 +37,7 @@
       stroke-width: 2;
       clip-path: unset;
       &__shadow {
-        stroke-width: 8;
+        stroke-width: 10;
       }
     }
     /* on hover */

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -31,13 +31,14 @@
     opacity: 1;
     stroke-width: 1.45;
     fill: white;
-    outline: 0 solid;
     border-radius: 50%;
     /* on click */
     &.focus {
       stroke-width: 2;
-      outline-width: 6px;
       clip-path: unset;
+      &__shadow {
+        stroke-width: 8;
+      }
     }
     /* on hover */
     &.active {

--- a/aim/web/ui/src/components/ScatterPlot/styles.scss
+++ b/aim/web/ui/src/components/ScatterPlot/styles.scss
@@ -36,8 +36,10 @@
     /* on click */
     &.focus {
       stroke-width: 2;
-      outline-width: 6px;
       clip-path: unset;
+      &__shadow {
+        stroke-width: 10;
+      }
     }
     /* on hover */
     &.active {

--- a/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
@@ -16,7 +16,6 @@ import { IUpdateFocusedChartArgs } from 'types/components/LineChart/LineChart';
 import { AggregationAreaMethods } from 'utils/aggregateGroupData';
 import getRoundedValue from 'utils/roundValue';
 
-import hexToRgbA from '../hexToRgbA';
 import { formatValueByAlignment } from '../formatByAlignment';
 
 import { getDimensionValue } from './getDimensionValue';
@@ -444,21 +443,20 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
     attrNodeRef.current.select('.focus__shadow')?.remove();
 
     const newFocusedPoint = attrNodeRef.current.select(`[id=Circle-${key}]`);
-    if (newFocusedPoint) {
-      attrNodeRef.current
-        .append('circle')
-        .classed('HoverCircle focus focus__shadow', true)
-        .attr('r', CircleEnum.ActiveRadius)
-        .attr('cx', newFocusedPoint.attr('cx'))
-        .attr('cy', newFocusedPoint.attr('cy'))
-        .attr('stroke', hexToRgbA(newFocusedPoint.attr('color'), 0.3))
-        .raise();
+    newFocusedPoint
+      .classed('focus', true)
+      .attr('r', CircleEnum.ActiveRadius)
+      .raise();
 
-      newFocusedPoint
-        .classed('focus', true)
-        .attr('r', CircleEnum.ActiveRadius)
-        .raise();
-    }
+    attrNodeRef.current
+      .append('circle')
+      .classed('HoverCircle focus focus__shadow', true)
+      .attr('r', CircleEnum.ActiveRadius)
+      .attr('cx', newFocusedPoint.attr('cx'))
+      .attr('cy', newFocusedPoint.attr('cy'))
+      .attr('stroke', newFocusedPoint.attr('stroke'))
+      .attr('stroke-opacity', 0.4)
+      .lower();
   }
 
   function drawCircles(nearestCircles: INearestCircle[]): void {
@@ -474,7 +472,7 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       .attr('r', CircleEnum.Radius)
       .attr('stroke', (d: INearestCircle) => d.color)
       .attr('fill', (d: INearestCircle) => d.color)
-      .attr('color', (d: INearestCircle) => d.color)
+      .attr('stroke-opacity', 1)
       .on('click', handlePointClick);
   }
 

--- a/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
@@ -441,11 +441,24 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       .classed('active', false)
       .classed('focus', false);
 
-    attrNodeRef.current
-      .select(`[id=Circle-${key}]`)
-      .classed('focus', true)
-      .attr('r', CircleEnum.ActiveRadius)
-      .raise();
+    attrNodeRef.current.select('.focus__shadow')?.remove();
+
+    const newFocusedPoint = attrNodeRef.current.select(`[id=Circle-${key}]`);
+    if (newFocusedPoint) {
+      attrNodeRef.current
+        .append('circle')
+        .classed('HoverCircle focus focus__shadow', true)
+        .attr('r', CircleEnum.ActiveRadius)
+        .attr('cx', newFocusedPoint.attr('cx'))
+        .attr('cy', newFocusedPoint.attr('cy'))
+        .attr('stroke', hexToRgbA(newFocusedPoint.attr('color'), 0.3))
+        .raise();
+
+      newFocusedPoint
+        .classed('focus', true)
+        .attr('r', CircleEnum.ActiveRadius)
+        .raise();
+    }
   }
 
   function drawCircles(nearestCircles: INearestCircle[]): void {
@@ -462,7 +475,6 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       .attr('stroke', (d: INearestCircle) => d.color)
       .attr('fill', (d: INearestCircle) => d.color)
       .attr('color', (d: INearestCircle) => d.color)
-      .style('outline-color', (d: INearestCircle) => hexToRgbA(d.color, 0.3))
       .on('click', handlePointClick);
   }
 

--- a/aim/web/ui/src/utils/d3/drawParallelHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawParallelHoverAttributes.ts
@@ -15,8 +15,6 @@ import { ILineDataType } from 'types/utils/d3/drawParallelLines';
 
 import getRoundedValue from 'utils/roundValue';
 
-import hexToRgbA from '../hexToRgbA';
-
 import { CircleEnum, ScaleEnum } from './';
 
 const drawParallelHoverAttributes = ({
@@ -283,11 +281,24 @@ const drawParallelHoverAttributes = ({
       .classed('active', false)
       .classed('focus', false);
 
-    attrNodeRef.current
-      .select(`[id=Circle-${key}]`)
+    attrNodeRef.current.select('.focus__shadow')?.remove();
+
+    const newFocusedPoint = attrNodeRef.current.select(`[id=Circle-${key}]`);
+
+    newFocusedPoint
       .classed('focus', true)
       .attr('r', CircleEnum.ActiveRadius)
       .raise();
+
+    attrNodeRef.current
+      .append('circle')
+      .classed('HoverCircle focus focus__shadow', true)
+      .attr('r', CircleEnum.ActiveRadius)
+      .attr('cx', newFocusedPoint.attr('cx'))
+      .attr('cy', newFocusedPoint.attr('cy'))
+      .attr('stroke', newFocusedPoint.attr('stroke'))
+      .attr('stroke-opacity', 0.4)
+      .lower();
   }
 
   function drawParallelCircles(
@@ -313,15 +324,7 @@ const drawParallelHoverAttributes = ({
           ? attrRef.current.yColorIndicatorScale(d.lastYScalePos)
           : d.color,
       )
-      .attr('color', (d: IParallelNearestCircle) => d.color)
-      .style('outline-color', (d: IParallelNearestCircle) =>
-        hexToRgbA(
-          isVisibleColorIndicator
-            ? attrRef.current.yColorIndicatorScale(d.lastYScalePos)
-            : d.color,
-          0.3,
-        ),
-      )
+      .attr('stroke-opacity', 1)
       .on('click', handlePointClick);
     // set active circle
     drawActiveCircle(closestCircle?.key);


### PR DESCRIPTION
Chart focused point outline is square instead of a circle on safari

- removed `outline` styles
- added a new circle under the focused point for creating shadows