### PR TITLE
[feat] Add outlined state on project statistics cards

### DIFF
--- a/aim/web/ui/src/components/StatisticsBar/StatisticsBar.d.ts
+++ b/aim/web/ui/src/components/StatisticsBar/StatisticsBar.d.ts
@@ -9,7 +9,7 @@ export interface IStatisticsBarProps {
   data: Array<StatisticsBarItem>;
   width?: number | string;
   height?: number | string;
-  onMouseOver?: (label: string) => void;
+  onMouseOver?: (id: string, source: string) => void;
   onMouseLeave?: () => void;
 }
 

--- a/aim/web/ui/src/components/StatisticsBar/StatisticsBar.scss
+++ b/aim/web/ui/src/components/StatisticsBar/StatisticsBar.scss
@@ -8,6 +8,7 @@
     display: inline-flex;
     height: 100%;
     position: absolute;
+    transition: all 0.18s ease-out;
     &:first-child {
       border-top-left-radius: $border-radius-sm;
       border-bottom-left-radius: $border-radius-sm;
@@ -17,10 +18,10 @@
       border-bottom-right-radius: $border-radius-sm;
     }
     &.highlighted {
-      transition: all 0.18s ease-out;
       z-index: 1;
       height: calc(100% + 2px);
       margin-top: -1px;
+      box-shadow: 0 0 0 2px white;
     }
   }
 }

--- a/aim/web/ui/src/components/StatisticsBar/StatisticsBar.tsx
+++ b/aim/web/ui/src/components/StatisticsBar/StatisticsBar.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { Tooltip } from '@material-ui/core';
+
 import { IBarStyle, IStatisticsBarProps } from '.';
 
 import './StatisticsBar.scss';
@@ -15,7 +17,7 @@ function StatisticsBar({
   const onSafeMouseOver = React.useCallback(
     (id: string) => {
       if (typeof onMouseOver === 'function') {
-        onMouseOver(id);
+        onMouseOver(id, 'bar');
       }
     },
     [onMouseOver],
@@ -37,18 +39,19 @@ function StatisticsBar({
   }, [data]);
   return (
     <div className='StatisticsBar' style={{ width, height }}>
-      {Object.values(data).map((item, i) => (
-        <span
-          key={`${item.label}-${item.color}`}
-          title={`${item.label}`}
-          className={classNames('StatisticsBar__item', {
-            highlighted: item.percent && item.highlighted,
-          })}
-          style={{ ...barStyles[i], left: barStyles[i].left + '%' }}
-          onMouseLeave={onMouseLeave}
-          onMouseOver={() => onSafeMouseOver(item.label || '')}
-        />
-      ))}
+      {Object.values(data).map(
+        ({ percent, color, label = '', highlighted }, i) =>
+          percent ? (
+            <Tooltip key={`${label}-${color}`} title={label}>
+              <div
+                className={classNames('StatisticsBar__item', { highlighted })}
+                style={{ ...barStyles[i], left: barStyles[i].left + '%' }}
+                onMouseLeave={onMouseLeave}
+                onMouseOver={() => onSafeMouseOver(label)}
+              />
+            </Tooltip>
+          ) : null,
+      )}
     </div>
   );
 }

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
@@ -7,9 +7,10 @@ export interface IStatisticsCardProps {
   icon?: IconName;
   iconBgColor?: string;
   cardBgColor?: string;
-  onMouseOver?: (id: string) => void;
+  onMouseOver?: (id: string, source: string) => void;
   onMouseLeave?: () => void;
   navLink?: string;
   highlighted?: boolean;
-  disabled?: boolean;
+  outlined?: boolean;
+  isLoading?: boolean;
 }

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
@@ -8,6 +8,8 @@
   border-radius: $border-radius-sm;
   min-width: toRem(130px);
   max-width: toRem(130px);
+  border: 1px solid transparent;
+  transition: all 0.18s ease-out;
   &__iconWrapper {
     width: 2rem;
     min-width: 2rem;
@@ -17,9 +19,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    &__icon {
-      color: white;
-    }
   }
   &__info {
     display: flex;
@@ -39,12 +38,5 @@
   }
   &.highlighted {
     cursor: pointer;
-    transition: all 0.18s ease-out;
-    .StatisticsCard__info__label, .StatisticsCard__info__count {
-      color: white;
-    }
-    .StatisticsCard__iconWrapper__icon {
-      color: $pico-80;
-    }
   }
 }

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import classNames from 'classnames';
 import { useHistory } from 'react-router-dom';
+import classNames from 'classnames';
 
 import { Tooltip } from '@material-ui/core';
 
@@ -14,64 +14,74 @@ import './StatisticsCard.scss';
 
 function StatisticsCard({
   label,
-  title,
+  title = '',
   count,
   icon,
-  iconBgColor = '#fff',
+  iconBgColor = '#000000',
   cardBgColor = hexToRgbA(iconBgColor, 0.1),
   onMouseOver,
   onMouseLeave,
   navLink,
   highlighted,
-  disabled = false,
+  outlined = false,
+  isLoading = false,
 }: IStatisticsCardProps) {
   const history = useHistory();
   const onSafeMouseOver = React.useCallback(
     (id: string) => {
-      if (!disabled && typeof onMouseOver === 'function') {
-        onMouseOver(id);
+      if (typeof onMouseOver === 'function') {
+        onMouseOver(id, 'card');
       }
     },
     [onMouseOver],
   );
+  const renderCount = isLoading ? '--' : count;
+  const styles = {
+    card: {
+      borderColor: `${outlined ? iconBgColor : 'transparent'}`,
+      backgroundColor: highlighted ? iconBgColor : cardBgColor,
+    },
+    iconWrapper: {
+      backgroundColor: highlighted ? '#fff' : iconBgColor,
+    },
+    iconColor: highlighted ? iconBgColor : '#fff',
+    label: highlighted ? { color: '#fff' } : {},
+    count: highlighted ? { color: '#fff' } : {},
+  };
   return (
-    <Tooltip title={title || ''}>
+    <Tooltip title={title} placement='top'>
       <div
-        onClick={() => !disabled && navLink && history.push(navLink)}
+        onClick={() => navLink && history.push(navLink)}
         onMouseLeave={onMouseLeave}
         onMouseOver={() => onSafeMouseOver(label)}
-        className={classNames('StatisticsCard', {
-          highlighted: navLink && highlighted,
-        })}
-        style={{
-          backgroundColor: navLink && highlighted ? iconBgColor : cardBgColor,
-        }}
+        className={classNames('StatisticsCard', { highlighted })}
+        style={styles.card}
       >
         {icon && (
           <div
             className='StatisticsCard__iconWrapper'
-            style={{
-              backgroundColor: navLink && highlighted ? '#fff' : iconBgColor,
-            }}
+            style={styles.iconWrapper}
           >
-            <Icon
-              className='StatisticsCard__iconWrapper__icon'
-              name={icon}
-              color={navLink && highlighted ? iconBgColor : '#fff'}
-            />
+            <Icon name={icon} color={styles.iconColor} />
           </div>
         )}
         <div className='StatisticsCard__info'>
-          <Text className='StatisticsCard__info__label' size={10} weight={600}>
+          <Text
+            className='StatisticsCard__info__label'
+            size={10}
+            weight={600}
+            style={styles.label}
+          >
             {label}
           </Text>
-          <Tooltip title={`${count}`}>
+          <Tooltip title={renderCount}>
             <Text
               className='StatisticsCard__info__count'
               size={16}
               weight={600}
+              style={styles.count}
             >
-              {count}
+              {renderCount}
             </Text>
           </Tooltip>
         </div>

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
@@ -3,7 +3,7 @@ import { IconName } from 'components/kit/Icon';
 export interface IProjectStatistic {
   label: string;
   count: number;
-  iconBgColor: string;
+  iconBgColor?: string;
   icon?: IconName;
   navLink?: string;
   title?: string;

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
@@ -27,7 +27,7 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     label: 'Sys. metrics',
     count: 0,
     icon: 'metrics',
-    iconBgColor: '#FCB500',
+    iconBgColor: '#AF4EAB',
     navLink: `${routes.METRICS.path}?select=${encode({
       advancedQuery: "metric.name.startswith('__system__') == True",
       advancedMode: true,
@@ -54,7 +54,7 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     label: 'Audios',
     icon: 'audio',
     count: 0,
-    iconBgColor: '#729B1B',
+    iconBgColor: '#FCB500',
     navLink: '',
     title: 'Explorer coming soon',
   },
@@ -94,7 +94,10 @@ const runsCountingInitialMap: Record<'archived' | 'runs', IProjectStatistic> = {
 };
 
 function ProjectStatistics() {
-  const [hoveredState, setHoveredState] = React.useState('');
+  const [hoveredState, setHoveredState] = React.useState({
+    source: '',
+    id: '',
+  });
   const { projectParamsStore, projectContributionsStore } =
     useProjectStatistics();
 
@@ -133,15 +136,17 @@ function ProjectStatistics() {
   );
   const statisticsBarData = React.useMemo(
     () =>
-      Object.values(statisticsMap).map((item) => ({
-        highlighted: hoveredState === item.label,
-        label: item.label,
-        color: item.iconBgColor,
-        percent:
-          totalTrackedSequencesCount === 0
-            ? 0
-            : (item.count / totalTrackedSequencesCount) * 100,
-      })),
+      Object.values(statisticsMap).map(
+        ({ label, iconBgColor = '#000', count }) => ({
+          highlighted: hoveredState.id === label,
+          label,
+          color: iconBgColor,
+          percent:
+            totalTrackedSequencesCount === 0
+              ? 0
+              : (count / totalTrackedSequencesCount) * 100,
+        }),
+      ),
     [statisticsMap, totalTrackedSequencesCount, hoveredState],
   );
   const runsCountingMap = React.useMemo(
@@ -157,13 +162,12 @@ function ProjectStatistics() {
     }),
     [archivedRuns, totalRunsCount],
   );
-  const onMouseOver = React.useCallback((id: string = '') => {
-    setHoveredState(id);
+  const onMouseOver = React.useCallback((id = '', source = '') => {
+    setHoveredState({ source, id });
   }, []);
   const onMouseLeave = React.useCallback(() => {
-    setHoveredState('');
+    setHoveredState({ source: '', id: '' });
   }, []);
-
   return (
     <div className='ProjectStatistics'>
       <Text
@@ -187,7 +191,8 @@ function ProjectStatistics() {
               iconBgColor={iconBgColor}
               onMouseOver={onMouseOver}
               onMouseLeave={onMouseLeave}
-              highlighted={hoveredState === label}
+              highlighted={!!navLink && hoveredState.id === label}
+              isLoading={projectContributionsStore.loading}
             />
           ),
         )}
@@ -214,7 +219,13 @@ function ProjectStatistics() {
               iconBgColor={iconBgColor}
               onMouseOver={onMouseOver}
               onMouseLeave={onMouseLeave}
-              highlighted={hoveredState === label}
+              highlighted={
+                !!navLink &&
+                hoveredState.source === 'card' &&
+                hoveredState.id === label
+              }
+              outlined={hoveredState.id === label}
+              isLoading={projectParamsStore.loading}
             />
           ),
         )}

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/useProjectStatistics.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/useProjectStatistics.tsx
@@ -16,7 +16,9 @@ function useProjectStatistics() {
     contributionsEngine.projectContributionsState((state) => state);
 
   React.useEffect(() => {
-    projectStatsEngine.fetchProjectParams();
+    if (!projectParamsStore.data) {
+      projectStatsEngine.fetchProjectParams();
+    }
     return () => {
       projectStatsEngine.destroy();
     };

--- a/aim/web/ui/src/styles/components/_tooltip.scss
+++ b/aim/web/ui/src/styles/components/_tooltip.scss
@@ -5,10 +5,12 @@
   overflow: hidden;
 }
 
-.MuiTooltip-tooltipPlacementTop, .MuiTooltip-tooltipPlacementBottom {
+.MuiTooltip-tooltipPlacementTop,
+.MuiTooltip-tooltipPlacementBottom {
   margin: 6px 0;
 }
 
-.MuiTooltip-tooltipPlacementLeft, .MuiTooltip-tooltipPlacementRight {
+.MuiTooltip-tooltipPlacementLeft,
+.MuiTooltip-tooltipPlacementRight {
   margin: 0 6px;
 }

--- a/aim/web/ui/src/styles/components/_tooltip.scss
+++ b/aim/web/ui/src/styles/components/_tooltip.scss
@@ -4,3 +4,11 @@
   max-height: $tooltip-max-height;
   overflow: hidden;
 }
+
+.MuiTooltip-tooltipPlacementTop, .MuiTooltip-tooltipPlacementBottom {
+  margin: 6px 0;
+}
+
+.MuiTooltip-tooltipPlacementLeft, .MuiTooltip-tooltipPlacementRight {
+  margin: 0 6px;
+}

--- a/aim/web/ui/src/types/core/AimObjects/CustomObject.d.ts
+++ b/aim/web/ui/src/types/core/AimObjects/CustomObject.d.ts
@@ -6,8 +6,8 @@ import { Params, RunProps } from './Run';
 export interface BaseRangeInfo {
   record_range_used: Tuple<number>;
   record_range_total: Tuple<number>;
-  index_range_used: ?Tuple<number>;
-  index_range_total: ?Tuple<number>;
+  index_range_used: Tuple<number> | null;
+  index_range_total: Tuple<number> | null;
 }
 
 export interface ObjectSequenceBase<T> extends BaseRangeInfo, SequenceBaseView {

--- a/aim/web/ui/src/types/core/AimObjects/Run.d.ts
+++ b/aim/web/ui/src/types/core/AimObjects/Run.d.ts
@@ -16,12 +16,12 @@ export interface Experiment {
 
 export interface RunProps {
   hash: string;
-  name: ?string;
-  description: ?string;
-  experiment: ?Experiment;
-  tags: ?Array<Tag>;
+  name: string | null;
+  description: string | null;
+  experiment: Experiment | null;
+  tags: Array<Tag> | null;
   creation_time: number;
-  end_time: ?number;
+  end_time: number | null;
 }
 
 export interface RunInfo {

--- a/aim/web/ui/src/types/core/AimObjects/Sequence.d.ts
+++ b/aim/web/ui/src/types/core/AimObjects/Sequence.d.ts
@@ -22,14 +22,14 @@ export interface MetricsBaseView extends SequenceBaseView {
 }
 
 export interface SequenceAlignedView extends SequenceBase {
-  x_axis_values: ?EncodedNumpyArray;
-  x_axis_iters: ?EncodedNumpyArray;
+  x_axis_values: EncodedNumpyArray | null;
+  x_axis_iters: EncodedNumpyArray | null;
 }
 
 export interface SequenceFullView extends SequenceAlignedView {
   slice: [number, number, number];
-  values: ?EncodedNumpyArray;
+  values: EncodedNumpyArray | null;
   epochs: Array<number>;
   iters: Array<number>;
-  timestamps: ?EncodedNumpyArray;
+  timestamps: EncodedNumpyArray | null;
 }


### PR DESCRIPTION
Add outlined state on cards:
- when hovering over on the self card 
- when hovering over on a statistics bar item

Divide statistics cards highlighting states into two states:
- filled:  when the card is also a link (to the corresponding explorer)
- default: when the card has no link to navigate (there is no explorer yet)