### PR TITLE
[fix] Fix the "matched runs" sentence color style overriding issue in progress bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes:
 
-- Progress Bar `matched runs` text incorrect color style (KaroMourad)
+- Fix the "matched runs" sentence color style in progress bars (KaroMourad)
 
 ## 3.11.1 Jun 27, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixes:
+
+- Progress Bar `matched runs` text incorrect color style (KaroMourad)
+
 ## 3.11.1 Jun 27, 2022
 
 - Replace base58 encoder with base64 (KaroMourad, VkoHov)

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.tsx
@@ -41,6 +41,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
     groupConfig = {},
     name = '',
     context = {},
+    run,
   } = tooltipContent || {};
   function renderPopoverHeader(): React.ReactNode {
     switch (chartType) {
@@ -227,16 +228,13 @@ const PopoverContent = React.forwardRef(function PopoverContent(
               </div>
             </ErrorBoundary>
           )}
-          {focusedState?.active && tooltipContent.run.hash ? (
+          {focusedState?.active && run?.hash ? (
             <ErrorBoundary>
               <div>
                 <Divider />
                 <div className='PopoverContent__box'>
                   <Link
-                    to={PathEnum.Run_Detail.replace(
-                      ':runHash',
-                      tooltipContent.run.hash,
-                    )}
+                    to={PathEnum.Run_Detail.replace(':runHash', run.hash)}
                     component={RouteLink}
                     className='PopoverContent__runDetails'
                     underline='none'
@@ -250,7 +248,7 @@ const PopoverContent = React.forwardRef(function PopoverContent(
                 <Divider />
                 <div className='PopoverContent__box'>
                   <ErrorBoundary>
-                    <AttachedTagsList runHash={tooltipContent.run.hash} />
+                    <AttachedTagsList runHash={run.hash} />
                   </ErrorBoundary>
                 </div>
               </div>

--- a/aim/web/ui/src/components/ProgressBar/ProgressBar.scss
+++ b/aim/web/ui/src/components/ProgressBar/ProgressBar.scss
@@ -95,7 +95,6 @@
       font-family: Inter, sans-serif;
       font-feature-settings: 'tnum';
       &__matched {
-        color: $success-color;
         margin-left: auto;
       }
     }

--- a/aim/web/ui/src/components/ProgressBar/ProgressBar.tsx
+++ b/aim/web/ui/src/components/ProgressBar/ProgressBar.tsx
@@ -74,6 +74,7 @@ function ProgressBar({
               className='ProgressBar__container__info__matched'
               size={14}
               weight={600}
+              color='success'
             >
               {matched} matched run(s)
             </Text>

--- a/aim/web/ui/src/components/kit/Text/Text.scss
+++ b/aim/web/ui/src/components/kit/Text/Text.scss
@@ -159,6 +159,27 @@
         color: $primary-color-5;
       }
     }
+    &_success {
+      color: $success-color;
+      &_100 {
+        color: $success-color;
+      }
+      &_80 {
+        color: $success-color-80;
+      }
+      &_50 {
+        color: $success-color-50;
+      }
+      &_25 {
+        color: $success-color-25;
+      }
+      &_10 {
+        color: $success-color-10;
+      }
+      &_5 {
+        color: $success-color-5;
+      }
+    }
     &_inherit {
       color: inherit;
     }

--- a/aim/web/ui/src/components/kit/Text/Text.tsx
+++ b/aim/web/ui/src/components/kit/Text/Text.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
@@ -27,11 +28,13 @@ function Text({
   ...rest
 }: ITextProps): React.FunctionComponentElement<React.ReactNode> {
   const Element = (): React.FunctionComponentElement<React.ReactNode> => {
-    const classes: string = `${className || ''} Text Text__size_${
-      size ? size : 12
-    } Text__weight_${weight ? weight : 500} Text__color_${`${
-      color ? color : 'primary'
-    }${tint ? `_${tint}` : ''}`}`;
+    const classes: string = classNames({
+      [`${className}`]: !!className,
+      Text: true,
+      [`Text__size_${size || 12}`]: true,
+      [`Text__weight_${weight || 500}`]: true,
+      [`Text__color_${color || 'primary'}${tint ? `_${tint}` : ''}`]: true,
+    });
     switch (component) {
       case 'h1':
         return (


### PR DESCRIPTION
- Progress bar matched runs color style overrides from `main.css` chunk in the production build
- Add `success` styles on `Text` component
- Fix Something went wrong issue in the `PopoverContent` component