### PR TITLE
[feat] Use style variable for font-weight across Aim UI

### DIFF
--- a/aim/web/ui/src/components/AttachedTagsList/AttachedTagsList.scss
+++ b/aim/web/ui/src/components/AttachedTagsList/AttachedTagsList.scss
@@ -11,11 +11,11 @@
   &__title {
     text-transform: uppercase;
     color: $pico-50;
-    font-weight: 500;
+    font-weight: $font-500;
   }
 
   &__noAttachedTags {
-    font-weight: 500;
+    font-weight: $font-500;
     font-size: 0.688rem;
     color: $pico-70;
   }
@@ -57,7 +57,7 @@
   &__ControlPopover__title {
     color: $pico-50;
     background: inherit;
-    font-weight: 500;
+    font-weight: $font-500;
     border: unset;
   }
 }

--- a/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.scss
+++ b/aim/web/ui/src/components/ChartPanel/PopoverContent/PopoverContent.scss
@@ -47,7 +47,7 @@
 
     &__contextValue {
       margin-left: 0.5rem;
-      font-weight: 400;
+      font-weight: $font-400;
     }
 
     &__runDetails {
@@ -67,11 +67,11 @@
     &__subtitle1 {
       color: $pico-50;
       text-transform: uppercase;
-      font-weight: 500;
+      font-weight: $font-500;
     }
 
     &__subtitle2 {
-      font-weight: 600;
+      font-weight: $font-600;
       text-transform: capitalize;
       color: $text-color;
       margin-top: 8px;

--- a/aim/web/ui/src/components/CodeBlock/CodeBlock.scss
+++ b/aim/web/ui/src/components/CodeBlock/CodeBlock.scss
@@ -11,7 +11,7 @@
   pre {
     margin: 0;
     font-style: normal;
-    font-weight: 500;
+    font-weight: $font-500;
     font-size: $text-lg;
     line-height: 1.3125em;
     overflow: auto;

--- a/aim/web/ui/src/components/CustomTable/Table.scss
+++ b/aim/web/ui/src/components/CustomTable/Table.scss
@@ -19,7 +19,7 @@ $border-radius: 0.2rem;
   box-sizing: border-box;
   content-visibility: auto;
   contain: content;
-  font-weight: 500;
+  font-weight: $font-500;
   &__container {
     height: 100%;
     width: 100%;
@@ -454,7 +454,7 @@ $border-radius: 0.2rem;
 .Table__GroupedColumnHeader {
   color: $pico-50;
   span {
-    font-weight: 700;
+    font-weight: $font-700;
   }
 }
 

--- a/aim/web/ui/src/components/HeatMap/HeatMapStyle.scss
+++ b/aim/web/ui/src/components/HeatMap/HeatMapStyle.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/index' as *;
+
 .CalendarHeatmap {
 }
 
@@ -12,7 +14,7 @@
 
   &.CalendarHeatmap__map__axis--x {
     font-size: 12px;
-    font-weight: 500;
+    font-weight: $font-500;
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/aim/web/ui/src/components/HighPlot/HighPlot.scss
+++ b/aim/web/ui/src/components/HighPlot/HighPlot.scss
@@ -108,7 +108,7 @@
     border: 1px solid $primary-light;
     color: $primary-dark;
     font-size: 10px;
-    font-weight: normal;
+    font-weight: $font-400;
     white-space: nowrap;
   }
   .ChartMouseValueXAxis {
@@ -135,7 +135,6 @@
       stroke-width: 1;
       opacity: 0.2;
     }
-
   }
   .Line {
     stroke-width: 2;

--- a/aim/web/ui/src/components/IllustrationBlock/IllustrationBlock.scss
+++ b/aim/web/ui/src/components/IllustrationBlock/IllustrationBlock.scss
@@ -27,11 +27,11 @@
   }
   &__small {
     &__title {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-md;
     }
     &__content {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-md;
     }
     &__img {
@@ -46,11 +46,11 @@
   }
   &__medium {
     &__title {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-md;
     }
     &__content {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-md;
     }
     &__img {
@@ -64,11 +64,11 @@
   }
   &__large {
     &__title {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-lg;
     }
     &__content {
-      font-weight: 500;
+      font-weight: $font-500;
       font-size: $text-lg;
     }
     &__img {
@@ -82,7 +82,7 @@
   }
   &__xLarge {
     &__title {
-      font-weight: 500;
+      font-weight: $font-500;
       margin-bottom: 1rem;
     }
     &__img {

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -58,7 +58,7 @@
     border: 1px solid $primary-light;
     color: $primary-dark;
     font-size: 10px;
-    font-weight: normal;
+    font-weight: $font-400;
     white-space: nowrap;
   }
   .ChartMouseValueXAxis {
@@ -132,7 +132,8 @@
   }
 
   .inProgressLineIndicator {
-    animation: inProgressIndicator 0.5s cubic-bezier(0.6, -0.03, 0.22, 0.76) infinite;
+    animation: inProgressIndicator 0.5s cubic-bezier(0.6, -0.03, 0.22, 0.76)
+      infinite;
     stroke-width: 1;
     opacity: 1;
   }

--- a/aim/web/ui/src/components/NotificationContainer/NotificationContainer.scss
+++ b/aim/web/ui/src/components/NotificationContainer/NotificationContainer.scss
@@ -33,7 +33,7 @@
   }
   &__contentBox {
     &__severity {
-      font-weight: 600;
+      font-weight: $font-600;
       font-size: $text-md;
       text-transform: capitalize;
       color: $pico;

--- a/aim/web/ui/src/components/NotificationContainer/NotificationContainer.scss
+++ b/aim/web/ui/src/components/NotificationContainer/NotificationContainer.scss
@@ -39,7 +39,7 @@
       color: $pico;
     }
     &__message {
-      font-weight: normal;
+      font-weight: $font-400;
       font-size: $text-md;
       color: $pico;
     }

--- a/aim/web/ui/src/components/ScatterPlot/styles.scss
+++ b/aim/web/ui/src/components/ScatterPlot/styles.scss
@@ -59,7 +59,7 @@
     border: 1px solid $primary-light;
     color: $primary-dark;
     font-size: 10px;
-    font-weight: normal;
+    font-weight: $font-400;
     white-space: nowrap;
   }
   .ChartMouseValueXAxis {

--- a/aim/web/ui/src/components/SideBar/Sidebar.scss
+++ b/aim/web/ui/src/components/SideBar/Sidebar.scss
@@ -36,7 +36,7 @@
         margin-top: 6px;
         font-size: 0.7rem;
         font-style: normal;
-        font-weight: 500;
+        font-weight: $font-500;
         color: #fff;
       }
     }

--- a/aim/web/ui/src/components/SliderWithInput/SliderWithInput.scss
+++ b/aim/web/ui/src/components/SliderWithInput/SliderWithInput.scss
@@ -17,7 +17,7 @@
       border: 0.0625rem solid $cuddle-70;
       border-radius: $border-radius-xss;
       font-size: 0.625rem;
-      font-weight: 600;
+      font-weight: $font-600;
       color: $pico-80;
       padding-left: 0.375rem;
       /* Chrome, Safari, Edge, Opera */
@@ -75,7 +75,7 @@
     &__title {
       margin-right: 0.25rem;
       font-size: $text-xxs;
-      font-weight: 400;
+      font-weight: $font-400;
       color: $pico-70;
     }
     &__sliderValuesLabel {

--- a/aim/web/ui/src/components/Table/BaseTable.scss
+++ b/aim/web/ui/src/components/Table/BaseTable.scss
@@ -1,3 +1,4 @@
+@use 'src/styles/abstracts' as *;
 $table-prefix: BaseTable !default;
 
 @mixin table-edge-padding($padding-left: null, $padding-right: null) {
@@ -40,7 +41,7 @@ $table-prefix: BaseTable !default;
   $box-shadow-blur: 4px !default;
   $border: 1px solid #eeeeee !default;
   $header-background-color: #f8f8f8 !default;
-  $header-font-weight: 600 !default;
+  $header-font-weight: $font-600 !default;
   $row-hovered-background-color: #e2f2ff !default;
   $header-cell-hovered-background-color: #f3f3f3 !default;
   $sort-indicator-hovered-color: #888888 !default;

--- a/aim/web/ui/src/components/kit/Badge/Badge.scss
+++ b/aim/web/ui/src/components/kit/Badge/Badge.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   height: 1.75rem;
   border-radius: 0.375rem;
-  font-weight: 500;
+  font-weight: $font-500;
   white-space: nowrap;
   vertical-align: middle;
   text-decoration: none;

--- a/aim/web/ui/src/components/kit/Slider/Slider.scss
+++ b/aim/web/ui/src/components/kit/Slider/Slider.scss
@@ -37,7 +37,7 @@
         transform: unset;
         span {
           font-size: 0.625rem;
-          font-weight: 600;
+          font-weight: $font-600;
           color: $primary-color;
           transform: unset;
         }

--- a/aim/web/ui/src/components/kit/Text/Text.scss
+++ b/aim/web/ui/src/components/kit/Text/Text.scss
@@ -37,19 +37,25 @@
 
   &__weight {
     &_300 {
-      font-weight: 250;
+      font-weight: $font-300;
     }
     &_400 {
-      font-weight: 350;
+      font-weight: $font-400;
     }
     &_500 {
-      font-weight: 450;
+      font-weight: $font-500;
     }
     &_600 {
-      font-weight: 550;
+      font-weight: $font-600;
     }
     &_700 {
-      font-weight: 650;
+      font-weight: $font-700;
+    }
+    &_800 {
+      font-weight: $font-700;
+    }
+    &_900 {
+      font-weight: $font-700;
     }
   }
 

--- a/aim/web/ui/src/pages/Bookmarks/components/BookmarkCard/BookmarkCard.scss
+++ b/aim/web/ui/src/pages/Bookmarks/components/BookmarkCard/BookmarkCard.scss
@@ -17,7 +17,7 @@
     flex: 1 1;
     p {
       margin-top: 0.25rem;
-      font-weight: normal;
+      font-weight: $font-400;
       font-size: $text-sm;
     }
   }

--- a/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.scss
+++ b/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.scss
@@ -42,7 +42,7 @@
 .SelectForm__tags__empty {
   font-size: $text-md;
   color: $pico-50;
-  font-weight: normal;
+  font-weight: $font-400;
 }
 
 .SelectForm__metric__select {

--- a/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.scss
+++ b/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.scss
@@ -56,7 +56,7 @@
   width: 100%;
   input {
     font-size: $text-sm;
-    font-weight: 500;
+    font-weight: $font-500;
   }
 }
 

--- a/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/ManageColumnsPopover/ManageColumnsPopover.tsx
@@ -296,6 +296,7 @@ function ManageColumnsPopover({
                       <Icon name='search' />
                     </div>
                     <InputBase
+                      fullWidth
                       placeholder='Search'
                       value={searchKey}
                       onChange={onSearchKeyChange}

--- a/aim/web/ui/src/pages/RunDetail/DistributionsVisualizer/DistributionsVisualizer.scss
+++ b/aim/web/ui/src/pages/RunDetail/DistributionsVisualizer/DistributionsVisualizer.scss
@@ -8,7 +8,7 @@
   overflow: hidden;
   .highcharts-subtitle {
     font-style: normal;
-    font-weight: bold;
+    font-weight: $font-700;
     color: $pico-100 !important;
     font-family: 'Inter', sans-serif !important;
   }

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -6,7 +6,8 @@
     height: 100%;
     background: $cuddle-10;
     .BaseTable__row-cell {
-      @include monospaceFontFamily();
+      font-size: 15px;
+      @include monospaceFontFamily(15);
     }
     &__Tabs {
       .MuiTabs-fixed {
@@ -55,7 +56,7 @@
         display: flex;
         flex-direction: column;
         font-size: $text-md;
-        font-weight: 600;
+        font-weight: $font-600;
         color: $text-color;
         align-items: flex-start;
         height: fit-content;
@@ -143,7 +144,7 @@
         .MuiTab-textColorPrimary {
           color: $pico-80;
           font-size: $text-md;
-          font-weight: 500;
+          font-weight: $font-500;
           text-transform: unset;
           min-height: 40px;
           transition: all 0.18s ease-out;

--- a/aim/web/ui/src/pages/RunDetail/RunDetailNotesTab/RunDetailNotesTab.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetailNotesTab/RunDetailNotesTab.scss
@@ -48,7 +48,7 @@
       padding: $space-unit 2rem;
       padding-left: toRem(48px);
       font-family: 'Inter', sans-serif;
-      font-weight: 500;
+      font-weight: $font-500;
       height: 100%;
       opacity: 1;
       color: $pico;

--- a/aim/web/ui/src/pages/RunDetail/RunDetailSettingsTab/RunDetailSettingsTab.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetailSettingsTab/RunDetailSettingsTab.scss
@@ -80,7 +80,7 @@
         &.MuiInputLabel-shrink {
           font-size: $text-xs;
           color: $pico-50;
-          font-weight: 500;
+          font-weight: $font-500;
         }
       }
     }
@@ -109,13 +109,13 @@
             transform: translate(14px, -6px) scale(0.75);
             font-size: $text-xs;
             color: $pico-50;
-            font-weight: 500;
+            font-weight: $font-500;
           }
         }
 
         .MuiFormLabel-root {
           color: $pico-50;
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           &.Mui-error {
             color: #f44336;
@@ -124,7 +124,7 @@
 
         .MuiInputBase-root {
           .MuiInputBase-input {
-            font-weight: 500;
+            font-weight: $font-500;
             font-size: $text-md;
             color: $text-color;
           }

--- a/aim/web/ui/src/pages/Runs/Runs.scss
+++ b/aim/web/ui/src/pages/Runs/Runs.scss
@@ -64,11 +64,11 @@
           padding-right: 0.5625rem;
         }
         .MuiInputBase-input {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-sm;
           color: #414b6d;
           &::placeholder {
-            font-weight: 500;
+            font-weight: $font-500;
             font-size: $text-sm;
             color: #606986;
             opacity: 1;
@@ -83,7 +83,7 @@
           padding-right: 9px;
         }
         .MuiButton-label {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-sm;
           justify-content: flex-start;
         }
@@ -110,7 +110,7 @@
           bottom: 0;
         }
         &__title {
-          font-weight: 600;
+          font-weight: $font-600;
           font-size: $text-sm;
         }
       }
@@ -124,7 +124,7 @@
         justify-content: center;
         align-items: center;
         &__title {
-          font-weight: 600;
+          font-weight: $font-600;
           font-size: $text-sm;
         }
       }

--- a/aim/web/ui/src/pages/Tags/Tags.scss
+++ b/aim/web/ui/src/pages/Tags/Tags.scss
@@ -20,15 +20,15 @@
     &__tabs {
       .MuiTab-textColorInherit {
         opacity: 1;
-        font-weight: 500;
+        font-weight: $font-500;
         font-size: $text-md;
         text-transform: none;
         &.MuiInputBase-input {
-          font-weight: 600;
+          font-weight: $font-600;
         }
       }
       .Mui-selected {
-        font-weight: 600;
+        font-weight: $font-600;
         color: $pico;
       }
     }
@@ -79,11 +79,11 @@
           padding-right: 0.5625rem;
         }
         .MuiInputBase-input {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           color: #414b6d;
           &::placeholder {
-            font-weight: 500;
+            font-weight: $font-500;
             font-size: $text-md;
             color: #606986;
             opacity: 1;
@@ -98,7 +98,7 @@
           padding-right: 0.5rem;
         }
         .MuiButton-label {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           justify-content: flex-start;
         }
@@ -127,7 +127,7 @@
           bottom: 0;
         }
         &__title {
-          font-weight: 600;
+          font-weight: $font-600;
           font-size: $text-md;
         }
       }
@@ -183,19 +183,19 @@
     }
   }
   &__runDuration {
-    font-weight: 500;
+    font-weight: $font-500;
     color: $text-color;
     font-size: $text-lg;
     @include monospaceFontFamily(14);
   }
   &__runCreatedDate {
-    font-weight: 500;
+    font-weight: $font-500;
     color: $text-color;
     font-size: $text-lg;
     @include monospaceFontFamily(14);
   }
   &__runName {
-    font-weight: 500;
+    font-weight: $font-500;
     color: $primary-color;
     text-decoration: none;
     font-size: $text-lg;
@@ -309,7 +309,7 @@
     }
     &__textBox {
       &__titleText {
-        font-weight: 600;
+        font-weight: $font-600;
         font-size: $text-md;
         margin-bottom: 5px;
       }

--- a/aim/web/ui/src/pages/Tags/Tags.scss
+++ b/aim/web/ui/src/pages/Tags/Tags.scss
@@ -314,7 +314,7 @@
         margin-bottom: 5px;
       }
       &__contentText {
-        font-weight: normal;
+        font-weight: $font-400;
         font-size: $text-sm;
       }
     }

--- a/aim/web/ui/src/styles/abstracts/_variables.scss
+++ b/aim/web/ui/src/styles/abstracts/_variables.scss
@@ -128,6 +128,17 @@ $lg: 62em; // (min-width: 992px)
 $gl: 64em; //! gap `lg - xl` (min-width: 1024px)
 $xl: 75em; // (min-width: 1200px)
 $xxl: 80em; // (min-width: 1280px)
+
+// font weight
+
+$font-300: 250;
+$font-400: 350;
+$font-500: 450;
+$font-600: 550;
+$font-700: 650;
+$font-800: 750;
+$font-900: 850;
+
 // space
 $space-unit: 1rem;
 $space-xxxxs: $space-unit * 0.125;

--- a/aim/web/ui/src/styles/base/_reset.scss
+++ b/aim/web/ui/src/styles/base/_reset.scss
@@ -14,7 +14,7 @@ html {
 body {
   font-size: 1em;
   font-family: 'Inter', sans-serif;
-  font-weight: 500;
+  font-weight: $font-500;
   color: $text-color;
   height: 100%;
   max-width: 100vw;

--- a/aim/web/ui/src/styles/components/_inputs.scss
+++ b/aim/web/ui/src/styles/components/_inputs.scss
@@ -36,7 +36,7 @@ body {
   &__OutLined {
     &__Small {
       .MuiInputLabel-outlined.MuiInputLabel-marginDense {
-        font-weight: 500;
+        font-weight: $font-500;
         font-size: $text-md;
         color: $text-color;
         transform: translate(14px, 8px) scale(1);
@@ -49,7 +49,7 @@ body {
 
       .MuiInputBase-root {
         .MuiInputBase-input {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           color: $text-color;
           padding: 0.375rem 1rem;
@@ -69,7 +69,7 @@ body {
     }
     &__Medium {
       .MuiInputLabel-outlined.MuiInputLabel-marginDense {
-        font-weight: 500;
+        font-weight: $font-500;
         font-size: $text-md;
         color: $pico-50;
         transform: translate(14px, 8px) scale(1);
@@ -88,7 +88,7 @@ body {
           border-color: #f44336 !important;
         }
         .MuiInputBase-input {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           color: $text-color;
           padding: 0.375rem 1rem;
@@ -109,7 +109,7 @@ body {
     &__Large {
       .MuiInputBase-root {
         .MuiInputBase-input {
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           color: $text-color;
           padding: 0.5625rem 1rem 0.625rem;
@@ -153,13 +153,13 @@ body {
             transform: translate(14px, -6px) scale(0.75);
             font-size: $text-md;
             color: $pico-80;
-            font-weight: 500;
+            font-weight: $font-500;
           }
         }
 
         .MuiFormLabel-root {
           color: $pico-50;
-          font-weight: 500;
+          font-weight: $font-500;
           font-size: $text-md;
           &.Mui-error {
             color: #f44336;
@@ -168,7 +168,7 @@ body {
 
         .MuiInputBase-root {
           .MuiInputBase-input {
-            font-weight: 500;
+            font-weight: $font-500;
             font-size: $text-md;
             color: $text-color;
           }


### PR DESCRIPTION
- Use style variable for font-weight across Aim UI
- Fix input width in manage columns popover
- Set the cell font-size to 15px for the tables in the RunDetail page
