### PR TITLE
[fix] Check None value for Pytorch model gradients histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-- Check if gradient is None when tracking gradient distributions
+## Unreleased
+
+### Fixes:
+
+- Check if gradient is None when tracking gradient distributions (kage08)
 
 ## 3.11.1 Jun 27, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Check if gradient is None when tracking gradient distributions
+
 ## 3.11.1 Jun 27, 2022
 
 - Replace base58 encoder with base64 (KaroMourad, VkoHov)
@@ -7,7 +9,6 @@
 - Fix the loading logic of the `monaco editor` across the Aim Ui (arsengit)
 - Fix `Table` export functionality in Params and Scatters explorers (arsengit)
 - Allow mixing numeric types on a single Sequence (alberttorosyan)
-- Check if gradient is None when tracking gradient distributions
 
 ## 3.11.0 Jun 21, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix the loading logic of the `monaco editor` across the Aim Ui (arsengit)
 - Fix `Table` export functionality in Params and Scatters explorers (arsengit)
 - Allow mixing numeric types on a single Sequence (alberttorosyan)
+- Check if gradient is None when tracking gradient distributions
 
 ## 3.11.0 Jun 21, 2022
 

--- a/aim/sdk/adapters/pytorch.py
+++ b/aim/sdk/adapters/pytorch.py
@@ -62,14 +62,12 @@ def get_model_layers(model, dt, parent_name=None):
             layers[layer_name] = {}
             if hasattr(m, 'weight') \
                     and m.weight is not None \
-                    and hasattr(m.weight, dt) \
-                    and getattr(m.weight, dt) is not None:
+                    and getattr(m.weight, dt, None) is not None:
                 layers[layer_name]['weight'] = get_pt_tensor(getattr(m.weight, dt)).numpy()
 
             if hasattr(m, 'bias') \
                     and m.bias is not None \
-                    and hasattr(m.bias, dt) \
-                    and getattr(m.bias, dt) is not None:
+                    and getattr(m.bias, dt, None) is not None:
                 layers[layer_name]['bias'] = get_pt_tensor(getattr(m.bias, dt)).numpy()
 
     return layers

--- a/aim/sdk/adapters/pytorch.py
+++ b/aim/sdk/adapters/pytorch.py
@@ -62,12 +62,14 @@ def get_model_layers(model, dt, parent_name=None):
             layers[layer_name] = {}
             if hasattr(m, 'weight') \
                     and m.weight is not None \
-                    and hasattr(m.weight, dt):
+                    and hasattr(m.weight, dt) \
+                    and getattr(m.weight, dt) is not None:
                 layers[layer_name]['weight'] = get_pt_tensor(getattr(m.weight, dt)).numpy()
 
             if hasattr(m, 'bias') \
                     and m.bias is not None \
-                    and hasattr(m.bias, dt):
+                    and hasattr(m.bias, dt) \
+                    and getattr(m.bias, dt) is not None:
                 layers[layer_name]['bias'] = get_pt_tensor(getattr(m.bias, dt)).numpy()
 
     return layers

--- a/aim/sdk/adapters/pytorch.py
+++ b/aim/sdk/adapters/pytorch.py
@@ -60,15 +60,17 @@ def get_model_layers(model, dt, parent_name=None):
             layers.update(get_model_layers(m, dt, layer_name))
         else:
             layers[layer_name] = {}
-            if hasattr(m, 'weight') \
-                    and m.weight is not None \
-                    and getattr(m.weight, dt, None) is not None:
-                layers[layer_name]['weight'] = get_pt_tensor(getattr(m.weight, dt)).numpy()
+            weight = None
+            if hasattr(m, 'weight') and m.weight is not None:
+                weight = getattr(m.weigth, dt, None)
+                if weight is not None:
+                    layers[layer_name]['weight'] = get_pt_tensor(weight).numpy()
 
-            if hasattr(m, 'bias') \
-                    and m.bias is not None \
-                    and getattr(m.bias, dt, None) is not None:
-                layers[layer_name]['bias'] = get_pt_tensor(getattr(m.bias, dt)).numpy()
+            bias = None
+            if hasattr(m, 'bias') and m.bias is not None:
+                bias = getattr(m, 'bias', None)
+                if bias is not None:
+                    layers[layer_name]['bias'] = get_pt_tensor(bias).numpy()
 
     return layers
 

--- a/aim/sdk/adapters/pytorch.py
+++ b/aim/sdk/adapters/pytorch.py
@@ -62,13 +62,13 @@ def get_model_layers(model, dt, parent_name=None):
             layers[layer_name] = {}
             weight = None
             if hasattr(m, 'weight') and m.weight is not None:
-                weight = getattr(m.weigth, dt, None)
+                weight = getattr(m.weight, dt, None)
                 if weight is not None:
                     layers[layer_name]['weight'] = get_pt_tensor(weight).numpy()
 
             bias = None
             if hasattr(m, 'bias') and m.bias is not None:
-                bias = getattr(m, 'bias', None)
+                bias = getattr(m.bias, dt, None)
                 if bias is not None:
                     layers[layer_name]['bias'] = get_pt_tensor(bias).numpy()
 


### PR DESCRIPTION
When tracking histograms of gradients, some tensors may not have gradients during specific training loops.
So check if grad is not None before converting to numpy.

This commit fixes #1925