### PR TITLE
[feat] Run unit-tests before nightly releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -28,6 +28,35 @@ jobs:
           git commit -m "Update VERSION file"
           git push
 
+  run-checks:
+    runs-on: ubuntu-latest
+    name: Run Unit-tests & Code-style checks
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 'nightly'
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+          architecture: x64
+
+      - name: install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.dev.txt
+          python -m pip install -r tests/requirements.txt
+
+      - name: code style checks
+        run: |
+          flake8 aim
+
+      - name: unit-tests
+        run: |
+          pytest tests || pytest --lf tests
+
   trigger-packaging-workflow:
     needs: version-override
     uses: ./.github/workflows/python-package.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Restrict Run.hash to auto-generated values only (alberttorosyan)
 - Add ability to pin metrics in Run Page (mihran113, roubkar)
+- Add step for unit tests for nightly releases workflow (mihran113)
 
 ### Fixes:
 


### PR DESCRIPTION
Added a job before packaging workflow to run unit tests for nightly releases. 
This is added as an extra job not a step, to be able to re-run without triggering the `version-override` job.