### PR TITLE
[feat] Add collected ranges info into engine and run-search request params

### DIFF
--- a/aim/web/ui/package-lock.json
+++ b/aim/web/ui/package-lock.json
@@ -49,7 +49,8 @@
         "styled-components": "^5.3.3",
         "typeface-roboto": "^1.1.13",
         "web-vitals": "^1.0.1",
-        "yup": "^0.32.9"
+        "yup": "^0.32.9",
+        "zustand": "^4.0.0-rc.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.11.4",
@@ -13874,9 +13875,11 @@
       }
     },
     "node_modules/immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -22307,6 +22310,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/react-dev-utils/node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -27586,6 +27598,14 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -30211,6 +30231,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0-rc.4.tgz",
+      "integrity": "sha512-BP35Rq40GBTKKtYyjLuZogzXGh289xqO8U8ivGIK43nRqURD2dEEImkUci1/jWRUz7J1OPJkUZuNySCho801gQ==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -40928,9 +40971,11 @@
       }
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "optional": true,
+      "peer": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -47570,6 +47615,11 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -51718,6 +51768,12 @@
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
       "requires": {}
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -53830,6 +53886,14 @@
         "nanoclone": "^0.2.1",
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
+      }
+    },
+    "zustand": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0-rc.4.tgz",
+      "integrity": "sha512-BP35Rq40GBTKKtYyjLuZogzXGh289xqO8U8ivGIK43nRqURD2dEEImkUci1/jWRUz7J1OPJkUZuNySCho801gQ==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
       }
     }
   }

--- a/aim/web/ui/package.json
+++ b/aim/web/ui/package.json
@@ -43,7 +43,8 @@
     "styled-components": "^5.3.3",
     "typeface-roboto": "^1.1.13",
     "web-vitals": "^1.0.1",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "zustand": "^4.0.0-rc.4"
   },
   "scripts": {
     "start": "react-app-rewired --max_old_space_size=4096 start",

--- a/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
@@ -131,9 +131,6 @@ function QueryForm(props: IQueryFormProps) {
     [query.advancedModeOn],
   );
 
-  useEffect(() => {
-    console.log(query);
-  }, [query]);
   const onSubmit = React.useCallback(() => {
     if (isFetching) {
       //TODO: abort request
@@ -141,6 +138,10 @@ function QueryForm(props: IQueryFormProps) {
     } else {
       engine.search({
         q: getQueryStringFromSelect(query, sequenceName),
+        record_range: '0:10',
+        index_range: '0:10',
+        record_density: 10,
+        index_density: 10,
         report_progress: false,
       });
     }

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/index.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/index.ts
@@ -9,11 +9,12 @@ import { RunsSearchQueryParams } from 'services/api/base-explorer/runsApi';
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
 import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 
-import createPipeline, { Pipeline, PipelineOptions } from '../pipeline';
 import { IInstructionsState } from '../store/slices/instructionsSlice';
+import createPipeline, { Pipeline, PipelineOptions } from '../pipeline';
 import { GroupType, Order } from '../pipeline/grouping/types';
 import { instructionsSelector } from '../store';
 import { IEngineConfigFinal } from '../types';
+import { IQueryableData } from '../pipeline/adapter/processor';
 
 import {
   createDefaultBoxStateSlice,
@@ -33,6 +34,7 @@ type ExplorerState = {
   data: any;
   additionalData: any;
   foundGroups: any; // remove this
+  queryableData: IQueryableData;
 };
 
 type ExplorerConfig = {
@@ -51,6 +53,7 @@ const initialState: ExplorerState = {
   data: null,
   additionalData: null,
   foundGroups: null,
+  queryableData: {},
 };
 
 let pipeline: Pipeline;
@@ -234,8 +237,9 @@ function createEngine(config: IEngineConfigFinal) {
       ],
     });
 
-    const { additionalData, data } = res;
-    storeVanilla.setState({ data, additionalData });
+    const { additionalData, data, queryable_data: queryableData } = res;
+
+    storeVanilla.setState({ data, additionalData, queryableData });
   }
 
   async function group(
@@ -321,9 +325,7 @@ function createEngine(config: IEngineConfigFinal) {
     instructionsSelector: (state: any) => state.instructions,
 
     // explorer
-    dataSelector: (state: any) => state.data,
     sequenceNameSelector: (state: any) => state.sequenceName,
-    additionalDataSelector: (state: any) => state.additionalData,
     pipelineStatusSelector: (state: any) => state.pipeline.status,
 
     engineStatusSelector: (state: ExplorerState) => ({
@@ -345,7 +347,10 @@ function createEngine(config: IEngineConfigFinal) {
 
     styleAppliers,
     // pipeline result result
+    dataSelector: (state: any) => state.data,
+    additionalDataSelector: (state: any) => state.additionalData,
     foundGroupsSelector: (state: any) => state.foundGroups,
+    queryableDataSelector: (state: any) => state.queryableData,
   };
 }
 

--- a/aim/web/ui/src/pages/BaseExplorer/index.tsx
+++ b/aim/web/ui/src/pages/BaseExplorer/index.tsx
@@ -63,7 +63,7 @@ const config: IExplorerConfig = {
         },
         defaultApplications: {
           fields: [],
-          orders: [Order.DESC, Order.ASC],
+          orders: [],
         },
         // state: {
         //   // observable state, to listen on base visualizer

--- a/aim/web/ui/src/services/api/base-explorer/runsApi/types.ts
+++ b/aim/web/ui/src/services/api/base-explorer/runsApi/types.ts
@@ -24,14 +24,14 @@ export type RunsSearchQueryParams = {
   report_progress?: boolean;
 
   /**
-   * This parameter is used to indicate the range of records by index form index1 to index2
+   * This parameter is used to indicate the range of records by index form index1 to index2 or "index1:index2"
    */
-  index_range?: Tuple<number>;
+  index_range?: Tuple<number> | string;
 
   /**
-   * This parameter is used to indicate the range of records by step form index1 to index2
+   * This parameter is used to indicate the range of records by step form index1 to index2 or "index1:index2"
    */
-  record_range?: Tuple<number>;
+  record_range?: Tuple<number> | string;
 
   /**
    * This parameter is used to for simple sampling, indicates how many steps want to load including their objects

--- a/aim/web/ui/src/services/api/base-explorer/runsApi/types.ts
+++ b/aim/web/ui/src/services/api/base-explorer/runsApi/types.ts
@@ -2,6 +2,8 @@
  * type RunsSearchQueryParams
  * The request query options type of GET /runs/search
  */
+import { Tuple } from 'types/core/shared';
+
 export type RunsSearchQueryParams = {
   /**
    * Number of points
@@ -20,6 +22,26 @@ export type RunsSearchQueryParams = {
    * This flag is using when need to follow to the progress of streaming data
    */
   report_progress?: boolean;
+
+  /**
+   * This parameter is used to indicate the range of records by index form index1 to index2
+   */
+  index_range?: Tuple<number>;
+
+  /**
+   * This parameter is used to indicate the range of records by step form index1 to index2
+   */
+  record_range?: Tuple<number>;
+
+  /**
+   * This parameter is used to for simple sampling, indicates how many steps want to load including their objects
+   */
+  record_density?: number;
+
+  /**
+   * This parameter is used to for simple sampling, indicates how many objects want to load
+   */
+  index_density?: number;
 };
 
 /**

--- a/aim/web/ui/src/types/core/AimObjects/CustomObject.d.ts
+++ b/aim/web/ui/src/types/core/AimObjects/CustomObject.d.ts
@@ -1,13 +1,13 @@
+import { Tuple } from '../shared';
+
 import { SequenceBaseView } from './Sequence';
 import { Params, RunProps } from './Run';
 
-type NumberTuple = [number, number];
-
 export interface BaseRangeInfo {
-  record_range_used: NumberTuple;
-  record_range_total: NumberTuple;
-  index_range_used: ?NumberTuple;
-  index_range_total: ?NumberTuple;
+  record_range_used: Tuple<number>;
+  record_range_total: Tuple<number>;
+  index_range_used: ?Tuple<number>;
+  index_range_total: ?Tuple<number>;
 }
 
 export interface ObjectSequenceBase<T> extends BaseRangeInfo, SequenceBaseView {

--- a/aim/web/ui/src/types/core/shared/index.d.ts
+++ b/aim/web/ui/src/types/core/shared/index.d.ts
@@ -8,3 +8,5 @@ export interface EncodedNumpyArray {
 export type Context = Record<string, any>;
 
 export type Union<T, D> = T | D;
+
+export type Tuple<T> = [T, T];

--- a/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
@@ -96,7 +96,7 @@ export interface IGroupingConfig {
 export interface ISelectOption {
   label: string;
   group: string;
-  color: string;
+  color?: string;
   type?: string;
   value?: {
     option_name: string;


### PR DESCRIPTION
This PR includes
- type enhancement for run search query parameters, added new annotations for ranges and density parameters
- new key on engine named `queryableData` and its selector, the value of this key collected from run search result as record and index ranges information
- a simple query example of using newly added parameters for run search request
- added `zustand` as a dependency to have it on base-explorer