### PR TITLE
[fix] Break long metric names into multiple lines in Run Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.12.1
+
+- Break long metric names into multiple lines in Run Page (roubkar)
+
 ## 3.12.0 Jul 22, 2022
 
 ### Enhancements:

--- a/aim/web/ui/src/components/CustomTable/Table.scss
+++ b/aim/web/ui/src/components/CustomTable/Table.scss
@@ -109,7 +109,9 @@ $border-radius: 0.2rem;
 
 .Table__pane--selection {
   left: 0;
-  box-shadow: 1px 0 3px 0 $cuddle;
+  &.withShadow {
+    box-shadow: 1px 0 3px 0 $cuddle;
+  }
 }
 
 .Table__pane--right {

--- a/aim/web/ui/src/components/CustomTable/Table.tsx
+++ b/aim/web/ui/src/components/CustomTable/Table.tsx
@@ -317,7 +317,7 @@ function Table(props) {
             <ErrorBoundary key={'selection'}>
               <div
                 className={classNames('Table__pane Table__pane--selection', {
-                  onlyGroupColumn: leftPane.length === 0,
+                  withShadow: leftPane.length === 0,
                 })}
               >
                 <Column

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -252,6 +252,7 @@
         padding: 1rem 1.5rem 1.5rem;
         &__metricName {
           margin: $space-xs 0;
+          word-break: break-all;
         }
         .SelectForm__tags__item {
           margin-top: 0.5rem;


### PR DESCRIPTION
- Break long metric names into multiple lines in Run Page
- Fix a minor issue with the selection pane shadow for the Explorer table