### PR TITLE
[feat] Add soon badge on dashboard statistic cards

### DIFF
--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
@@ -6,10 +6,11 @@
   align-items: center;
   justify-content: flex-start;
   border-radius: $border-radius-sm;
-  min-width: toRem(130px);
-  max-width: toRem(130px);
+  min-width: toRem(132px);
+  max-width: toRem(132px);
   border: 1px solid transparent;
   transition: all 0.18s ease-out;
+  position: relative;
   &__iconWrapper {
     width: 2rem;
     min-width: 2rem;
@@ -35,6 +36,19 @@
     &__label {
       text-transform: capitalize;
     }
+  }
+  &__soonBadge {
+    position: absolute;
+    top: -8px;
+    right: -6px;
+    text-align: center;
+    white-space: nowrap;
+    padding: 1px 4px;
+    color: $pico;
+    border-radius: $border-radius-xss;
+    background-color: white;
+    box-shadow: 0 1px 2px 0 #00000029;
+    user-select: none;
   }
   &.highlighted {
     cursor: pointer;

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
@@ -8,7 +8,7 @@
   border-radius: $border-radius-sm;
   min-width: toRem(132px);
   max-width: toRem(132px);
-  border: 1px solid transparent;
+  border: $border-transparent;
   transition: all 0.18s ease-out;
   position: relative;
   &__iconWrapper {
@@ -39,11 +39,11 @@
   }
   &__soonBadge {
     position: absolute;
-    top: -8px;
-    right: -6px;
+    top: -$space-xs;
+    right: -$space-xxs;
     text-align: center;
     white-space: nowrap;
-    padding: 1px 4px;
+    padding: $space-xxxxxs $space-xxxs;
     color: $pico;
     border-radius: $border-radius-xss;
     background-color: white;

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
@@ -38,7 +38,7 @@ function StatisticsCard({
   const renderCount = isLoading ? '--' : count;
   const styles = {
     card: {
-      borderColor: `${outlined ? iconBgColor : 'transparent'}`,
+      borderColor: outlined ? iconBgColor : 'transparent',
       backgroundColor: highlighted ? iconBgColor : cardBgColor,
     },
     iconWrapper: {
@@ -49,44 +49,51 @@ function StatisticsCard({
     count: highlighted ? { color: '#fff' } : {},
   };
   return (
-    <Tooltip title={title} placement='top'>
-      <div
-        onClick={() => navLink && history.push(navLink)}
-        onMouseLeave={onMouseLeave}
-        onMouseOver={() => onSafeMouseOver(label)}
-        className={classNames('StatisticsCard', { highlighted })}
-        style={styles.card}
-      >
-        {icon && (
-          <div
-            className='StatisticsCard__iconWrapper'
-            style={styles.iconWrapper}
-          >
-            <Icon name={icon} color={styles.iconColor} />
-          </div>
-        )}
-        <div className='StatisticsCard__info'>
-          <Text
-            className='StatisticsCard__info__label'
-            size={10}
-            weight={600}
-            style={styles.label}
-          >
-            {label}
-          </Text>
-          <Tooltip title={renderCount}>
-            <Text
-              className='StatisticsCard__info__count'
-              size={16}
-              weight={600}
-              style={styles.count}
-            >
-              {renderCount}
-            </Text>
-          </Tooltip>
+    <div
+      onClick={() => navLink && history.push(navLink)}
+      onMouseLeave={onMouseLeave}
+      onMouseOver={() => onSafeMouseOver(label)}
+      className={classNames('StatisticsCard', { highlighted })}
+      style={styles.card}
+    >
+      {!navLink && (
+        <Text
+          component='p'
+          className='StatisticsCard__soonBadge'
+          weight={600}
+          size={8}
+        >
+          Coming soon
+        </Text>
+      )}
+
+      {icon && (
+        <div className='StatisticsCard__iconWrapper' style={styles.iconWrapper}>
+          <Icon name={icon} color={styles.iconColor} />
         </div>
+      )}
+      <div className='StatisticsCard__info'>
+        <Text
+          className='StatisticsCard__info__label'
+          size={10}
+          weight={600}
+          style={styles.label}
+        >
+          {label}
+        </Text>
+
+        <Text
+          className='StatisticsCard__info__count'
+          size={16}
+          weight={600}
+          style={styles.count}
+        >
+          <Tooltip title={renderCount}>
+            <div>{renderCount}</div>
+          </Tooltip>
+        </Text>
       </div>
-    </Tooltip>
+    </div>
   );
 }
 

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -156,7 +156,7 @@ import getClosestValue from 'utils/getClosestValue';
 import getObjectPaths from 'utils/getObjectPaths';
 import getSmoothenedData from 'utils/getSmoothenedData';
 import JsonToCSV from 'utils/JsonToCSV';
-import { getItem, setItem } from 'utils/storage';
+import { setItem } from 'utils/storage';
 import { encode } from 'utils/encoder/encoder';
 import onBookmarkCreate from 'utils/app/onBookmarkCreate';
 import onBookmarkUpdate from 'utils/app/onBookmarkUpdate';

--- a/aim/web/ui/src/styles/abstracts/_variables.scss
+++ b/aim/web/ui/src/styles/abstracts/_variables.scss
@@ -145,6 +145,7 @@ $font-900: 850;
 
 // space
 $space-unit: 1rem;
+$space-xxxxxs: $space-unit * 0.0625;
 $space-xxxxs: $space-unit * 0.125;
 $space-xxxs: $space-unit * 0.25;
 $space-xxs: $space-unit * 0.375;


### PR DESCRIPTION
Dashboard statistic cards have the ability to navigate to the corresponding explorer page.
As there are no `Audio`, `Text`, and `Distributions` explorers yet, we need to mark corresponding cards, to show explicitly, that they are not able to navigate to explorers.

