### PR TITLE
[feat] Implement Run check-ins and watcher service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add logging for remote resource cleanup and network stability (mihran113)
 - Restrict Run.hash to auto-generated values only (alberttorosyan)
 - Add ability to compare selected runs from the table (arsengit)
+- Notify users about failed/stalled runs (mahnerak, alberttorosyan)  
 - Add ability to pin metrics in Run Page (mihran113, roubkar)
 - Add step for unit tests for nightly releases workflow (mihran113)
 

--- a/aim/cli/watcher_cli.py
+++ b/aim/cli/watcher_cli.py
@@ -1,7 +1,9 @@
 import click
-from click import core
 import uuid
-import json
+
+from click import core
+from collections import OrderedDict
+from typing import Optional, Mapping
 
 from aim.ext.notifier import get_config
 from aim.ext.notifier.utils import has_watcher_config, set_default_config
@@ -9,56 +11,110 @@ from aim.sdk.run_status_watcher import RunStatusWatcher
 from aim.sdk.repo import Repo
 
 core._verify_python3_env = lambda: None
-DEFAULT_MESSAGE_TEMPLATE = "❗️ Something wrong with Run '{run_hash}'. Please check. ❗️"
+DEFAULT_MESSAGE_TEMPLATE = "❗️ Something wrong with Run '{run.hash}'. Please check. ❗️"
 
 
-def check_configuration(repo: Repo):
+class OrderedGroup(click.Group):
+    def __init__(self, name: Optional[str] = None, commands: Optional[Mapping[str, click.Command]] = None, **kwargs):
+        super(OrderedGroup, self).__init__(name, commands, **kwargs)
+        #: the registered subcommands by their exported names.
+        self.commands = commands or OrderedDict()
+
+    def list_commands(self, ctx: click.Context) -> Mapping[str, click.Command]:
+        return self.commands
+
+
+def check_configuration(ctx: click.Context, repo: Repo) -> bool:
     if not has_watcher_config(repo.path):
-        if click.confirm(f'Repo {repo.path} has no configured notifications. Would you like to '
-                         f'use default configuration?', abort=True):
+        click.echo(f'Repo \'{repo.path}\' has no configured notifiers.')
+        if click.confirm('Would you like to configure notifiers?', default=True):
+            ctx.invoke(add_config)
+        elif click.confirm('Would you like to use default configuration?'):
             set_default_config(repo.path)
+        else:
+            return False
+    return True
 
 
-@click.group(invoke_without_command=True)
-@click.option('--repo', required=False, type=click.Path(exists=True,
-                                                        file_okay=False,
-                                                        dir_okay=True,
-                                                        writable=True))
+def dump_notifier_config(cfg: dict):
+    lines = ['', '', f'Type: {cfg["type"]}']
+    for arg_name, value in cfg['arguments'].items():
+        printable_name = arg_name.replace('_', ' ').capitalize()
+        lines.append(f'{printable_name}: {value}')
+    lines.append('--------')
+    click.echo('\n'.join(lines))
+
+
+@click.group()
+@click.option('--repo',
+              required=False,
+              help='Aim Repo to check Run statuses.',
+              type=click.Path(exists=True,
+                              file_okay=False,
+                              dir_okay=True,
+                              writable=True))
 @click.pass_context
 def cli_entry_point(ctx, repo):
+    """Service for detecting and reporting training Run failures."""
     repo_path = repo or Repo.default_repo_path()
-    if ctx.invoked_subcommand is None:
-        repo = Repo.from_path(repo_path)
-        check_configuration(repo)
-        watcher = RunStatusWatcher(repo)
-        watcher.start_watcher()
-    else:
-        ctx.ensure_object(dict)
-        ctx.obj['repo_path'] = repo_path
-
-
-@cli_entry_point.group('config', invoke_without_command=True)
-@click.pass_context
-def config(ctx):
-    repo_path = ctx.obj['repo_path']
     repo = Repo.from_path(repo_path)
-    check_configuration(repo)
 
+    ctx.ensure_object(dict)
+    ctx.obj['repo'] = repo
     ctx.obj['config'] = get_config(repo.path)
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(add_config)
 
 
-@config.command('dump')
+@cli_entry_point.command(name='start')
+@click.pass_context
+def start_watcher(ctx):
+    """Start watcher service to monitor and report stuck/failed Runs."""
+    repo = ctx.obj['repo']
+    if check_configuration(ctx, repo):
+        watcher = RunStatusWatcher(repo)
+        click.secho(f'Starting Aim watcher for repo \'{repo.path}\'...', fg='yellow')
+        click.echo('Press Ctrl+C to exit')
+        watcher.start_watcher()
+
+
+@cli_entry_point.group(cls=OrderedGroup, name='notifiers')
+@click.pass_context
+def config_notifiers(ctx):
+    """Configure how notifications should be received."""
+    pass
+
+
+@click.command(name='dump', hidden=True)
 @click.pass_context
 def dump_config(ctx):
-    config = ctx.obj['config']
-    click.echo(config.dump())
+    """Dump notifier configuration file."""
+    cfg = ctx.obj['config']
+    if not cfg.exists():
+        repo = ctx.obj['repo']
+        click.echo(f'Cannot find notifier configuration for Repo \'{repo.path}\'.')
+        return
+
+    click.echo(cfg.dump())
 
 
-@config.group('add', invoke_without_command=True)
+@click.command(name='list')
+@click.pass_context
+def list_config(ctx):
+    """List available notifiers."""
+    cfg = ctx.obj['config']
+    if not cfg.exists():
+        repo = ctx.obj['repo']
+        click.echo(f'Cannot find notifier configuration for Repo \'{repo.path}\'.')
+        return
+
+    click.echo("{:<40} {:<10} {:<10}".format('NOTIFIER ID', 'TYPE', 'STATUS'))
+    for notifier in cfg.notifiers.values():
+        click.echo("{:<40} {:<10} {:<10}".format(notifier['id'], notifier['type'], notifier['status']))
+
+
+@click.group(name='add', invoke_without_command=True)
 @click.pass_context
 def add_config(ctx):
+    """Add a new notifier configuration (slack, workplace, etc.)."""
     if ctx.invoked_subcommand is None:
         add_new = True
         while add_new:
@@ -70,28 +126,40 @@ def add_config(ctx):
                 if isinstance(param, click.Option) and param.prompt:
                     extra_args[param.name] = param.prompt_for_value(ctx)
             ctx.invoke(sub_cmd, **extra_args)
-            add_new = click.confirm('Would you like to add another Notifier?')
+            add_new = click.confirm('Would you like to add another notifier?')
 
 
-@config.command('remove')
+@click.command(name='remove')
 @click.argument('notifier-id', required=True, type=str)
 @click.pass_context
 def remove_config(ctx, notifier_id):
+    """Remove notifier configuration from the list."""
     cfg = ctx.obj['config']
+    if not cfg.exists():
+        repo = ctx.obj['repo']
+        click.echo(f'Cannot find notifier configuration for Repo \'{repo.path}\'.')
+        return
+
     if notifier_id in cfg.notifiers:
-        click.echo(json.dumps(cfg.get(notifier_id), indent=2))
-        click.confirm('Remove configuration above?', abort=True)
+        dump_notifier_config(cfg.get(notifier_id))
+        click.confirm('Remove notifier configuration above?', abort=True)
         cfg.remove(notifier_id)
         cfg.save()
     else:
         click.echo(f'No notifier with id {notifier_id} found.')
 
 
-@config.command('enable')
+@click.command(name='enable')
 @click.argument('notifier-id', required=True, type=str)
 @click.pass_context
 def enable_config(ctx, notifier_id):
+    """Start receiving notifications from given notifier."""
     cfg = ctx.obj['config']
+    if not cfg.exists():
+        repo = ctx.obj['repo']
+        click.echo(f'Cannot find notifier configuration for Repo \'{repo.path}\'.')
+        return
+
     if notifier_id in cfg.notifiers:
         cfg.enable(notifier_id)
         cfg.save()
@@ -99,11 +167,17 @@ def enable_config(ctx, notifier_id):
         click.echo(f'No notifier with id {notifier_id} found.')
 
 
-@config.command('disable')
+@click.command(name='disable')
 @click.argument('notifier-id', required=True, type=str)
 @click.pass_context
-def enable_config(ctx, notifier_id):
+def disable_config(ctx, notifier_id):
+    """Stop receiving notifications from given notifier."""
     cfg = ctx.obj['config']
+    if not cfg.exists():
+        repo = ctx.obj['repo']
+        click.echo(f'Cannot find notifier configuration for Repo \'{repo.path}\'.')
+        return
+
     if notifier_id in cfg.notifiers:
         cfg.disable(notifier_id)
         cfg.save()
@@ -111,7 +185,7 @@ def enable_config(ctx, notifier_id):
         click.echo(f'No notifier with id {notifier_id} found.')
 
 
-@add_config.command('workplace')
+@add_config.command(name='workplace')
 @click.option('--group-id', prompt=True, required=True, type=int)
 @click.option('--access-token', prompt=True, required=True, type=str)
 @click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
@@ -127,13 +201,13 @@ def workplace_config(ctx, group_id, access_token, message):
             'message': message,
         }
     }
-    click.echo(json.dumps(new_cfg, indent=2))
-    click.confirm('Save configuration above?', abort=True)
+    dump_notifier_config(new_cfg)
+    click.confirm('Save notifier configuration above?', default=True, abort=True)
     cfg.add(new_cfg)
     cfg.save()
 
 
-@add_config.command('slack')
+@add_config.command(name='slack')
 @click.option('--webhook-url', prompt=True, required=True, type=str)
 @click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
 @click.pass_context
@@ -147,13 +221,13 @@ def slack_config(ctx, webhook_url, message):
             'message': message,
         }
     }
-    click.echo(json.dumps(new_cfg, indent=2))
-    click.confirm('Save configuration above?', abort=True)
+    dump_notifier_config(new_cfg)
+    click.confirm('Save notifier configuration above?', default=True, abort=True)
     cfg.add(new_cfg)
     cfg.save()
 
 
-@add_config.command('logger')
+@add_config.command(name='logger')
 @click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
 @click.pass_context
 def logger_config(ctx, message):
@@ -165,7 +239,15 @@ def logger_config(ctx, message):
             'message': message,
         }
     }
-    click.echo(json.dumps(new_cfg, indent=2))
-    click.confirm('Save configuration above?', abort=True)
+    dump_notifier_config(new_cfg)
+    click.confirm('Save notifier configuration above?', default=True, abort=True)
     cfg.add(new_cfg)
     cfg.save()
+
+
+config_notifiers.add_command(add_config)
+config_notifiers.add_command(list_config)
+config_notifiers.add_command(remove_config)
+config_notifiers.add_command(disable_config)
+config_notifiers.add_command(enable_config)
+config_notifiers.add_command(dump_config)

--- a/aim/cli/watcher_cli.py
+++ b/aim/cli/watcher_cli.py
@@ -1,0 +1,171 @@
+import click
+from click import core
+import uuid
+import json
+
+from aim.ext.notifier import get_config
+from aim.ext.notifier.utils import has_watcher_config, set_default_config
+from aim.sdk.run_status_watcher import RunStatusWatcher
+from aim.sdk.repo import Repo
+
+core._verify_python3_env = lambda: None
+DEFAULT_MESSAGE_TEMPLATE = "❗️ Something wrong with Run '{run_hash}'. Please check. ❗️"
+
+
+def check_configuration(repo: Repo):
+    if not has_watcher_config(repo.path):
+        if click.confirm(f'Repo {repo.path} has no configured notifications. Would you like to '
+                         f'use default configuration?', abort=True):
+            set_default_config(repo.path)
+
+
+@click.group(invoke_without_command=True)
+@click.option('--repo', required=False, type=click.Path(exists=True,
+                                                        file_okay=False,
+                                                        dir_okay=True,
+                                                        writable=True))
+@click.pass_context
+def cli_entry_point(ctx, repo):
+    repo_path = repo or Repo.default_repo_path()
+    if ctx.invoked_subcommand is None:
+        repo = Repo.from_path(repo_path)
+        check_configuration(repo)
+        watcher = RunStatusWatcher(repo)
+        watcher.start_watcher()
+    else:
+        ctx.ensure_object(dict)
+        ctx.obj['repo_path'] = repo_path
+
+
+@cli_entry_point.group('config', invoke_without_command=True)
+@click.pass_context
+def config(ctx):
+    repo_path = ctx.obj['repo_path']
+    repo = Repo.from_path(repo_path)
+    check_configuration(repo)
+
+    ctx.obj['config'] = get_config(repo.path)
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(add_config)
+
+
+@config.command('dump')
+@click.pass_context
+def dump_config(ctx):
+    config = ctx.obj['config']
+    click.echo(config.dump())
+
+
+@config.group('add', invoke_without_command=True)
+@click.pass_context
+def add_config(ctx):
+    if ctx.invoked_subcommand is None:
+        add_new = True
+        while add_new:
+            sub_commands = ctx.command.list_commands(ctx)
+            choice = click.prompt('Select notifier type to add:', show_choices=True, type=click.Choice(sub_commands))
+            sub_cmd = ctx.command.get_command(ctx, choice)
+            extra_args = {}
+            for param in sub_cmd.params:
+                if isinstance(param, click.Option) and param.prompt:
+                    extra_args[param.name] = param.prompt_for_value(ctx)
+            ctx.invoke(sub_cmd, **extra_args)
+            add_new = click.confirm('Would you like to add another Notifier?')
+
+
+@config.command('remove')
+@click.argument('notifier-id', required=True, type=str)
+@click.pass_context
+def remove_config(ctx, notifier_id):
+    cfg = ctx.obj['config']
+    if notifier_id in cfg.notifiers:
+        click.echo(json.dumps(cfg.get(notifier_id), indent=2))
+        click.confirm('Remove configuration above?', abort=True)
+        cfg.remove(notifier_id)
+        cfg.save()
+    else:
+        click.echo(f'No notifier with id {notifier_id} found.')
+
+
+@config.command('enable')
+@click.argument('notifier-id', required=True, type=str)
+@click.pass_context
+def enable_config(ctx, notifier_id):
+    cfg = ctx.obj['config']
+    if notifier_id in cfg.notifiers:
+        cfg.enable(notifier_id)
+        cfg.save()
+    else:
+        click.echo(f'No notifier with id {notifier_id} found.')
+
+
+@config.command('disable')
+@click.argument('notifier-id', required=True, type=str)
+@click.pass_context
+def enable_config(ctx, notifier_id):
+    cfg = ctx.obj['config']
+    if notifier_id in cfg.notifiers:
+        cfg.disable(notifier_id)
+        cfg.save()
+    else:
+        click.echo(f'No notifier with id {notifier_id} found.')
+
+
+@add_config.command('workplace')
+@click.option('--group-id', prompt=True, required=True, type=int)
+@click.option('--access-token', prompt=True, required=True, type=str)
+@click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
+@click.pass_context
+def workplace_config(ctx, group_id, access_token, message):
+    cfg = ctx.obj['config']
+    new_cfg = {
+        'id': str(uuid.uuid4()),
+        'type': 'workplace',
+        'arguments': {
+            'group_id': group_id,
+            'access_token': access_token,
+            'message': message,
+        }
+    }
+    click.echo(json.dumps(new_cfg, indent=2))
+    click.confirm('Save configuration above?', abort=True)
+    cfg.add(new_cfg)
+    cfg.save()
+
+
+@add_config.command('slack')
+@click.option('--webhook-url', prompt=True, required=True, type=str)
+@click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
+@click.pass_context
+def slack_config(ctx, webhook_url, message):
+    cfg = ctx.obj['config']
+    new_cfg = {
+        'id': str(uuid.uuid4()),
+        'type': 'slack',
+        'arguments': {
+            'url': webhook_url,
+            'message': message,
+        }
+    }
+    click.echo(json.dumps(new_cfg, indent=2))
+    click.confirm('Save configuration above?', abort=True)
+    cfg.add(new_cfg)
+    cfg.save()
+
+
+@add_config.command('logger')
+@click.option('--message', prompt=True, required=False, type=str, default=DEFAULT_MESSAGE_TEMPLATE, show_default=True)
+@click.pass_context
+def logger_config(ctx, message):
+    cfg = ctx.obj['config']
+    new_cfg = {
+        'id': str(uuid.uuid4()),
+        'type': 'logger',
+        'arguments': {
+            'message': message,
+        }
+    }
+    click.echo(json.dumps(new_cfg, indent=2))
+    click.confirm('Save configuration above?', abort=True)
+    cfg.add(new_cfg)
+    cfg.save()

--- a/aim/ext/notifier/__init__.py
+++ b/aim/ext/notifier/__init__.py
@@ -1,4 +1,4 @@
-from aim.ext.notifier.notifier import Notifier
+from aim.ext.notifier.notifier import Notifier, NotificationSendError
 from aim.ext.notifier.notifier_builder import NotifierBuilder
 from aim.ext.notifier.config import Config
 from aim.ext.notifier.utils import get_config_path
@@ -11,8 +11,9 @@ def get_config(base_dir) -> Config:
 
 def get_notifier(base_dir) -> Notifier:
     cfg = get_config(base_dir)
+    cfg.load()
     builder = NotifierBuilder(cfg.notifiers)
     return builder.build()
 
 
-__all__ = ['Notifier', 'Config', 'get_config', 'get_notifier']
+__all__ = ['Notifier', 'NotificationSendError', 'Config', 'get_config', 'get_notifier']

--- a/aim/ext/notifier/__init__.py
+++ b/aim/ext/notifier/__init__.py
@@ -1,29 +1,18 @@
-import os
-from pathlib import Path
-
 from aim.ext.notifier.notifier import Notifier
 from aim.ext.notifier.notifier_builder import NotifierBuilder
+from aim.ext.notifier.config import Config
+from aim.ext.notifier.utils import get_config_path
 
 
-here = os.path.abspath(os.path.dirname(__file__))
+def get_config(base_dir) -> Config:
+    config_file = get_config_path(base_dir)
+    return Config(config_file)
 
 
-def default_config_path() -> Path:
-    return Path(here) / 'config_default.json'
-
-
-def get_config(config_file: Path) -> dict:
-    import json
-
-    with config_file.open() as notif_fh:
-        return json.load(notif_fh)
-
-
-def get_notifier(config_file: Path) -> Notifier:
-    base_config = get_config(config_file)
-    notif_config = base_config['notifications']
-    builder = NotifierBuilder(notif_config['notifiers'])
+def get_notifier(base_dir) -> Notifier:
+    cfg = get_config(base_dir)
+    builder = NotifierBuilder(cfg.notifiers)
     return builder.build()
 
 
-__all__ = ['Notifier', 'get_notifier', 'default_config_path']
+__all__ = ['Notifier', 'Config', 'get_config', 'get_notifier']

--- a/aim/ext/notifier/__init__.py
+++ b/aim/ext/notifier/__init__.py
@@ -1,0 +1,29 @@
+import os
+from pathlib import Path
+
+from aim.ext.notifier.notifier import Notifier
+from aim.ext.notifier.notifier_builder import NotifierBuilder
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def default_config_path() -> Path:
+    return Path(here) / 'config_default.json'
+
+
+def get_config(config_file: Path) -> dict:
+    import json
+
+    with config_file.open() as notif_fh:
+        return json.load(notif_fh)
+
+
+def get_notifier(config_file: Path) -> Notifier:
+    base_config = get_config(config_file)
+    notif_config = base_config['notifications']
+    builder = NotifierBuilder(notif_config['notifiers'])
+    return builder.build()
+
+
+__all__ = ['Notifier', 'get_notifier', 'default_config_path']

--- a/aim/ext/notifier/base_notifier.py
+++ b/aim/ext/notifier/base_notifier.py
@@ -5,5 +5,8 @@ class BaseNotifier(object):
     def __init__(self, _id: str):
         self._id = _id
 
+    def __repr__(self):
+        return f'<{self.__class__.__name__} object at {id(self)}>'
+
     def notify(self, message: Optional[str] = None, **kwargs):
         raise NotImplementedError

--- a/aim/ext/notifier/base_notifier.py
+++ b/aim/ext/notifier/base_notifier.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+
+class BaseNotifier(object):
+    def __init__(self, _id: str):
+        self._id = _id
+
+    def notify(self, message: Optional[str] = None, **kwargs):
+        raise NotImplementedError

--- a/aim/ext/notifier/config.py
+++ b/aim/ext/notifier/config.py
@@ -4,15 +4,26 @@ import uuid
 from typing import Dict
 from pathlib import Path
 
+from aim.ext.notifier.utils import get_empty_config_path
+
 
 class Config:
     def __init__(self, config_file: Path):
         self._cfg_file: Path = config_file
         self._cfg = {}
-        self.load()
+        if self.exists():
+            self._from_file(self._cfg_file)
+        else:
+            self._from_file(get_empty_config_path())
+
+    def exists(self) -> bool:
+        return self._cfg_file.exists()
 
     def load(self):
-        with self._cfg_file.open() as cfg_fh:
+        self._from_file(self._cfg_file)
+
+    def _from_file(self, cfg_file: Path):
+        with cfg_file.open() as cfg_fh:
             self._cfg = json.load(cfg_fh)
 
     def save(self):

--- a/aim/ext/notifier/config.py
+++ b/aim/ext/notifier/config.py
@@ -1,0 +1,49 @@
+import json
+import uuid
+
+from typing import Dict
+from pathlib import Path
+
+
+class Config:
+    def __init__(self, config_file: Path):
+        self._cfg_file: Path = config_file
+        self._cfg = {}
+        self.load()
+
+    def load(self):
+        with self._cfg_file.open() as cfg_fh:
+            self._cfg = json.load(cfg_fh)
+
+    def save(self):
+        with self._cfg_file.open('w+') as cfg_fh:
+            json.dump(self._cfg, cfg_fh, indent=2)
+
+    def dump(self) -> str:
+        return json.dumps(self._cfg, indent=2)
+
+    def add(self, config: Dict):
+        cfg_id = config['id']
+        config['status'] = 'enabled'
+        self._cfg['notifications']['notifiers'][cfg_id] = config
+
+    def get(self, cfg_id: uuid.UUID) -> Dict:
+        return self.notifiers.get(cfg_id, {})
+
+    def enable(self, cfg_id: uuid.UUID):
+        cfg = self.notifiers[cfg_id]
+        cfg['status'] = 'enabled'
+
+    def disable(self, cfg_id: uuid.UUID):
+        cfg = self.notifiers[cfg_id]
+        cfg['status'] = 'disabled'
+
+    def remove(self, cfg_id: uuid.UUID) -> bool:
+        if cfg_id in self.notifiers:
+            del self.notifiers[cfg_id]
+            return True
+        return False
+
+    @property
+    def notifiers(self) -> Dict:
+        return self._cfg['notifications']['notifiers']

--- a/aim/ext/notifier/config_default.json
+++ b/aim/ext/notifier/config_default.json
@@ -7,7 +7,7 @@
         "type": "logger",
         "status": "enabled",
         "arguments": {
-          "message": "❗️ Something wrong with Run '{run_hash}'. Please check. ❗️"
+          "message": "❗️ Something wrong with Run '{run.hash}'. Please check. ❗️"
         }
       }
     }

--- a/aim/ext/notifier/config_default.json
+++ b/aim/ext/notifier/config_default.json
@@ -1,0 +1,14 @@
+{
+  "notifications": {
+    "version": "1.0",
+    "notifiers": [
+    {
+        "id": "b6487000-b521-4a2a-a42b-8fee1b7fa43d",
+        "type": "logger",
+        "arguments": {
+          "message": "❗️ Something wrong with Run '{run_hash}'. Please check. ❗️"
+        }
+      }
+    ]
+  }
+}

--- a/aim/ext/notifier/config_default.json
+++ b/aim/ext/notifier/config_default.json
@@ -1,14 +1,15 @@
 {
   "notifications": {
     "version": "1.0",
-    "notifiers": [
-    {
+    "notifiers": {
+    "b6487000-b521-4a2a-a42b-8fee1b7fa43d": {
         "id": "b6487000-b521-4a2a-a42b-8fee1b7fa43d",
         "type": "logger",
+        "status": "enabled",
         "arguments": {
           "message": "❗️ Something wrong with Run '{run_hash}'. Please check. ❗️"
         }
       }
-    ]
+    }
   }
 }

--- a/aim/ext/notifier/config_empty.json
+++ b/aim/ext/notifier/config_empty.json
@@ -1,0 +1,6 @@
+{
+  "notifications": {
+    "version": "1.0",
+    "notifiers": {}
+  }
+}

--- a/aim/ext/notifier/logging_notifier.py
+++ b/aim/ext/notifier/logging_notifier.py
@@ -1,0 +1,16 @@
+import logging
+from typing import Optional
+
+from aim.ext.notifier.base_notifier import BaseNotifier
+
+
+class LoggingNotifier(BaseNotifier):
+    def __init__(self, _id: str, config: dict):
+        super().__init__(_id)
+        self.message_template = config['message']
+        self.logger = logging.getLogger('notifier')
+
+    def notify(self, message: Optional[str] = None, **kwargs):
+        message_template = message or self.message_template
+        msg = message_template.format(**kwargs)
+        self.logger.error(msg)

--- a/aim/ext/notifier/notifier.py
+++ b/aim/ext/notifier/notifier.py
@@ -1,9 +1,21 @@
+import logging
+import time
 from typing import List, Optional
 
 from aim.ext.notifier.base_notifier import BaseNotifier
 
+logger = logging.getLogger(__name__)
+
+
+class NotificationSendError(RuntimeError):
+    def __init__(self, e: Exception):
+        super().__init__(e)
+
 
 class Notifier(BaseNotifier):
+    MAX_RETRIES = 5
+    RETRY_DELAY = 1
+
     def __init__(self):
         self._notifiers: List[BaseNotifier] = []
 
@@ -12,4 +24,19 @@ class Notifier(BaseNotifier):
 
     def notify(self, message: Optional[str] = None, **kwargs):
         for sub in self._notifiers:
-            sub.notify(message, **kwargs)
+            attempt = 0
+            while attempt < self.MAX_RETRIES:
+                try:
+                    sub.notify(message, **kwargs)
+                    break
+                except Exception as e:
+                    attempt += 1
+                    if attempt == self.MAX_RETRIES:
+                        logger.error(f'Notifier {sub} failed to send message "{message}". '
+                                     f'No retries left.')
+                        raise NotificationSendError(e)
+                    else:
+                        logger.error(f'Notifier {sub} failed to send message "{message}". '
+                                     f'Retry attempts left {self.MAX_RETRIES - attempt} '
+                                     f'Next retry in {self.RETRY_DELAY} seconds.')
+                        time.sleep(self.RETRY_DELAY)

--- a/aim/ext/notifier/notifier.py
+++ b/aim/ext/notifier/notifier.py
@@ -1,0 +1,15 @@
+from typing import List, Optional
+
+from aim.ext.notifier.base_notifier import BaseNotifier
+
+
+class Notifier(BaseNotifier):
+    def __init__(self):
+        self._notifiers: List[BaseNotifier] = []
+
+    def add(self, sub: BaseNotifier):
+        self._notifiers.append(sub)
+
+    def notify(self, message: Optional[str] = None, **kwargs):
+        for sub in self._notifiers:
+            sub.notify(message, **kwargs)

--- a/aim/ext/notifier/notifier_builder.py
+++ b/aim/ext/notifier/notifier_builder.py
@@ -20,10 +20,12 @@ class NotifierBuilder(object):
 
     def build(self) -> Notifier:
         notifier = Notifier()
-        for sub_config in self.config:
+        for sub_config in self.config.values():
             notif_type = sub_config['type']
             notif_id = sub_config['id']
             args = sub_config['arguments']
+            if sub_config['status'] != 'enabled':
+                continue
             try:
                 notif_cls = self._factories[notif_type]
             except KeyError:

--- a/aim/ext/notifier/notifier_builder.py
+++ b/aim/ext/notifier/notifier_builder.py
@@ -1,0 +1,34 @@
+import logging
+
+from aim.ext.notifier.logging_notifier import LoggingNotifier
+from aim.ext.notifier.slack_notifier import SlackNotifier
+from aim.ext.notifier.workplace_notifier import WorkplaceNotifier
+from aim.ext.notifier.notifier import Notifier
+
+logger = logging.getLogger(__name__)
+
+
+class NotifierBuilder(object):
+    _factories = {
+        'logger': LoggingNotifier,
+        'workplace': WorkplaceNotifier,
+        'slack': SlackNotifier
+    }
+
+    def __init__(self, config: dict):
+        self.config = config
+
+    def build(self) -> Notifier:
+        notifier = Notifier()
+        for sub_config in self.config:
+            notif_type = sub_config['type']
+            notif_id = sub_config['id']
+            args = sub_config['arguments']
+            try:
+                notif_cls = self._factories[notif_type]
+            except KeyError:
+                logger.warning(f'Unknown notifier type {notif_type}. Skipping.')
+            else:
+                sub_notifier = notif_cls(notif_id, args)
+                notifier.add(sub_notifier)
+        return notifier

--- a/aim/ext/notifier/slack_notifier.py
+++ b/aim/ext/notifier/slack_notifier.py
@@ -1,0 +1,17 @@
+import requests
+from typing import Optional
+
+from aim.ext.notifier.base_notifier import BaseNotifier
+
+
+class SlackNotifier(BaseNotifier):
+    def __init__(self, _id: str, config: dict):
+        super().__init__(_id)
+        self.message_template = config['message']
+
+        self.url = config['url']
+
+    def notify(self, message: Optional[str] = None, **kwargs):
+        message_template = message or self.message_template
+        msg = message_template.format(**kwargs)
+        requests.post(self.url, json={'text': msg})

--- a/aim/ext/notifier/utils.py
+++ b/aim/ext/notifier/utils.py
@@ -25,6 +25,10 @@ def get_default_config_path() -> Path:
     return Path(here) / 'config_default.json'
 
 
+def get_empty_config_path() -> Path:
+    return Path(here) / 'config_empty.json'
+
+
 def has_watcher_config(base_dir: Union[str, Path]) -> bool:
     config_path = get_config_path(base_dir)
     return config_path.is_file()

--- a/aim/ext/notifier/utils.py
+++ b/aim/ext/notifier/utils.py
@@ -1,0 +1,36 @@
+import os
+import shutil
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Union
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+@lru_cache()
+def get_working_directory(base_dir: Union[str, Path]) -> Path:
+    if not isinstance(base_dir, Path):
+        base_dir = Path(base_dir)
+    work_dir = base_dir / 'ext' / 'notifications'
+    work_dir.mkdir(parents=True, exist_ok=True)
+    return work_dir
+
+
+def get_config_path(base_dir: Union[str, Path]) -> Path:
+    return get_working_directory(base_dir) / 'config.json'
+
+
+def get_default_config_path() -> Path:
+    return Path(here) / 'config_default.json'
+
+
+def has_watcher_config(base_dir: Union[str, Path]) -> bool:
+    config_path = get_config_path(base_dir)
+    return config_path.is_file()
+
+
+def set_default_config(base_dir: Union[str, Path]):
+    config = get_config_path(base_dir)
+    default_config = get_default_config_path()
+    shutil.copy(default_config, config)

--- a/aim/ext/notifier/workplace_notifier.py
+++ b/aim/ext/notifier/workplace_notifier.py
@@ -1,0 +1,24 @@
+import requests
+from typing import Optional
+
+from aim.ext.notifier.base_notifier import BaseNotifier
+
+
+class WorkplaceNotifier(BaseNotifier):
+    def __init__(self, _id: str, config: dict):
+        super().__init__(_id)
+        self.message_template = config['message']
+        self.wp_access_token = config['access_token']
+        self.wp_group_id = config['group_id']
+        self.url = self._get_workplace_url()
+
+    def notify(self, message: Optional[str] = None, **kwargs):
+        message_template = message or self.message_template
+        msg = message_template.format(**kwargs)
+        params = {'access_token': self.wp_access_token}
+        requests.post(self.url, json={'message': msg}, params=params)
+
+    def _get_workplace_url(self):
+        api_version = 'v14.0'
+
+        return f'https://graph.facebook.com/{api_version}/{self.wp_group_id}/feed'

--- a/aim/sdk/checkins/__init__.py
+++ b/aim/sdk/checkins/__init__.py
@@ -1,0 +1,583 @@
+"""
+This system is designed to let users to check if the run had any progress.
+
+While it may seem an easy task, it's very difficult to have a reliable way to
+check if everything is fine with the process; The main (rank0) process may be
+killed having no chance of notifying about failure. Even if the main process is
+alive, the other moving parts may be stuck (network sync with other nodes,
+filesystem, dataloader) those are not necessarily part of the main execution
+thread. It leaves no other choice other than defining:
+
+> The run is considered to be failed if it
+> had not reported any progress in the promised time.
+
+Thus, we can mark progress (we call these `check-in`s) and the expected time of
+the next check-in. We can report a check-in after each forwarding each batch and
+promising the next check-in to be reported in the next minute. If no check-ins
+are received in the next minute, the run is most certainly failed or stuck (or
+very unexpected things happened thus compromising the performance of the system).
+This can have some exceptions: for instance, checkpointing the model and saving
+the state into the filesystem may take a while. For such cases, aim integration
+should check-in right before triggering checkpointing by promising much larger
+time intervals.
+
+Monitoring of run progress can be easily done by a service that periodically
+polls the check-in instances. If the last check-in was there for longer than it
+promised, the run is considered to  be failed thus triggering a (configurable)
+failure alert.
+
+Check-ins with zero `expect_next_in` values denote an absence of the expiration
+date. In order to mark the run as successful, the last check-in should be
+reported with a zero `expect_next_in` to indicate no further check-ins are
+expected so the monitoring server will not treat stopped process as failed.
+
+# IMPLEMENTATION DETAILS
+
+## FORMAT
+The check-ins are implemented to be stored in the filesystem, in `.aim` repo
+under the `check_ins` directory. Each file has no contents and encodes all the
+information in the name.
+
+The name format is as follows:
+    `{run_hash}-{idx:08d}-{flag_name}-{absolute_time:011.2f}-{expect_next_in:05d}`
+where `idx` is auto-incremented index per run, `flag_name` is the name of the
+flag (usually `check-in`), `absolute_time` is the utc time of the check-in (is
+intended only for debugging purposes), `expect_next_in` is the time in seconds
+until the next check-in is expected.
+
+## TIME
+Note that we don't use last modified time to detect if the file is modified
+because it's not that reliable especially for virtual and remote filesystems.
+The utc time in the filename may vary across machines, and used only for the
+debugging purposes.
+
+## MONITORING SERVICE
+The monitoring service supposed to periodically poll the directory and check for
+the latest (lexicographically highest) check-ins per run.
+If the last check-in was there (starting from the first time the monitoring
+server had seen the file) for longer than it promised, the run is considered to
+be failed thus triggering a (configurable) failure alert. A grace period is
+introduced to avoid false positives.
+
+## NON-BLOCKING INTERFACE
+
+### `RunCheckIn.check_in()`:
+By default, the check-in is non-blocking call in order to avoid any latency
+introduced. This way, the caller can feel free to check-in as soon as possible,
+even after each batch is forwarded or report the progress in vert small steps.
+
+In order to avoid overloading the filesystem, not all the check-ins are stored
+in the filesystem. Instead, if there is still time before the expiration, we can
+wait thus avoiding unnecessary disk I/O. The filesystem writes are done only
+when the time is (nearly) up. A separate thread is used to handle this process
+which also cleans up of the obsolete check-ins having lower lexicographic order
+than the current one.
+
+### `RunCheckIn.report_successful_finish()`:
+Marking the run as successful is blocking call by default to ensure the check-in
+is written to the filesystem before the run process exits. Note, that the
+initialization of `RunCheckIn` also does include blocking call to poll the
+latest state in case of existing runs.
+
+## INDIRECT INTERFACE
+The preferred way of reporting check-ins is to call `.check_in()` method on the
+Run instance. However, in certain cases, the caller may want to check-in from a
+code location that has no access to the Run instance (e.g. in dataloader, or in
+the checkpoint callback). In such cases, the `.check_in()` method can be called
+indirectly by calling `RunCheckIn.check_in()` which will infer the run instance.
+
+This is only possible if there is a single run instance in the process.
+"""
+
+import math
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Dict, Tuple, Set, Union, TYPE_CHECKING
+
+from cachetools import LRUCache
+
+if TYPE_CHECKING:
+    from aim.sdk import Run
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+cache = LRUCache(maxsize=3)
+
+
+GRACE_PERIOD = 100  # seconds
+MAX_SUSPEND_TIME = 30  # 5 seconds
+PLAN_ADVANCE_TIME = 10  # 5 seconds
+
+
+@dataclass(frozen=True)
+class AsteriskType:
+    """
+    The purpose of this helper symbol is to enable the injecting an asterisk
+    into any formatted string no matter what format spec uses.
+
+    For example:
+    >>> '{a:.2f}-{b:.2f}'.format(a=3.5, b=Asterisk)
+    >>> '3.50-*'
+    """
+
+    def __format__(self, __format_spec: str) -> str:
+        return "*"
+
+
+# Singletone instance of AsteriskType
+Asterisk = AsteriskType()
+
+
+@dataclass(order=True, frozen=True)
+class CheckIn:
+    """
+    CheckIn is a dataclass that represents a single check-in.
+
+    All the time-related fields are in `time.monotonic`, relative time expressed in
+    seconds, until stated otherwise. In case of `expect_next_in=0` we treat it as
+    a special case, meaning that the check-in is not expected to expire.
+    Indicies are used to identify check-ins and are unique within a run, auto-incremented.
+    """
+
+    idx: int = 0
+    expect_next_in: int = field(default=0, compare=False)
+    first_seen: float = field(default_factory=time.monotonic, compare=False, repr=False)
+
+    # We keep per-run cache to memoize the first time we've seen check-ins
+    per_run_cache: ClassVar[Dict[str, LRUCache]] = defaultdict(
+        lambda: LRUCache(maxsize=3)
+    )
+
+    def __bool__(self) -> bool:
+        return bool(self.idx)
+
+    @classmethod
+    def first_seen_cached(
+        cls,
+        *,
+        run_hash: str,
+        idx: int,
+        expect_next_in: int,
+    ) -> float:
+        """
+        Return the first seen time of the check-in.
+        """
+        per_run_cache = cls.per_run_cache[run_hash]
+        key = (idx, expect_next_in)
+        try:
+            return per_run_cache[key]
+        except KeyError:
+            now = time.monotonic()
+            logger.info(f"* first time ({now}) seen for {key} for {run_hash}")
+            per_run_cache[key] = now
+            return now
+
+    @property
+    def expiry_date(self) -> float:
+        """
+        Return the time when the check-in is expected to expire.
+        """
+        return self.first_seen + self.expect_next_in
+
+    @classmethod
+    def parse(cls, path: Union[Path, str]) -> Tuple[str, "CheckIn"]:
+        """
+        Parse a check-in file path and return a tuple of:
+          * run hash the check-in belongs to,
+          * the check-in itself.
+        """
+        if isinstance(path, str):
+            path = Path(path)
+
+        run_hash, str_idx, sep, utc_time, str_expect_next_in = path.name.rsplit(
+            "-", maxsplit=4
+        )
+        assert sep == "check_in"
+
+        idx = int(str_idx)
+        expect_next_in = int(str_expect_next_in)
+
+        first_seen = cls.first_seen_cached(
+            run_hash=run_hash, idx=idx, expect_next_in=expect_next_in
+        )
+
+        return run_hash, cls(
+            idx=idx,
+            expect_next_in=expect_next_in,
+            first_seen=first_seen,
+        )
+
+    @classmethod
+    def poll(cls, *, directory: Path, run_hash: str) -> "CheckIn":
+        """
+        Poll the directory for the current check-in.
+
+        The `current` check-in is defined as the highest one in the lexicographic order.
+        """
+        pattern = cls.generate_filename(run_hash=run_hash)
+        paths = list(directory.glob(pattern))
+
+        if not paths:
+            logger.info(f"no check-in found for {run_hash}; returning zero-check-in")
+            return CheckIn()
+
+        check_in_path = max(paths)
+        logger.info(f"found check-in: {check_in_path}")
+        parsed_run_hash, check_in = cls.parse(check_in_path)
+        assert parsed_run_hash == run_hash
+        logger.info(f"parsed check-in: {check_in}")
+
+        return check_in
+
+    def increment(self, *, expect_next_in: int = 0) -> "CheckIn":
+        """
+        Create a new check-in and auto-increment the index based on the current one.
+        """
+        new = CheckIn(
+            idx=self.idx + 1,
+            expect_next_in=max(expect_next_in, self.expect_next_in),
+        )
+        logger.info(f"incrementing check-in: {self} -> {new}")
+        return new
+
+    def time_calibrated(self):
+        """
+        The check-in `expect_next_in` is counted from the time the check-in was
+        first created / seen.
+
+        As the `CheckIn` objects are designed to be immutable, we need to
+        recalibrate the time when the check-in is expected to expire, returning
+        a new `CheckIn` object.
+        """
+        now = time.monotonic()
+        if self.expect_next_in == 0:
+            expect_next_in = 0
+        else:
+            expect_next_in = max(1, math.ceil(self.expiry_date - now))
+        new = CheckIn(
+            idx=self.idx,
+            expect_next_in=expect_next_in,
+            first_seen=now,
+        )
+        logger.info(f"calibrated check-in: {self} -> {new}")
+        return new
+
+    @classmethod
+    def generate_filename(
+        cls,
+        *,
+        run_hash: Union[str, AsteriskType],
+        idx: Union[int, AsteriskType] = Asterisk,
+        flag_name: Union[str, AsteriskType] = "check_in",
+        absolute_time: Union[float, AsteriskType] = Asterisk,
+        expect_next_in: Union[int, AsteriskType] = Asterisk,
+    ) -> str:
+        """
+        Generate a filename for a check-in.
+
+        Supports Asterisk objects so that we can generate a patterns.
+
+        For example:
+        >>> CheckIn.generate_filename(run_hash="run_hash", idx=Asterisk, absolute_time=Asterisk, expect_next_in=10)
+        >>> "run_hash-*-check_in-*-10"
+        """
+        return f"{run_hash}-{idx:08d}-{flag_name}-{absolute_time:011.2f}-{expect_next_in:05d}"
+
+    def cleanup(
+        self,
+        *,
+        directory: Path,
+        run_hash: str,
+    ) -> "CheckIn":
+        """
+        Cleanups all the expired check-ins for the given run hash.
+
+        This will remove all check-ins that are older than the current one.
+        Returns the new current check-in.
+        """
+        pattern = self.generate_filename(run_hash=run_hash)
+        *paths_to_remove, current_check_in_path = sorted(directory.glob(pattern))
+        logger.info(f"found {len(paths_to_remove)} check-ins:")
+        logger.info(f"the acting one: {current_check_in_path}")
+        for path in paths_to_remove:
+            logger.info(f"check-in {path} is being removed")
+            path.unlink(missing_ok=True)
+            time.sleep(0.2)  # TODO remove this artificial delay
+            logger.info(f"check-in {path} removed")
+
+        parsed_run_hash, check_in = self.parse(current_check_in_path)
+        assert parsed_run_hash == run_hash
+        logger.info(f"returning acting check-in after cleanup: {check_in}")
+
+        return check_in
+
+    def touch(
+        self,
+        *,
+        directory: Union[Path, str],
+        run_hash: str,
+        cleanup: bool = True,
+        calibrate: bool = True,
+    ) -> "CheckIn":
+        """
+        Physically write the check-in to the filesystem so that it is visible to the
+        other nodes that share the filesystem.
+
+        As `CheckIn.touch()` could be called much later that it is created, we
+        need to calibrate `expected_next_in` w.r.t. current time. If `calibrate` is
+        `False` (`True` by default), then `expected_next_in` is not recalibrated.
+
+        If `cleanup` is True (default), this will remove all the expired check-ins.
+        """
+        if not isinstance(directory, Path):
+            directory = Path(directory)
+
+        if calibrate and self.expect_next_in:
+            return self.time_calibrated().touch(
+                directory=directory,
+                run_hash=run_hash,
+                cleanup=cleanup,
+                calibrate=False,
+            )
+
+        directory.mkdir(parents=True, exist_ok=True)
+
+        utc_time = time.time()
+        filename = self.generate_filename(
+            run_hash=run_hash,
+            idx=self.idx,
+            expect_next_in=self.expect_next_in,
+            absolute_time=utc_time,
+        )
+        new_path = directory / filename
+        logger.info(f"touching check-in: {new_path}")
+
+        time.sleep(0.4)  # TODO remove this artificial delay
+        new_path.touch(exist_ok=True)
+
+        if cleanup:
+            self.cleanup(directory=directory, run_hash=run_hash)
+
+        return self
+
+    def time_left(self) -> float:
+        """
+        Returns the time left before the check-in expires.
+
+        If the check-in has no expiry date, then this returns +infinity.
+        """
+        if self.expect_next_in == 0:
+            return math.inf
+        now = time.monotonic()
+        return self.expiry_date - now
+
+
+class RunCheckIns:
+    """
+    A handler for check-ins for a given run.
+
+    Uses filesystem to store the check-ins. Handles resumed `Run`s.
+    Background thread is used to adjust the rate of check-ins written
+    to the filesystem in order to avoid overloading.
+
+    Calling `report_successful_finish()` is required to mark the run as
+    finished, otherwise the run will be marked as failed.
+    """
+
+    instances: Set["RunCheckIns"] = set()
+
+    def __init__(
+        self,
+        run: 'Run',
+    ) -> None:
+        logger.info(f"creating RunCheckIns for {run}")
+        self.run_hash = run.hash
+        self.repo_dir = Path(run.repo.path)
+        self.dir = self.repo_dir / "check_ins"
+        logger.info(f"polling for check-ins in {self.dir}")
+        leftover = CheckIn.poll(
+            directory=self.dir,
+            run_hash=self.run_hash,
+        )
+        if leftover:
+            logger.info(f"leftover check-in: {leftover}")
+        else:
+            logger.info("no leftover check-in found. starting from zero")
+        self.last_check_in = leftover.increment()
+        self.physical_check_in = self.last_check_in.touch(
+            directory=self.dir,
+            run_hash=self.run_hash,
+        )
+        logger.info(f"starting from: {self.physical_check_in}")
+
+        self.instances.add(self)
+
+        self.thread = threading.Thread(target=self.writer, daemon=True)
+        self.flush_condition = threading.Condition()
+        self.stop_signal = threading.Event()
+        logger.info(f"starting writer thread for {self}")
+        self.thread.start()
+
+        # we need to patch certain methods to make them
+        # available both as instance and class methods.
+        self.check_in = self._check_in
+        self.report_successful_finish = self._report_successful_finish
+
+    @classmethod
+    def default(cls) -> "RunCheckIns":
+        try:
+            default_instance, = cls.instances
+        except ValueError:
+            if cls.instances:
+                raise ValueError(
+                    f"{cls.__name__} has {len(cls.instances)} instances, indirect check-in is not supported"
+                )
+            else:
+                logger.warning(f"{cls.__name__} has no instances")
+                return None
+        return default_instance
+
+    def close(self):
+        self.stop()
+        self.instances.remove(self)
+
+    def stop(self):
+        """
+        Flush the last check-in and stop the thread.
+        """
+        self.stop_signal.set()
+        self.flush()
+        self.thread.join()
+
+    def writer(self):
+        """
+        The writer thread that periodically flushes the last check-in.
+        This background thread also takes care of cleaning up expired check-ins
+        and throttling the check-in rate in order to avoid overloading the
+        filesystem. However, it can be notified to flush the last check-in
+        on-demand. This is useful when reporting certain events that are preferable
+        to be reported as soon as possible, e.g. success status of the Run.
+        """
+        while True:
+            time_left = self.physical_check_in.time_left()
+            if time_left + GRACE_PERIOD < 0:
+                logger.error(f"Missing check-in. Grace period expired { - GRACE_PERIOD - time_left:.2f} seconds ago. "
+                             f"Alerts should be sent soon by the monitoring server.")
+            elif time_left < 0:
+                logger.warning(f"Missing check-in. Late: {-time_left:.2f} seconds. "
+                               f"Remaining grace period: {GRACE_PERIOD + time_left:.2f} seconds")
+            elif time_left < PLAN_ADVANCE_TIME:
+                logger.info(f"Missing check-in. Time left: {time_left}:.2f")
+            plan = max(time_left - PLAN_ADVANCE_TIME, 1.0)
+            suspend_time = min(plan, MAX_SUSPEND_TIME)
+
+            with self.flush_condition:
+                self.flush_condition.wait(timeout=suspend_time)
+
+            check_in = self.last_check_in
+            if check_in != self.physical_check_in:
+                logger.info(f"detected newest check-in: {check_in}")
+                self.physical_check_in = check_in.touch(
+                    directory=self.dir, run_hash=self.run_hash
+                )
+                logger.info(f"changing to -> {self.physical_check_in}")
+                continue
+
+            if self.stop_signal.is_set():
+                logger.info("writer thread stopping as requested")
+                return
+
+    def flush(
+        self,
+        block: bool = True,
+    ) -> None:
+        """
+        Flush the last check-in.
+        """
+        logger.info(f"notifying {self}")
+        with self.flush_condition:
+            self.flush_condition.notify_all()
+        if block:
+            logger.info("blocking until the writer finishes")
+            while not self.last_check_in == self.physical_check_in:
+                time.sleep(0.2)  # TODO use notify
+                pass
+
+    def _check_in(
+        self,
+        *,
+        expect_next_in: int = 0,
+        block: bool = False,
+    ) -> None:
+        """
+        Check-in and optionally mark an expiry date by setting `expect_next_in`.
+
+        If `block` is True, then this will block until the check-in is flushed.
+        """
+        self.last_check_in = self.last_check_in.increment(expect_next_in=expect_next_in)
+        if block:
+            self.flush(block=True)
+
+    def _report_successful_finish(
+        self,
+        *,
+        block: bool = True,
+    ) -> None:
+        """
+        Report a successful end of the Run.
+
+        By default this will block until the check-in is flushed.
+        """
+        return self._check_in(block=block)
+
+    # The instance method `check_in` and `report_successful_finish` is patched into
+    # the instance in `__post_init__`
+    # so the same name is used for both the instance method and the class method.
+    @classmethod
+    def check_in(
+        cls,
+        *,
+        expect_next_in: int = 0,
+        block: bool = False,
+    ) -> None:
+        """
+        Check-in and optionally mark an expiry date by setting `expect_next_in`.
+
+        If `block` is True, then this will block until the check-in is flushed.
+
+        Note: This is a classmethod and designed to be called like:
+        `RunCheckIns.check_in(expect_next_in=10)`
+        * If no instance is available, this will log a warning and return.
+        * If multiple instances are available, this will raise an error.
+        """
+        default_instance = cls.default()
+        if default_instance is None:
+            return
+        default_instance._check_in(expect_next_in=expect_next_in, block=block)
+
+    @classmethod
+    def report_successful_finish(
+        cls,
+        *,
+        block: bool = True,
+    ) -> None:
+        """
+        Report a successful end of the Run.
+
+        By default this will block until the check-in is flushed.
+
+        Note: This is a classmethod and designed to be called like:
+        `RunCheckIns.report_successful_finish()`
+        * If no instance is available, this will log a warning and return.
+        * If multiple instances are available, this will raise an error.
+        """
+        default_instance = cls.default()
+        if default_instance is None:
+            return
+        default_instance._report_successful_finish(block=block)

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from aim.sdk.base_run import BaseRun
 from aim.sdk.sequence import Sequence
 from aim.sdk.tracker import RunTracker
-from aim.sdk.checkins import RunCheckIns
+from aim.sdk.reporter import RunStatusReporter
 from aim.sdk.sequence_collection import SingleRunSequenceCollection
 from aim.sdk.utils import (
     backup_run,
@@ -318,7 +318,7 @@ class Run(BaseRun, StructuredRunMixin):
         self._checkins = None
 
         if not read_only:
-            self._checkins = RunCheckIns(self)
+            self._checkins = RunStatusReporter(self)
             if log_system_params:
                 system_params = {
                     'packages': get_installed_packages(),
@@ -761,7 +761,7 @@ class Run(BaseRun, StructuredRunMixin):
         df = pd.DataFrame(data, index=[0])
         return df
 
-    def check_in(
+    def report_progress(
         self,
         *,
         expect_next_in: int = 0,

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from aim.sdk.base_run import BaseRun
 from aim.sdk.sequence import Sequence
 from aim.sdk.tracker import RunTracker
+from aim.sdk.checkins import RunCheckIns
 from aim.sdk.sequence_collection import SingleRunSequenceCollection
 from aim.sdk.utils import (
     backup_run,
@@ -68,6 +69,7 @@ class RunAutoClean(AutoClean['Run']):
         self._system_resource_tracker = instance._system_resource_tracker
         # this reference is needed for system resource tracker finalization
         self._tracker = instance._tracker
+        self._checkins = instance._checkins
 
     def finalize_run(self):
         """
@@ -105,6 +107,8 @@ class RunAutoClean(AutoClean['Run']):
         self.finalize_system_tracker()
         self.finalize_run()
         self.finalize_rpc_queue()
+        if self._checkins is not None:
+        self._checkins.close()
 
 
 # TODO: [AT] generate automatically based on ModelMappedRun
@@ -311,8 +315,10 @@ class Run(BaseRun, StructuredRunMixin):
                         raise
 
         self._props = None
+        self._checkins = None
 
         if not read_only:
+            self._checkins = RunCheckIns(self)
             if log_system_params:
                 system_params = {
                     'packages': get_installed_packages(),
@@ -754,3 +760,36 @@ class Run(BaseRun, StructuredRunMixin):
         import pandas as pd
         df = pd.DataFrame(data, index=[0])
         return df
+
+    def check_in(
+        self,
+        *,
+        expect_next_in: int = 0,
+        block: bool = False,
+    ) -> None:
+        """
+        Check-in the run. Report the expected time for the next check-in.
+
+        If no check-ins are received by the expiry date (plus the grace period), the
+        run is considered to have failed.
+
+        Args:
+            expect_next_in: (:obj:`int`, optional): The number of seconds to wait before the next check-in.
+            block: (:obj:`bool`, optional): If true, block the thread until the check-in is written to filesystem.
+        """
+        if self._checkins is None:
+            raise ValueError('Check-ins are not enabled for this run')
+        self._checkins._check_in(expect_next_in=expect_next_in, block=block)
+
+    def report_successful_finish(
+        self,
+        *,
+        block: bool = True,
+    ) -> None:
+        """
+        Report successful finish of the run. If the run is not marked as successfully finished,
+        it can potentially be considered as failed.
+        """
+        if self._checkins is None:
+            raise ValueError('Check-ins are not enabled for this run')
+        self._checkins._report_successful_finish(block=block)

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -108,7 +108,7 @@ class RunAutoClean(AutoClean['Run']):
         self.finalize_run()
         self.finalize_rpc_queue()
         if self._checkins is not None:
-        self._checkins.close()
+            self._checkins.close()
 
 
 # TODO: [AT] generate automatically based on ModelMappedRun

--- a/aim/sdk/run_status_watcher.py
+++ b/aim/sdk/run_status_watcher.py
@@ -1,0 +1,240 @@
+import json
+import time
+import queue
+import logging
+import shutil
+
+from threading import Thread
+from pathlib import Path
+from typing import Dict
+
+from aim.sdk.repo import Repo
+from aim.storage.locking import AutoFileLock
+from aim.ext.notifier import get_notifier, default_config_path, Notifier
+from aim.ext.cleanup import AutoClean
+
+
+logger = logging.getLogger(__name__)
+
+
+class StatusEvent:
+    def __init__(self, status_event_encoded: str):
+        obj_idx, idx, _, epoch_time, next_event_in = status_event_encoded.split('-')
+        self.idx: int = int(idx)
+        self.obj_idx: str = obj_idx
+        self.next_event_in: int = int(next_event_in)
+        self.epoch_time: float = float(epoch_time)
+
+
+class StatusNotification:
+    def __init__(self, event: StatusEvent, message: str = None):
+        self.event_idx = event.idx
+        self.obj_idx = event.obj_idx
+        self.message = message
+
+
+class StatusEventSet:
+    def __init__(self):
+        self.events: Dict[str, StatusEvent] = {}
+
+    def get(self, obj_idx: str) -> StatusEvent:
+        return self.events[obj_idx]
+
+    def add(self, event: StatusEvent) -> bool:
+        object_idx = event.obj_idx
+        if object_idx not in self.events:
+            self.events[object_idx] = event
+            return True
+        elif self.events[object_idx].idx < event.idx:
+            self.events[object_idx] = event
+            return True
+        return False
+
+
+class WorkerThread(Thread):
+    def __init__(self, func, **kwargs):
+        self.shutdown = False
+        self.func = func
+        super().__init__(target=self.worker, **kwargs)
+
+    def worker(self):
+        while True:
+            if self.shutdown:
+                break
+            self.func()
+
+    def stop(self):
+        logger.debug('Stopping worker thread...')
+        self.shutdown = True
+        self.join()
+        logger.debug('Worker thread stopped.')
+
+
+class NotificationQueue(object):
+    def __init__(self, notifier: Notifier, notifications_cache_path: Path):
+        self._notifications_cache_path = notifications_cache_path
+        self.notifications_cache: Dict[str, int] = {}
+        self.recover_notifications_cache()
+
+        self._stopped = False
+        self._notifier = notifier
+
+        self._queue = queue.Queue()
+        self._notifier_thread = Thread(target=self.listen, daemon=True)
+        self._notifier_thread.start()
+
+    def recover_notifications_cache(self):
+        with self._notifications_cache_path.open() as cache_fh:
+            try:
+                self.notifications_cache = json.load(cache_fh)
+            except json.decoder.JSONDecodeError:
+                self.notifications_cache = {}
+
+    def add_notification(self, notification: StatusNotification):
+        if not self.is_sent(notification):
+            self._queue.put(notification)
+
+    def stop(self):
+        logger.debug('Processing remaining notifications...')
+        self._queue.join()
+        logger.debug('Notifications queue is empty.')
+        logger.debug('Stopping worker thread...')
+        self._stopped = True
+        self._notifier_thread.join()
+        logger.debug('Worker thread stopped.')
+
+    def is_sent(self, notification: StatusNotification) -> bool:
+        last_event_idx = self.notifications_cache.get(notification.obj_idx, -1)
+        if last_event_idx < notification.event_idx:
+            return False
+        elif last_event_idx == notification.event_idx:
+            return True
+        else:
+            logger.warning(f'New event id {notification.event_idx} for object \'{notification.obj_idx}\' '
+                           f'is less than last reported event id {last_event_idx}.')
+            return True
+
+    def update_last_sent(self, notification: StatusNotification):
+        self.notifications_cache[notification.obj_idx] = notification.event_idx
+        with self._notifications_cache_path.open(mode='w') as notifications_fh:
+            json.dump(self.notifications_cache, notifications_fh)
+
+    def listen(self):
+        while True:
+            if self._stopped:
+                break
+            try:
+                notification = self._queue.get(timeout=1)
+                if self.is_sent(notification):
+                    logger.debug(f'Notification for object \'{notification.obj_idx}\' '
+                                 f'with event ID {notification.event_idx} has already been sent. Skipping.')
+                else:
+                    details = {'run_hash': notification.obj_idx}
+                    self._notifier.notify(notification.message, **details)
+                    self.update_last_sent(notification)
+
+                self._queue.task_done()
+            except queue.Empty:
+                continue
+
+
+class RunStatusWatcherAutoClean(AutoClean['RunStatusWatcher']):
+    PRIORITY = 30
+
+    def __init__(self, instance: 'RunStatusWatcher') -> None:
+        super().__init__(instance)
+        self.is_background = instance.background
+        self.watcher_thread = instance.watcher_thread
+        self.notifications_queue = instance.notifications_queue
+        self.lock = instance.lock
+
+    def _close(self) -> None:
+        if self.is_background:
+            assert self.watcher_thread is not None
+            self.watcher_thread.stop()
+        self.notifications_queue.stop()
+        self.lock.release()
+
+
+class RunStatusWatcher:
+    @staticmethod
+    def has_watcher_config(repo: Repo) -> bool:
+        repo_path = Path(repo.path)
+        config_path = repo_path / 'ext' / 'notifications' / 'config.json'
+        return config_path.is_file()
+
+    @staticmethod
+    def set_default_config(repo: Repo):
+        repo_path = Path(repo.path)
+        work_dir = repo_path / 'ext' / 'notifications'
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        config = work_dir / 'config.json'
+        default_config = default_config_path()
+        shutil.copy(default_config, config)
+
+    def __init__(self, repo: Repo, background: bool = False):
+        repo_path = Path(repo.path)
+        self.background = background
+
+        self._resources = None
+        self.initialized = False
+
+        work_dir = repo_path / 'ext' / 'notifications'
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        self.lock = AutoFileLock(work_dir / 'watcher.lock', timeout=0)
+        try:
+            self.lock.acquire()
+        except TimeoutError:
+            logger.error(f'Cannot start Run status watcher for \'{repo_path}\'. Failed to acquire lock.')
+            return
+
+        self._status_watch_dir: Path = repo_path / 'status'
+        self._status_watch_dir.mkdir(exist_ok=True)
+
+        self._notifications_cache_path: Path = work_dir / 'last_run_notifications'
+        self._notifications_cache_path.touch(exist_ok=True)
+        self._status_events = StatusEventSet()
+
+        self.notifier = get_notifier(work_dir / 'config.json')
+        self.watcher_thread = WorkerThread(self.check_for_new_events, daemon=True) if not background else None
+        self.notifications_queue = NotificationQueue(self.notifier, self._notifications_cache_path)
+
+        self.initialized = True
+        self._resources = RunStatusWatcherAutoClean(self)
+
+    def start_watcher(self):
+        if not self.initialized:
+            return
+        logger.info('Starting watcher...')
+        if self.background:
+            self.watcher_thread.start()
+        else:
+            self.run_forever()
+
+    def run_forever(self):
+        while True:
+            self.check_for_new_events()
+
+    def check_for_new_events(self):
+        new_events = self.poll_events()
+
+        for new_event in new_events.events.values():
+            if not self._status_events.add(new_event):
+                event = self._status_events.get(new_event.obj_idx)
+                epoch_now = time.time()
+                failed = (event.next_event_in < epoch_now - event.epoch_time)
+                if failed:
+                    notification = StatusNotification(event)
+                    self.notifications_queue.add_notification(notification)
+            else:
+                if new_event.next_event_in == 0:
+                    notification = StatusNotification(new_event, 'Run \'{run_hash}\' finished without error.')
+                    self.notifications_queue.add_notification(notification)
+
+    def poll_events(self) -> StatusEventSet:
+        events = StatusEventSet()
+        for check_in_file_path in sorted(self._status_watch_dir.glob('*check_in*')):
+            events.add(StatusEvent(check_in_file_path.name))
+        return events

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
     entry_points={
         'console_scripts': [
             'aim=aim.cli.cli:cli_entry_point',
+            'aim-watcher=aim.cli.watcher_cli:cli_entry_point',
         ],
     },
     cmdclass={


### PR DESCRIPTION
This system is designed to let users to check if the run had any progress.
 While it may seem an easy task, it's very difficult to have a reliable way to
 check if everything is fine with the process; The main (rank0) process may be
 killed having no chance of notifying about failure. Even if the main process is
 alive, the other moving parts may be stuck (network sync with other nodes,
 filesystem, dataloader) those are not necessarily part of the main execution
 thread. It leaves no other choice other than defining:

 > The run is considered to be failed if it had not reported any progress in the promised time.


 Thus, we can mark progress (we call these `check-in`s) and the expected time of
 the next check-in. We can report a check-in after each forwarding each batch and
 promising the next check-in to be reported in the next minute. If no check-ins
 are received in the next minute, the run is most certainly failed or stuck (or
 very unexpected things happened thus compromising the performance of the system).
 This can have some exceptions: for instance, checkpointing the model and saving
 the state into the filesystem may take a while. For such cases, aim integration
 should check-in right before triggering checkpointing by promising much larger
 time intervals.
 Monitoring of run progress can be easily done by a service that periodically
 polls the check-in instances. If the last check-in was there for longer than it
 promised, the run is considered to  be failed thus triggering a (configurable)
 failure alert.
 Check-ins with zero `expect_next_in` values denote an absence of the expiration
 date. In order to mark the run as successful, the last check-in should be
 reported with a zero `expect_next_in` to indicate no further check-ins are
 expected so the monitoring server will not treat stopped process as failed.
 # IMPLEMENTATION DETAILS
 ## FORMAT
 The check-ins are implemented to be stored in the filesystem, in `.aim` repo
 under the `check_ins` directory. Each file has no contents and encodes all the
 information in the name.
 The name format is as follows:
     `{run_hash}-{idx:08d}-{flag_name}-{absolute_time:011.2f}-{expect_next_in:05d}`
 where `idx` is auto-incremented index per run, `flag_name` is the name of the
 flag (usually `check-in`), `absolute_time` is the utc time of the check-in (is
 intended only for debugging purposes), `expect_next_in` is the time in seconds
 until the next check-in is expected.
 ## TIME
 Note that we don't use last modified time to detect if the file is modified
 because it's not that reliable especially for virtual and remote filesystems.
 The utc time in the filename may vary across machines, and used only for the
 debugging purposes.
 ## MONITORING SERVICE
 The monitoring service supposed to periodically poll the directory and check for
 the latest (lexicographically highest) check-ins per run.
 If the last check-in was there (starting from the first time the monitoring
 server had seen the file) for longer than it promised, the run is considered to
 be failed thus triggering a (configurable) failure alert. A grace period is
 introduced to avoid false positives.
 ## NON-BLOCKING INTERFACE
 ### `RunCheckIn.check_in()`:
 By default, the check-in is non-blocking call in order to avoid any latency
 introduced. This way, the caller can feel free to check-in as soon as possible,
 even after each batch is forwarded or report the progress in vert small steps.
 In order to avoid overloading the filesystem, not all the check-ins are stored
 in the filesystem. Instead, if there is still time before the expiration, we can
 wait thus avoiding unnecessary disk I/O. The filesystem writes are done only
 when the time is (nearly) up. A separate thread is used to handle this process
 which also cleans up of the obsolete check-ins having lower lexicographic order
 than the current one.
 ### `RunCheckIn.report_successful_finish()`:
 Marking the run as successful is blocking call by default to ensure the check-in
 is written to the filesystem before the run process exits. Note, that the
 initialization of `RunCheckIn` also does include blocking call to poll the
 latest state in case of existing runs.
 ## INDIRECT INTERFACE
 The preferred way of reporting check-ins is to call `.check_in()` method on the
 Run instance. However, in certain cases, the caller may want to check-in from a
 code location that has no access to the Run instance (e.g. in dataloader, or in
 the checkpoint callback). In such cases, the `.check_in()` method can be called
 indirectly by calling `RunCheckIn.check_in()` which will infer the run instance.
 This is only possible if there is a single run instance in the process.