### PR TITLE
[fix] Correct metric column key in run table grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Correct metric column key in run table grid (VkoHov)
+- Fix incorrect column keys of metrics in the table grid of the runs dashboard  (VkoHov)
 
 ## 3.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Correct metric column key in run table grid (VkoHov)
+
 ## 3.12.2
 
 - Apply lazy loading on metrics in Run Page (roubkar)

--- a/aim/web/ui/src/components/CustomTable/Table.tsx
+++ b/aim/web/ui/src/components/CustomTable/Table.tsx
@@ -54,8 +54,6 @@ function Table(props) {
     .sort((a, b) => rightCols.indexOf(a.key) - rightCols.indexOf(b.key));
   const sortedColumns = [...leftPane, ...middlePane, ...rightPane];
 
-  const middlePaneColsKey = middlePane.map((col) => col.key).join('');
-
   const groups = !Array.isArray(props.data);
 
   useEffect(() => {
@@ -127,12 +125,7 @@ function Table(props) {
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      props.listWindow.left,
-      props.listWindow.width,
-      colLefts,
-      middlePaneColsKey,
-    ],
+    [props.listWindow.left, props.listWindow.width, colLefts, columns],
   );
 
   const color = React.useMemo(

--- a/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
+++ b/aim/web/ui/src/pages/Runs/components/RunsTableGrid/RunsTableGrid.tsx
@@ -97,7 +97,8 @@ function getRunsTableColumns(
       const systemMetricsList: ITableColumn[] = [];
       const metricsList: ITableColumn[] = [];
       Object.keys(metricsColumns[key]).forEach((metricContext) => {
-        const columnKey = `${systemMetric ? key : `${key}_${metricContext}`}`;
+        const contextName = metricContext ? `_${metricContext}` : '';
+        const columnKey = `${systemMetric ? key : `${key}${contextName}`}`;
         let column = {
           key: columnKey,
           content: systemMetric ? (


### PR DESCRIPTION
Format metric keys for run table grid columns correctly