### PR TITLE
[fix] Tune spacings on the Bookmark page

### DIFF
--- a/aim/web/ui/src/pages/Bookmarks/Bookmarks.scss
+++ b/aim/web/ui/src/pages/Bookmarks/Bookmarks.scss
@@ -1,7 +1,7 @@
 @use 'src/styles/abstracts' as *;
 
 .Bookmarks {
-  height: 100vh;
+  height: 100%;
   &__appBar {
     position: fixed;
     width: 100%;

--- a/aim/web/ui/src/pages/Bookmarks/components/BookmarkCard/BookmarkCard.scss
+++ b/aim/web/ui/src/pages/Bookmarks/components/BookmarkCard/BookmarkCard.scss
@@ -79,10 +79,6 @@
       margin-right: 0.5rem;
     }
   }
-
-  &__run__expression {
-    margin-right: 2.8125rem;
-  }
   &:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
- Remove the right space of the `CodeBlock` in the `BookmarkCard`.
- Add space under the last child of the `BookmarkCard`.