### PR TITLE
[feat] Add controls management in ui core, enhance state management on engine

### DIFF
--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/BoxConfig.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/BoxConfig.tsx
@@ -11,6 +11,7 @@ import { IBaseComponentProps } from '../../types';
 import '../../../../components/ImagePropertiesPopover/ImagePropertiesPopover.scss';
 
 type BoxConfigState = {
+  isInitial: boolean;
   width: number;
   height: number;
   gap: number;
@@ -56,7 +57,7 @@ function BoxConfig(props: IBaseComponentProps) {
           <div
             onClick={onAnchorClick}
             className={`Controls__anchor ${
-              opened ? 'active outlined' : 'active'
+              opened ? 'active outlined' : !boxConfig.isInitial ? 'active' : ''
             }`}
           >
             <Icon

--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/index.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/index.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 
-import { IBaseComponentProps } from '../../types';
-
-import BoxConfig from './BoxConfig';
+import { IControlsProps } from '../../types';
 
 import './styles.scss';
 
-function Controls(props: IBaseComponentProps) {
+function Controls(props: IControlsProps) {
+  const controls = Object.keys(props.engine.controls).map((key: string) => {
+    const Control = props.engine.controls[key].component;
+    return <Control key={key} {...props} />;
+  });
+
   return (
     <div className='Controls__container ScrollBar__hidden'>
-      <div>
-        <BoxConfig engine={props.engine} />
-      </div>
+      <div>{controls}</div>
     </div>
   );
 }
 
-export default React.memo<IBaseComponentProps>(Controls);
+export default React.memo<IControlsProps>(Controls);

--- a/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 import _ from 'lodash-es';
 import classNames from 'classnames';
 
@@ -59,4 +59,4 @@ function GroupingItem({
   );
 }
 
-export default memo(GroupingItem);
+export default React.memo<IGroupingItemProps>(GroupingItem);

--- a/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
@@ -131,9 +131,6 @@ function QueryForm(props: IQueryFormProps) {
     [query.advancedModeOn],
   );
 
-  useEffect(() => {
-    console.log(query);
-  }, [query]);
   const onSubmit = React.useCallback(() => {
     if (isFetching) {
       //TODO: abort request

--- a/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/index.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/index.tsx
@@ -78,7 +78,7 @@ function BaseVisualizer(props: IVisualizationProps) {
           </Box>
         )}
       />
-      <Controls engine={engine} />
+      <props.controlComponent engine={engine} />
     </div>
   );
 }

--- a/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/index.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/index.tsx
@@ -78,7 +78,7 @@ function BaseVisualizer(props: IVisualizationProps) {
           </Box>
         )}
       />
-      <props.controlComponent engine={engine} />
+      {props.controlComponent && <props.controlComponent engine={engine} />}
     </div>
   );
 }

--- a/aim/web/ui/src/modules/BaseExplorer/index.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/index.tsx
@@ -20,7 +20,11 @@ function BaseExplorer(props: IBaseExplorerProps) {
   }, [engineInstance]);
 
   const visualizations = React.useMemo(() => {
-    const p = { engine: engineInstance, box: components.box };
+    const p = {
+      engine: engineInstance,
+      box: components.box,
+      controlComponent: components.controls,
+    };
     const Visualizations: React.ReactNode[] = components.visualizations.map(
       (Viz) => <Viz key={Viz.displayName} {...p} />,
     );
@@ -67,6 +71,7 @@ function createExplorer(config: IExplorerConfig): () => React.ReactElement {
     },
     states: config.states,
     grouping: EC.grouping,
+    controls: EC.controls,
   };
 
   const engine = createEngine(engineConfig);

--- a/aim/web/ui/src/modules/BaseExplorer/types.ts
+++ b/aim/web/ui/src/modules/BaseExplorer/types.ts
@@ -134,7 +134,7 @@ export interface IControlsProps extends IBaseComponentProps {}
 
 export interface IVisualizationProps extends IBaseComponentProps {
   box?: React.FunctionComponent<IBoxProps>;
-  controlComponent: React.FunctionComponent<IControlsProps>;
+  controlComponent?: React.FunctionComponent<IControlsProps>;
 }
 
 export interface IBoxProps extends IBaseComponentProps {

--- a/aim/web/ui/src/modules/BaseExplorer/types.ts
+++ b/aim/web/ui/src/modules/BaseExplorer/types.ts
@@ -4,7 +4,11 @@ import { GroupType } from 'modules/BaseExplorerCore/pipeline/grouping/types';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
 
-import { GroupingConfigs } from '../BaseExplorerCore/core-store/grouping';
+import {
+  GroupingConfig,
+  GroupingConfigs,
+} from '../BaseExplorerCore/core-store/grouping';
+import { ControlsConfigs } from '../BaseExplorerCore/core-store/controls';
 
 export interface IExplorerConfig {
   /**
@@ -57,6 +61,34 @@ export type IEngineConfig = {
     objectCreator?: () => any;
   };
   grouping?: GroupingConfigs;
+  /**
+   * @example
+   * {
+   *     boxProperties: {
+   *       component: BoxProperties,
+   *       settings:{
+   *           maxWidth: 100
+   *           ...etc
+   *       },
+   *       state: {
+   *           initialState: {
+   *               test: true
+   *           }
+   *       }
+   *     }
+   * }
+   *
+   * @Usage (if Control component is the default one)
+   * function BoxProperties(props: IBaseExplorerProps) {
+   *  const state = props.useStore(props.engine.controls.boxProperties.stateSelector);
+   *  const settings = props.useStore(props.engine.controls.boxProperties.settings);
+   *
+   *  // to update state, use props.engine.controls.boxProperties.methods.update
+   *  // to reset state, use props.engine.controls.boxProperties.methods.reset
+   *  const { component, settings, state } = box_properties;
+   *  return <div><div>
+   */
+  controls?: ControlsConfigs;
 };
 
 export type styleApplier = (object: any, currentConfig: any, group: any) => any;
@@ -79,6 +111,18 @@ export type IUIConfig = {
     grouping: React.FunctionComponent<IGroupingProps>;
     visualizations: React.FunctionComponent<IVisualizationProps>[];
     box: React.FunctionComponent<IBoxProps>;
+    /*
+     * @example
+     * function Control(props) {
+     *     // props.engine.controls is the encapsulated config generated from engines controls properties
+     *     // includes states and methods, settings, and component
+     *     const controlItems = Object.keys(props.engine.controls).map(key => {
+     *        const controlConfig = props.engine.controls[key];
+     *        return <controlConfig.component key={key} {...props} />;
+     *     });
+     * }
+     */
+    controls: React.FunctionComponent<IControlsProps>;
   };
 };
 
@@ -86,9 +130,13 @@ export interface IQueryFormProps extends IBaseComponentProps {
   hasAdvancedMode?: boolean;
 }
 export interface IGroupingProps extends IBaseComponentProps {}
+export interface IControlsProps extends IBaseComponentProps {}
+
 export interface IVisualizationProps extends IBaseComponentProps {
   box?: React.FunctionComponent<IBoxProps>;
+  controlComponent: React.FunctionComponent<IControlsProps>;
 }
+
 export interface IBoxProps extends IBaseComponentProps {
   data: any;
 }

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/controls.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/controls.ts
@@ -1,0 +1,89 @@
+import { omit } from 'lodash-es';
+
+import { createSliceState } from './utils';
+
+export type ControlConfig<State extends object, Settings> = {
+  /**
+   * Name of control, using as unique key of control
+   */
+  name: string;
+  component: Function;
+  /**
+   * Observable state
+   * The things kept on this object is observable, and aimed to use from controls
+   */
+  state?: {
+    initialState: State;
+  };
+  /**
+   * Static settings, i.e.
+   * {
+   *     maxWidth: 400,
+   *     minWidth: 100,
+   *     step: 10,
+   * }
+   */
+  settings?: Record<string, Settings>;
+};
+
+export type ControlsConfigs = {
+  [name: string]: Omit<ControlConfig<unknown & object, any>, 'name'>;
+};
+
+function createControl(config: ControlConfig<unknown & object, any>) {
+  const {
+    name,
+    component,
+
+    state = { initialState: {} },
+    settings = {},
+  } = config;
+
+  const observableState = createSliceState(
+    state.initialState,
+    `controls.${name}`,
+  );
+
+  return {
+    settings,
+    component,
+    observableState,
+  };
+}
+
+function createControlsSlice(slices: { [key: string]: any }) {
+  let initialState: Record<string, any> = {};
+  const subSlices: Record<string, any> = {};
+
+  Object.keys(slices).forEach((name) => {
+    const slice = slices[name];
+    initialState = {
+      ...initialState,
+      [name]: slice.observableState.initialState,
+    };
+    subSlices[name] = {
+      ...omit(slice, 'observableState'),
+      ...slice.observableState,
+    };
+  });
+
+  return {
+    initialState,
+    slices: subSlices,
+  };
+}
+
+function createControlsStateConfig(configs: ControlsConfigs = {}) {
+  const controls: { [key: string]: any } = {};
+
+  Object.keys(configs).forEach((name: string) => {
+    controls[name] = createControl({
+      name,
+      ...configs[name],
+    });
+  });
+
+  return createControlsSlice(controls);
+}
+
+export { createControlsStateConfig };

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/controls.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/controls.ts
@@ -34,7 +34,6 @@ function createControl(config: ControlConfig<unknown & object, any>) {
   const {
     name,
     component,
-
     state = { initialState: {} },
     settings = {},
   } = config;

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/index.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/index.ts
@@ -22,6 +22,7 @@ import {
   PreCreatedStateSlice,
 } from './utils';
 import { createGroupingsStateConfig } from './grouping';
+import { createControlsStateConfig } from './controls';
 
 type ExplorerState = {
   initialized: boolean;
@@ -116,6 +117,8 @@ function createEngine(config: IEngineConfigFinal) {
   );
 
   const groupConfigs = createGroupingsStateConfig(config.grouping);
+  const controlConfigs = createControlsStateConfig(config.controls);
+
   const styleAppliers = Object.keys(config.grouping || {}).map(
     (key: string) => {
       return config.grouping?.[key].styleApplier;
@@ -133,6 +136,10 @@ function createEngine(config: IEngineConfigFinal) {
 
   generatedInitialStates['groupings'] = {
     ...groupConfigs.initialState,
+  };
+
+  generatedInitialStates['controls'] = {
+    ...controlConfigs.initialState,
   };
 
   // store creation
@@ -159,6 +166,7 @@ function createEngine(config: IEngineConfigFinal) {
   );
   /*  Slices Creation */
 
+  // grouping
   const encapsulatedGroupProperties = Object.keys(groupConfigs.slices).reduce(
     (acc: { [key: string]: object }, name: string) => {
       const elem = groupConfigs.slices[name];
@@ -175,6 +183,18 @@ function createEngine(config: IEngineConfigFinal) {
     storeVanilla.setState,
     storeVanilla.getState,
   );
+
+  // grouping
+  const encapsulatedControlProperties = Object.keys(
+    controlConfigs.slices,
+  ).reduce((acc: { [key: string]: object }, name: string) => {
+    const elem = controlConfigs.slices[name];
+    acc[name] = {
+      ...elem,
+      methods: elem.methods(storeVanilla.setState, storeVanilla.getState),
+    };
+    return acc;
+  }, {});
 
   const storeReact = createReact(storeVanilla);
 
@@ -337,6 +357,10 @@ function createEngine(config: IEngineConfigFinal) {
     groupings: {
       ...encapsulatedGroupProperties,
       currentValuesSelector: groupConfigs.currentValuesSelector,
+    },
+    // controls
+    controls: {
+      ...encapsulatedControlProperties,
     },
     // instructions
     instructions: {

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/utils.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/utils.ts
@@ -10,7 +10,7 @@ export function createSliceState(initialState: object, name: string) {
     return getValue(state, name);
   };
 
-  // const initialStateHash = buildObjectHash(initialState);
+  const initialStateHash = buildObjectHash(initialState);
 
   const generateMethods = <TS extends Function, TG extends Function>(
     set: TS,
@@ -21,7 +21,7 @@ export function createSliceState(initialState: object, name: string) {
         // @ts-ignore
         ...get()[name],
         ...newState,
-        //initialState: initialStateHash === buildObjectHash(newState),
+        isInitial: initialStateHash === buildObjectHash(newState),
       };
 
       set({
@@ -31,14 +31,20 @@ export function createSliceState(initialState: object, name: string) {
 
     function reset() {
       set({
-        [name]: initialState,
+        [name]: {
+          ...initialState,
+          isInitial: true,
+        },
       });
     }
     return { update, reset };
   };
 
   return {
-    initialState,
+    initialState: {
+      ...initialState,
+      isInitial: true,
+    },
     stateSelector,
     methods: generateMethods,
   };

--- a/aim/web/ui/src/modules/BaseExplorerCore/core-store/utils.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/core-store/utils.ts
@@ -3,11 +3,14 @@ import { get as getValue } from 'lodash-es';
 import { GetState, SetState } from 'utils/store/createSlice';
 
 import { GenerateStoreMethods, IEngineConfigFinal } from '../types';
+import { buildObjectHash } from '../helpers';
 
 export function createSliceState(initialState: object, name: string) {
   const stateSelector = (state: any) => {
     return getValue(state, name);
   };
+
+  // const initialStateHash = buildObjectHash(initialState);
 
   const generateMethods = <TS extends Function, TG extends Function>(
     set: TS,
@@ -18,6 +21,7 @@ export function createSliceState(initialState: object, name: string) {
         // @ts-ignore
         ...get()[name],
         ...newState,
+        //initialState: initialStateHash === buildObjectHash(newState),
       };
 
       set({
@@ -58,6 +62,8 @@ export function createStateSlices(
 
   return createdStates;
 }
+
+//@TODO merge to createSlice
 export function createDefaultBoxStateSlice(config: {
   width: number;
   height: number;
@@ -65,6 +71,7 @@ export function createDefaultBoxStateSlice(config: {
 }) {
   const initialBoxConfig = config;
   const boxConfigSelector = (state: any) => state.boxConfig;
+  const initialStateHash = buildObjectHash(initialBoxConfig);
 
   const generateBoxConfigMethods = <TS extends Function, TG extends Function>(
     set: TS,
@@ -75,10 +82,12 @@ export function createDefaultBoxStateSlice(config: {
       height?: number;
       gap?: number;
     }) {
+      const newStateHash = buildObjectHash(newBoxConfig);
       const updatedConfig = {
         // @ts-ignore
         ...get().boxConfig,
         ...newBoxConfig,
+        isInitial: initialStateHash === newStateHash,
       };
 
       set({
@@ -88,14 +97,20 @@ export function createDefaultBoxStateSlice(config: {
 
     function reset() {
       set({
-        boxConfig: initialBoxConfig,
+        boxConfig: {
+          ...initialBoxConfig,
+          isInitial: true,
+        },
       });
     }
     return { update, reset };
   };
 
   return {
-    initialState: initialBoxConfig,
+    initialState: {
+      ...initialBoxConfig,
+      isInitial: true,
+    },
     stateSelector: boxConfigSelector,
     methods: generateBoxConfigMethods,
   };
@@ -115,9 +130,12 @@ export type PreCreatedStateSlice = {
   methods: GenerateStoreMethods;
 };
 
+//@TODO merge to createSlice
 export function createQueryUISlice(
   initialState: QueryUIStateUnit,
 ): PreCreatedStateSlice {
+  const initialStateHash = buildObjectHash(initialState);
+
   const selector = (state: any) => state.queryUI;
 
   const generateMethods: GenerateStoreMethods = <T>(
@@ -125,22 +143,25 @@ export function createQueryUISlice(
     get: GetState<T>,
   ) => {
     function update(newState: QueryUIStateUnit) {
+      const newStateHash = buildObjectHash(newState);
       const updated = {
         // @ts-ignore
         ...get().queryUI,
         ...newState,
+        isInitial: initialStateHash === newStateHash,
       };
 
       set({
         // @ts-ignore
         queryUI: updated,
+        isInitial: initialStateHash === newStateHash,
       });
     }
 
     function reset() {
       set({
         // @ts-ignore
-        queryUI: { ...initialState },
+        queryUI: { ...initialState, isInitial: true },
       });
     }
 
@@ -149,7 +170,10 @@ export function createQueryUISlice(
 
   return {
     methods: generateMethods,
-    initialState,
+    initialState: {
+      ...initialState,
+      isInitial: true,
+    },
     stateSelector: selector,
   };
 }

--- a/aim/web/ui/src/modules/BaseExplorerCore/helpers.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/helpers.ts
@@ -18,3 +18,40 @@ export function removeExampleTypesFromProjectData(params: GetParamsResult) {
   }
   return params;
 }
+
+export function cyrb53(object: any, seed = 0): string {
+  if (!object) {
+    return '';
+  }
+
+  const objectString = JSON.stringify(object);
+
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+
+  for (let i = 0; i < objectString.length; i++) {
+    const ch = objectString.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString();
+}
+
+// @TODO test more, write tests
+export function buildObjectHash(object: any): string {
+  if (!object) {
+    return '';
+  }
+
+  const objectString = JSON.stringify(object);
+
+  return cyrb53(objectString, 1) + '_' + cyrb53(objectString, 2);
+}

--- a/aim/web/ui/src/modules/BaseExplorerCore/types.ts
+++ b/aim/web/ui/src/modules/BaseExplorerCore/types.ts
@@ -3,6 +3,7 @@ import { GetState, SetState } from 'utils/store/createSlice';
 import { AimObjectDepths, SequenceTypesEnum } from '../../types/core/enums';
 
 import { GroupingConfigs } from './core-store/grouping';
+import { ControlConfig, ControlsConfigs } from './core-store/controls';
 
 export const engineStoreReservedSliceKeys = {
   initialized: 'initialized',
@@ -56,6 +57,7 @@ export interface IEngineConfigFinal {
     objectDepth: AimObjectDepths;
   };
   grouping?: GroupingConfigs;
+  controls?: ControlsConfigs;
   defaultBoxConfig: {
     width: number;
     height: number;

--- a/aim/web/ui/src/pages/BaseExplorer/index.tsx
+++ b/aim/web/ui/src/pages/BaseExplorer/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 
 import createExplorer from 'modules/BaseExplorer';
 import {
@@ -19,8 +19,11 @@ import {
   Order,
 } from 'modules/BaseExplorerCore/pipeline/grouping/types';
 import Figures from 'modules/BaseExplorer/components/Figures/Figures';
+import Controls from 'modules/BaseExplorer/components/Controls';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
+
+import BoxConfig from '../../modules/BaseExplorer/components/Controls/BoxConfig';
 
 const applyStyle: styleApplier = (object: any, boxConfig: any, group: any) => {
   return {
@@ -111,6 +114,50 @@ const config: IExplorerConfig = {
         // },
       },
     },
+
+    controls: {
+      boxProperties: {
+        component: BoxConfig,
+        settings: {
+          maxWidth: 600,
+          minWidth: 300,
+          maxGap: 100,
+          minGap: 100,
+          step: 10,
+        },
+        // no need to have state for boxProperties since it works with the state, which is responsible for grouping as well
+        // this is the reason for empty state, the state property is optional, just kept empty here to have an example for other controls
+        state: {
+          initialState: {},
+        },
+      },
+
+      // @TODO uncomment the code below to see how to see an example more than boxProperties the controls
+      // @TODO delete this example after successfully implementing the controls
+      /*testProperties: {
+        component: (props: IBaseComponentProps) => {
+          const state = props.engine.useStore(
+            props.engine.controls.testProperties.stateSelector,
+          );
+          const settings = props.engine.controls.testProperties;
+
+          function onUpdate() {
+            props.engine.controls.testProperties.methods.update({
+              test: false,
+            });
+          }
+          return <button onClick={onUpdate}>update</button>;
+        },
+        settings: {
+          test: 10,
+        },
+        // no need to have state for boxProperties since it works with the state, which is responsible for grouping as well
+        // this is the reason for empty state, the state property is optional, just kept empty here to have an example for other controls
+        state: {
+          initialState: {},
+        },
+      },*/
+    },
   },
   ui: {
     // visualizationType: 'box', // 'box', 'sequence'
@@ -129,6 +176,7 @@ const config: IExplorerConfig = {
       visualizations: [Visualizer],
       grouping: Grouping,
       box: Figures,
+      controls: Controls,
     },
   },
   states: {

--- a/aim/web/ui/src/pages/BaseExplorer/index.tsx
+++ b/aim/web/ui/src/pages/BaseExplorer/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 
 import createExplorer from 'modules/BaseExplorer';
 import {
@@ -20,10 +20,9 @@ import {
 } from 'modules/BaseExplorerCore/pipeline/grouping/types';
 import Figures from 'modules/BaseExplorer/components/Figures/Figures';
 import Controls from 'modules/BaseExplorer/components/Controls';
+import BoxConfig from 'modules/BaseExplorer/components/Controls/BoxConfig';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
-
-import BoxConfig from '../../modules/BaseExplorer/components/Controls/BoxConfig';
 
 const applyStyle: styleApplier = (object: any, boxConfig: any, group: any) => {
   return {

--- a/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
+++ b/aim/web/ui/src/types/services/models/explorer/createAppModel.d.ts
@@ -96,7 +96,7 @@ export interface IGroupingConfig {
 export interface ISelectOption {
   label: string;
   group: string;
-  color: string;
+  color?: string;
   type?: string;
   value?: {
     option_name: string;


### PR DESCRIPTION
This PR 
**adds**
- controls key in engine config, to pass controls config as it was possible for groupings (including settings, state, component keys)
- controls property of ui components on explorer config, to pass controls area wrapper, as it was for grouping
- `isInitial` flag on every state slice coming from engine, it is  `true` if the state is deeply equal to its `initialState`, otherwise it is false, and this property changes its value automatically, e.g. calling update or reset method of the state slice will automatically change this property, to compare states used `cyrb53` hashing algorithm, by comparing two objects hashes

**Includes**
- rendering controls component and inside default Controls component added code to render components array passed through engine's controls property