### PR TITLE
[fix] Fix the data live update handling in the Logs tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.3
+
+- Optimize rendering performance of the logs tab in the run page (VkoHov)
+
 ## 3.13.2 Sep 10, 2022
 
 - Fix content overlapping issue of x-axis alignment dropdown (KaroMourad)

--- a/aim/web/api/runs/utils.py
+++ b/aim/web/api/runs/utils.py
@@ -311,7 +311,7 @@ async def run_logs_streamer(run: Run, record_range: str) -> bytes:
 
     # range is missing completely
     if record_range.start is None and record_range.stop is None:
-        start = max(logs.last_step() - 500, 0)
+        start = max(logs.last_step() - 200, 0)
 
     steps_vals = logs.data.view('val').range(start, stop)
     for step, (val,) in steps_vals:

--- a/aim/web/ui/src/pages/RunDetail/RunLogsTab/LogRow.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunLogsTab/LogRow.tsx
@@ -8,12 +8,12 @@ function LogRow({
   index: number;
   style: React.CSSProperties;
   data: {
-    logsList: Array<{ index: string; value: string }>;
+    logsList: string[];
   };
 }) {
   return (
     <div style={style}>
-      <pre className={'LogRow__line'}>{data.logsList?.[index - 1]?.value}</pre>
+      <pre className='LogRow__line'>{data.logsList?.[index - 1]}</pre>
     </div>
   );
 }

--- a/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.d.ts
+++ b/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.d.ts
@@ -1,7 +1,7 @@
 export interface IRunLogsTabProps {
   isRunLogsLoading: boolean;
   runHash: string;
-  runLogs: { [key: string]: any };
+  runLogs: { [key: string]: { index: string; value: string } };
   inProgress: boolean;
   updatedLogsCount: number;
 }

--- a/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
@@ -234,7 +234,7 @@ function RunLogsTab({
                     itemCount={logsRowsData?.length + 1}
                     itemSize={() => SINGLE_LINE_HEIGHT}
                     width={'100%'}
-                    overscanCount={1000}
+                    overscanCount={200}
                     initialScrollOffset={
                       scrollOffset ?? logsRowsData?.length * SINGLE_LINE_HEIGHT
                     }

--- a/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
@@ -25,7 +25,7 @@ import { IRunLogsTabProps, LogsLastRequestEnum } from './RunLogsTab.d';
 import './RunLogsTab.scss';
 
 const SINGLE_LINE_HEIGHT = 15;
-const LOAD_MORE_LOGS_COUNT = 500;
+const LOAD_MORE_LOGS_COUNT = 200;
 
 function RunLogsTab({
   isRunLogsLoading,
@@ -234,7 +234,7 @@ function RunLogsTab({
                     itemCount={logsRowsData?.length + 1}
                     itemSize={() => SINGLE_LINE_HEIGHT}
                     width={'100%'}
-                    overscanCount={200}
+                    overscanCount={10}
                     initialScrollOffset={
                       scrollOffset ?? logsRowsData?.length * SINGLE_LINE_HEIGHT
                     }

--- a/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunLogsTab/RunLogsTab.tsx
@@ -15,6 +15,7 @@ import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import IllustrationBlock from 'components/IllustrationBlock/IllustrationBlock';
 
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
+import { RequestStatusEnum } from 'config/enums/requestStatusEnum';
 
 import runDetailAppModel from 'services/models/runs/runDetailAppModel';
 import * as analytics from 'services/analytics';
@@ -41,6 +42,9 @@ function RunLogsTab({
   const logsRowsData = React.useRef<string[] | null>(null);
   const [lastRequestType, setLastRequestType] =
     React.useState<LogsLastRequestEnum>(LogsLastRequestEnum.DEFAULT);
+  const [requestStatus, setRequestStatus] = React.useState<RequestStatusEnum>(
+    RequestStatusEnum.Ok,
+  );
   const logsRange = React.useRef<[number, number]>([0, 0]);
   const [scrollOffset, setScrollOffset] = React.useState<number | null>(null);
   const [visibleRowsRange, setVisibleRowsRange] = React.useState<{
@@ -86,8 +90,10 @@ function RunLogsTab({
     isLiveUpdate?: boolean;
     isLoadMore?: boolean;
   }) {
+    setRequestStatus(RequestStatusEnum.Pending);
     runsBatchRequestRef.current = runDetailAppModel.getRunLogs(params);
     runsBatchRequestRef.current.call().then(() => {
+      setRequestStatus(RequestStatusEnum.Ok);
       stopLiveUpdate();
       startLiveUpdate();
     });
@@ -111,7 +117,10 @@ function RunLogsTab({
       scrollOffset <= SINGLE_LINE_HEIGHT &&
       keysList &&
       keysList[0] !== 0 &&
-      scrollDirection === 'backward'
+      scrollDirection === 'backward' &&
+      (requestStatus === RequestStatusEnum.Ok ||
+        (requestStatus === RequestStatusEnum.Pending &&
+          lastRequestType === LogsLastRequestEnum.LIVE_UPDATE))
     ) {
       stopLiveUpdate();
       setLastRequestType(LogsLastRequestEnum.LOAD_MORE);


### PR DESCRIPTION
- Prevent calling of the live update before the other request is in pending state
- Change the overscan count of the virtualized list from 1000 to 100
- Change per request logs count to 200 