### PR TITLE
[fix] Fix issue on rendering aim ui on notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes:
 
+- Fix aim ui rendering issue on notebooks (rubenaprikyan)
 - Fix tensorboard convert while converting tensor (sharathmk99)
 - Fix incorrect column keys of metrics in the table grid of the runs dashboard  (VkoHov)
 

--- a/aim/cli/manager/manager.py
+++ b/aim/cli/manager/manager.py
@@ -16,7 +16,7 @@ class ManagerActionStatuses(enum.Enum):
 
 class ManagerActionResult:
     """
-        Object to returned by manager action
+        Object returned by manager action
         If status is ManagerActionStatuses.Failed the info dict should have a message property
         If status is ManagerActionStatuses.Succeed the info dict should have required properties for the specific action
         @TODO add type checking for info fields
@@ -27,7 +27,7 @@ class ManagerActionResult:
 
 
 def run_up(args):
-    args_list = []
+    args_list = ['--log-level=error']
     for p in args.keys():
         if p != '--proxy-url':
             args_list.append(p + '=' + args[p])
@@ -45,6 +45,7 @@ def run_up(args):
         'host': 'http://' + args['--host']
     }
 
+    time.sleep(2)
     for line in child_process.stderr:
         # @TODO improve this solution
         #  The child process `aim cli` has an incompatible things inside
@@ -56,7 +57,6 @@ def run_up(args):
             )
         else:
             if success_msg in line.decode():
-                time.sleep(2)
                 return ManagerActionResult(
                     ManagerActionStatuses.Succeed,
                     info


### PR DESCRIPTION
This problems came after adding warnings in `FileSystemInspector`.
The problem is,  the manager of the aim server running on notebook extension listens to the `stderr` to detect aim server is living or not to show the ui, and warnings are corrupting `stderr`.
Added `--log-level=error` argument while running `aim up` command, and the aim cli will log only errors.
Warnings aren't mandatory for the notebook user, since they are not using terminal to run aim.