### PR TITLE
[fix] Fix the loading logic of the `monaco editor` across the Aim Ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix the loading logic of the `monaco editor` across the Aim Ui
+
 ## 3.11.0 Jun 21, 2022
 
 ### Enhancements:

--- a/aim/web/ui/src/App.tsx
+++ b/aim/web/ui/src/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 
+import { loader } from '@monaco-editor/react';
+
 import AlertBanner from 'components/kit/AlertBanner';
 import SideBar from 'components/SideBar/SideBar';
 import ProjectWrapper from 'components/ProjectWrapper/ProjectWrapper';
@@ -21,6 +23,13 @@ import './App.scss';
 const basePath = getBasePath(false);
 
 const isVisibleCacheBanner = checkIsBasePathInCachedEnv(basePath) && inIframe();
+
+// loading monaco from node modules instead of CDN
+loader.config({
+  paths: {
+    vs: `${getBasePath()}/static-files/vs`,
+  },
+});
 
 function App(): React.FunctionComponentElement<React.ReactNode> {
   React.useEffect(() => {

--- a/aim/web/ui/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/aim/web/ui/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -3,23 +3,15 @@ import classNames from 'classnames';
 import * as monacoEditor from 'monaco-editor';
 import _ from 'lodash-es';
 
-import Editor, { useMonaco, loader } from '@monaco-editor/react';
+import Editor, { useMonaco } from '@monaco-editor/react';
 
 import { getMonacoConfig } from 'config/monacoConfig/monacoConfig';
-import { getBasePath } from 'config/config';
 
 import { showAutocompletion } from 'utils/showAutocompletion';
 
 import { IAutocompleteInputProps } from './ AutocompleteInput';
 
 import './AutocompleteInput.scss';
-
-// loading monaco from node modules instead of CDN
-loader.config({
-  paths: {
-    vs: `${getBasePath()}/static-files/vs`,
-  },
-});
 
 function AutocompleteInput({
   context,


### PR DESCRIPTION
- Load monaco editor from the node modules instead of CDN across the Aim Ui