### PR TITLE
[Fix] Fix rendering progress bar

### DIFF
--- a/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/components/GroupingItem/GroupingItem.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { isEmpty } from 'lodash-es';
-import _ from 'lodash';
 
 import { Tooltip } from '@material-ui/core';
 

--- a/aim/web/ui/src/components/ProgressBar/ProgressBar.tsx
+++ b/aim/web/ui/src/components/ProgressBar/ProgressBar.tsx
@@ -37,8 +37,7 @@ function ProgressBar({
 
   const barWidth = React.useMemo(
     () => (pendingStatus ? percent + '%' : 'unset'),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pendingStatus],
+    [pendingStatus, percent],
   );
   const fadeOutProgress = React.useMemo(
     () => !(processing || pendingStatus),


### PR DESCRIPTION
 The progress bar doesn’t render the progress of the search request.
 After memorizing the `ProgressBar` component variables, missing a variable in the dependency array.