### PR TITLE
[feat] Support dictionaries as argument of `Run.track`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^\[(?:feat|fix|doc|refactor)\]\s[A-Z].*(?<!\.)$'
+          regex: '^\[(?:feat|fix|doc|refactor|deprecation)\]\s[A-Z].*(?<!\.)$'
           github_token: ${{ github.token }}
   run-checks:
     if: github.event.pull_request.draft == false && github.event.action != 'edited'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements:
+
+- Support dictionary as an argument of `Run.track` (alberttorosyan)
+
 ## 3.13.0 Aug 21, 2022
 
 ### Enhancements:

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -423,7 +423,7 @@ class Run(BaseRun, StructuredRunMixin):
     def track(
         self,
         value,
-        name: str,
+        name: str = None,
         step: int = None,
         epoch: int = None,
         *,

--- a/examples/pytorch_track.py
+++ b/examples/pytorch_track.py
@@ -99,9 +99,6 @@ for epoch in range(num_epochs):
                                         total_step, loss.item()))
 
             # aim - Track model loss function
-            aim_run.track(loss.item(), name='loss', epoch=epoch,
-                          context={'subset':'train'})
-
             correct = 0
             total = 0
             _, predicted = torch.max(outputs.data, 1)
@@ -110,7 +107,8 @@ for epoch in range(num_epochs):
             acc = 100 * correct / total
 
             # aim - Track metrics
-            aim_run.track(acc, name='accuracy', epoch=epoch, context={'subset': 'train'})
+            items = {'accuracy': acc, 'loss': loss}
+            aim_run.track(items, epoch=epoch, context={'subset': 'train'})
 
             # aim - Track weights and gradients distributions
             track_params_dists(model, aim_run)


### PR DESCRIPTION
- Changed the value validation logic and `_track` implementation.
- Added unit-tests to cover dict tracking + negative cases with specifying `name` argument.
- Changed `examples/pytorch_track.py` to use the new interface.