### PR TITLE
[fix] Fix in-progress runs indicators overlapping issue by active points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Fix in-progress training runs indicators overlapping issue in line chart (KaroMourad)
+- Fix active runs indicators overlapping issue in LineChart (KaroMourad)
 
 ## 3.14.1 Oct 7, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix in-progress training runs indicators overlapping issue in line chart (KaroMourad)
+
 ## 3.14.1 Oct 7, 2022
 
 - Fix the current release duplication highlighting issue on the Dashboard page (arsengit)

--- a/aim/web/ui/src/components/HighPlot/HighPlot.scss
+++ b/aim/web/ui/src/components/HighPlot/HighPlot.scss
@@ -72,27 +72,24 @@
   &.zoomMode rect {
     cursor: zoom-in;
   }
-  .HoverLine {
-    stroke: #94999f; /* var(--grey-light) */
-  }
   .HoverCircle {
     cursor: pointer;
     opacity: 1;
-    stroke-width: 1.45;
+    stroke-width: 3;
     fill: white;
-    outline: 0 solid;
     border-radius: 50%;
+    paint-order: stroke;
     /* on click */
     &.focus {
-      stroke-width: 2;
+      stroke-width: 4;
       clip-path: unset;
       &__shadow {
-        stroke-width: 10;
+        stroke-width: 12;
       }
     }
     /* on hover */
     &.active {
-      stroke-width: 2.6;
+      stroke-width: 5;
     }
   }
   .Attributes {
@@ -132,20 +129,20 @@
       }
     }
     &.highlight > .Line:not(.active):not(.highlighted) {
-      stroke-width: 1;
+      stroke-width: 1.5;
       opacity: 0.2;
     }
   }
   .Line {
-    stroke-width: 2;
+    stroke-width: 1.5;
     opacity: 0.3;
     &.active {
       opacity: 1;
-      stroke-width: 3px;
+      stroke-width: 3;
     }
     &.highlighted {
       opacity: 1;
-      stroke-width: 2px;
+      stroke-width: 2;
     }
   }
 }

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -25,26 +25,24 @@
   &.zoomMode rect {
     cursor: zoom-in;
   }
-  .HoverLine {
-    stroke: #94999f; /* var(--grey-light) */
-  }
   .HoverCircle {
     cursor: pointer;
     opacity: 1;
-    stroke-width: 1.45;
+    stroke-width: 2.4;
     fill: white;
     border-radius: 50%;
+    paint-order: stroke;
     /* on click */
     &.focus {
-      stroke-width: 2;
+      stroke-width: 4;
       clip-path: unset;
       &__shadow {
-        stroke-width: 10;
+        stroke-width: 12;
       }
     }
     /* on hover */
     &.active {
-      stroke-width: 2.6;
+      stroke-width: 5;
     }
   }
   .Attributes {
@@ -96,16 +94,25 @@
         }
       }
       & > .Line:not(.active):not(.highlighted):not(.aggregated) {
-        stroke-width: 1.45;
+        stroke-width: 1.5;
         opacity: 0.2;
       }
       & > .AggrArea:not(.highlighted) {
         opacity: 0.2;
       }
+      .inProgressLineIndicator {
+        opacity: 0.5;
+        &.active {
+          opacity: 1;
+        }
+        &.highlighted {
+          opacity: 1;
+        }
+      }
     }
   }
   .Line {
-    stroke-width: 1.45;
+    stroke-width: 1.5;
     opacity: 1;
     &.active {
       opacity: 1;
@@ -118,12 +125,12 @@
     &.aggregated {
       opacity: 0;
       stroke-width: 0.4;
-      &.highlighted {
-        opacity: 0.5;
-        stroke-width: 2.8;
-      }
       &.active {
         opacity: 0.8;
+        stroke-width: 3;
+      }
+      &.highlighted {
+        opacity: 0.5;
         stroke-width: 2.8;
       }
     }
@@ -134,33 +141,21 @@
   }
 
   .inProgressLineIndicator {
-    animation: inProgressIndicator 0.5s cubic-bezier(0.6, -0.03, 0.22, 0.76)
+    animation: inProgressIndicator 0.6s cubic-bezier(0.6, -0.03, 0.22, 0.76)
       infinite;
-    stroke-width: 1;
     opacity: 1;
-  }
-
-  .Lines.highlight {
-    .inProgressLineIndicator {
-      opacity: 0.2;
-      &.active {
-        opacity: 1;
-      }
-      &.highlighted {
-        opacity: 1;
-      }
-    }
+    paint-order: stroke;
   }
 
   @keyframes inProgressIndicator {
     0% {
-      stroke-width: 0.6;
+      stroke-width: 3;
     }
     50% {
-      stroke-width: 1.5;
+      stroke-width: 5.2;
     }
     100% {
-      stroke-width: 0.6;
+      stroke-width: 3;
     }
   }
 }

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -154,13 +154,13 @@
 
   @keyframes inProgressIndicator {
     0% {
-      stroke-width: 0;
+      stroke-width: 0.6;
     }
     50% {
       stroke-width: 1.5;
     }
     100% {
-      stroke-width: 0;
+      stroke-width: 0.6;
     }
   }
 }

--- a/aim/web/ui/src/components/LineChart/LineChart.scss
+++ b/aim/web/ui/src/components/LineChart/LineChart.scss
@@ -46,9 +46,15 @@
     }
   }
   .Attributes {
-    &.highlight > .HoverCircle:not(.active):not(.focus) {
-      opacity: 0.5;
+    &.highlight {
+      .HoverCircle:not(.active):not(.focus) {
+        opacity: 0.5;
+      }
+      .inProgressLineIndicator:not(.active):not(.focus) {
+        opacity: 0.8;
+      }
     }
+
   }
   .ChartMouseValue {
     position: absolute;
@@ -100,15 +106,6 @@
       & > .AggrArea:not(.highlighted) {
         opacity: 0.2;
       }
-      .inProgressLineIndicator {
-        opacity: 0.5;
-        &.active {
-          opacity: 1;
-        }
-        &.highlighted {
-          opacity: 1;
-        }
-      }
     }
   }
   .Line {
@@ -141,10 +138,12 @@
   }
 
   .inProgressLineIndicator {
-    animation: inProgressIndicator 0.6s cubic-bezier(0.6, -0.03, 0.22, 0.76)
+    animation: inProgressIndicator 0.5s cubic-bezier(0.6, -0.03, 0.22, 0.76)
       infinite;
     opacity: 1;
     paint-order: stroke;
+    cursor: pointer;
+    filter: drop-shadow(0 0 0.5px #ffffff) drop-shadow(0 0 0.5px #ffffff) drop-shadow(0 0 0.5px #ffffff);
   }
 
   @keyframes inProgressIndicator {

--- a/aim/web/ui/src/components/LineChart/LineChart.tsx
+++ b/aim/web/ui/src/components/LineChart/LineChart.tsx
@@ -159,30 +159,6 @@ const LineChart = React.forwardRef(function LineChart(
       }
     }
 
-    if (!readOnly) {
-      drawHoverAttributes({
-        index,
-        nameKey,
-        data,
-        axesScaleType,
-        highlightMode,
-        syncHoverState,
-        visAreaRef,
-        attributesRef,
-        plotBoxRef,
-        visBoxRef,
-        svgNodeRef,
-        bgRectNodeRef,
-        attributesNodeRef,
-        xAxisLabelNodeRef,
-        yAxisLabelNodeRef,
-        linesNodeRef,
-        highlightedNodeRef,
-        aggregationConfig,
-        alignmentConfig,
-      });
-    }
-
     drawBrush({
       index,
       plotBoxRef,
@@ -201,6 +177,31 @@ const LineChart = React.forwardRef(function LineChart(
       readOnly,
       unableToDrawConditions,
     });
+
+    if (!readOnly) {
+      drawHoverAttributes({
+        index,
+        nameKey,
+        data,
+        processedData,
+        axesScaleType,
+        highlightMode,
+        syncHoverState,
+        visAreaRef,
+        attributesRef,
+        plotBoxRef,
+        visBoxRef,
+        svgNodeRef,
+        bgRectNodeRef,
+        attributesNodeRef,
+        xAxisLabelNodeRef,
+        yAxisLabelNodeRef,
+        linesNodeRef,
+        highlightedNodeRef,
+        aggregationConfig,
+        alignmentConfig,
+      });
+    }
 
     drawUnableToRender({
       renderArr: unableToDrawConditions,

--- a/aim/web/ui/src/components/ScatterPlot/styles.scss
+++ b/aim/web/ui/src/components/ScatterPlot/styles.scss
@@ -25,27 +25,24 @@
   &.zoomMode rect {
     cursor: zoom-in;
   }
-  .HoverLine {
-    stroke: #94999f; /* var(--grey-light) */
-  }
   .HoverCircle {
     cursor: pointer;
     opacity: 1;
-    stroke-width: 1.45;
+    stroke-width: 3;
     fill: white;
-    outline: 0 solid;
     border-radius: 50%;
+    paint-order: stroke;
     /* on click */
     &.focus {
-      stroke-width: 2;
+      stroke-width: 4;
       clip-path: unset;
       &__shadow {
-        stroke-width: 10;
+        stroke-width: 12;
       }
     }
     /* on hover */
     &.active {
-      stroke-width: 2.6;
+      stroke-width: 5;
     }
   }
   .Attributes {
@@ -86,12 +83,13 @@
   .Circle {
     cursor: pointer;
     opacity: 1;
-    stroke-width: 1.45;
+    stroke-width: 2.4;
     fill: white;
     outline: 0 solid;
     border-radius: 50%;
+    paint-order: stroke;
     &.active {
-      stroke-width: 2.6;
+      stroke-width: 5;
     }
     &.highlighted {
       opacity: 1;

--- a/aim/web/ui/src/components/ScatterPlot/types.d.ts
+++ b/aim/web/ui/src/components/ScatterPlot/types.d.ts
@@ -4,6 +4,7 @@ import { IChartTitle } from 'types/services/models/metrics/metricsAppModel';
 import { ITrendlineOptions } from 'types/services/models/scatter/scatterAppModel';
 import { ISyncHoverStateArgs } from 'types/utils/d3/drawHoverAttributes';
 import { IDimensionType } from 'types/utils/d3/drawParallelAxes';
+import { IRun } from 'types/services/models/metrics/runModel';
 
 export interface IPoint {
   key: string;
@@ -14,6 +15,7 @@ export interface IPoint {
   color: string;
   groupKey: string;
   chartIndex?: number;
+  run?: IRun;
 }
 
 export interface IScatterPlotProps {

--- a/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
+++ b/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
@@ -61,6 +61,7 @@ export interface INearestCircle {
   y: number;
   key: string;
   color: string;
+  inProgress?: boolean;
 }
 
 export interface IActivePoint {
@@ -70,6 +71,7 @@ export interface IActivePoint {
   xPos: number;
   yPos: number;
   chartIndex: number;
+  inProgress?: boolean;
   pointRect: {
     top: number;
     bottom: number;

--- a/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
+++ b/aim/web/ui/src/types/utils/d3/drawHoverAttributes.d.ts
@@ -11,11 +11,15 @@ import {
 import { ScaleEnum, HighlightEnum } from 'utils/d3';
 
 import { IAxisScale } from './getAxisScale';
+import { IProcessedData } from './processLineChartData';
+
+export type HoverAttrData = ILine | IPoint;
 
 export interface IDrawHoverAttributesArgs {
   index: number;
   nameKey: string;
-  data: ILine[] | IPoint[];
+  data: HoverAttrData[];
+  processedData?: IProcessedData[];
   axesScaleType: { xAxis: ScaleEnum; yAxis: ScaleEnum };
   visAreaRef: React.MutableRefObject<>;
   attributesNodeRef: React.MutableRefObject<>;

--- a/aim/web/ui/src/utils/d3/drawBrush.ts
+++ b/aim/web/ui/src/utils/d3/drawBrush.ts
@@ -102,7 +102,6 @@ function drawBrush(args: IDrawBrushArgs): void {
       attributesRef.current.xScale,
       attributesRef.current.yScale,
     );
-    attributesRef.current.updateFocusedChart?.();
   }
 
   // This remove the grey brush area as soon as the selection has been done

--- a/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawHoverAttributes.ts
@@ -366,23 +366,25 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       if (!hoverLineY.empty()) {
         // update vertical hoverLine
         hoverLineY
-          .attr('x1', axisLineData.x1)
-          .attr('y1', axisLineData.y1)
-          .attr('x2', axisLineData.x2)
-          .attr('y2', axisLineData.y2);
+          .attr('x1', axisLineData.x1.toFixed(2))
+          .attr('y1', axisLineData.y1.toFixed(2))
+          .attr('x2', axisLineData.x2.toFixed(2))
+          .attr('y2', axisLineData.y2.toFixed(2));
       } else {
         // create vertical hoverLine
         attrNodeRef.current
           .append('line')
           .attr('id', 'HoverLine-y')
           .attr('class', 'HoverLine')
+          .style('stroke', '#94999f')
           .style('stroke-width', 1)
           .style('stroke-dasharray', '4 2')
           .style('fill', 'none')
-          .attr('x1', axisLineData.x1)
-          .attr('y1', axisLineData.y1)
-          .attr('x2', axisLineData.x2)
-          .attr('y2', axisLineData.y2)
+          .style('pointer-events', 'none')
+          .attr('x1', axisLineData.x1.toFixed(2))
+          .attr('y1', axisLineData.y1.toFixed(2))
+          .attr('x2', axisLineData.x2.toFixed(2))
+          .attr('y2', axisLineData.y2.toFixed(2))
           .lower();
       }
     }
@@ -421,9 +423,11 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
           .append('line')
           .attr('id', 'HoverLine-x')
           .attr('class', 'HoverLine')
+          .style('stroke', '#94999f')
           .style('stroke-width', 1)
           .style('stroke-dasharray', '4 2')
           .style('fill', 'none')
+          .style('pointer-events', 'none')
           .attr('x1', axisLineData.x1)
           .attr('y1', axisLineData.y1)
           .attr('x2', axisLineData.x2)
@@ -433,11 +437,12 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
     }
   }
 
-  function drawActiveCircle(key: string): void {
+  function drawActiveCircle(key: string, inProgress: boolean = false): void {
     attrNodeRef.current
       .select(`[id=Circle-${key}]`)
       .attr('r', CircleEnum.ActiveRadius)
       .classed('active', true)
+      .classed('inProgressLineIndicator', inProgress)
       .raise();
   }
 
@@ -490,7 +495,6 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       .attr('stroke', (d: INearestCircle) => d.color)
       .attr('fill', (d: INearestCircle) => d.color)
       .attr('stroke-opacity', 1)
-      .classed('inProgressLineIndicator', (d: INearestCircle) => !!d.inProgress)
       .on('click', handlePointClick);
   }
 
@@ -614,7 +618,8 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       .selectAll('circle')
       .attr('r', CircleEnum.Radius)
       .classed('active', false)
-      .classed('focus', false);
+      .classed('focus', false)
+      .classed('inProgressLineIndicator', false);
 
     clearHorizontalAxisLine();
     clearYAxisLabel();
@@ -657,7 +662,7 @@ function drawHoverAttributes(args: IDrawHoverAttributesArgs): void {
       drawHorizontalAxisLine(circle.y);
       drawXAxisLabel(xValue);
       drawYAxisLabel(yValue);
-      drawActiveCircle(circle.key);
+      drawActiveCircle(circle.key, circle.inProgress);
     }
 
     const activePoint = getActivePoint(circle, xValue, yValue);

--- a/aim/web/ui/src/utils/d3/drawLines.ts
+++ b/aim/web/ui/src/utils/d3/drawLines.ts
@@ -24,7 +24,6 @@ function drawLines(args: IDrawLinesArgs): void {
     aggregationConfig,
     processedData,
     processedAggrData,
-    readOnly = false,
   } = args;
 
   if (!linesNodeRef?.current) {
@@ -39,63 +38,7 @@ function drawLines(args: IDrawLinesArgs): void {
     linesNodeRef.current
       .selectAll('.Line')
       .attr('d', lineGenerator(xScale, yScale, curve));
-
-    if (!readOnly) {
-      updateActiveRunsIndicators();
-    }
   };
-
-  function updateActiveRunsIndicators(): void {
-    linesNodeRef.current
-      ?.selectAll('.inProgressLineIndicator')
-      .attr('cx', (d: IProcessedData) => {
-        if (d.data.length > 0) {
-          const lastPoint = d.data[d.data.length - 1];
-          return xScale(lastPoint[0]).toFixed(2);
-        }
-      })
-      .attr('cy', (d: IProcessedData) => {
-        if (d.data.length > 0) {
-          const lastPoint = d.data[d.data.length - 1];
-          return yScale(lastPoint[1]).toFixed(2);
-        }
-      })
-      .raise();
-  }
-
-  function drawActiveRunsIndicators(data: IProcessedData[]): void {
-    const activeRuns =
-      data?.filter((d: IProcessedData) => d?.run?.props?.active) ?? [];
-
-    linesNodeRef.current
-      ?.selectAll('.inProgressLineIndicator')
-      .data(activeRuns)
-      .join('circle')
-      .attr(
-        'data-selector',
-        (d: IProcessedData) =>
-          `Line-Sel-${highlightMode}-${d.selectors?.[highlightMode]}`,
-      )
-      .attr('clip-path', `url(#${nameKey}-circles-rect-clip-${index})`)
-      .attr('class', 'inProgressLineIndicator')
-      .style('stroke', (d: IProcessedData) => d.color)
-      .style('fill', (d: IProcessedData) => d.color)
-      .attr('id', (d: IProcessedData) => `inProgressLineIndicator-${d.key}`)
-      .attr('cx', (d: IProcessedData) => {
-        if (d.data.length > 0) {
-          const lastPoint = d.data[d.data.length - 1];
-          return xScale(lastPoint[0]).toFixed(2);
-        }
-      })
-      .attr('cy', (d: IProcessedData) => {
-        if (d.data.length > 0) {
-          const lastPoint = d.data[d.data.length - 1];
-          return yScale(lastPoint[1]).toFixed(2);
-        }
-      })
-      .attr('r', 1.8)
-      .raise();
-  }
 
   linesRef.current.updateLines = function (data: IProcessedData[]): void {
     linesNodeRef.current
@@ -116,10 +59,6 @@ function drawLines(args: IDrawLinesArgs): void {
       .style('stroke-dasharray', (d: IProcessedData) => d.dasharray)
       .data(data.map((d: IProcessedData) => d.data))
       .attr('d', lineGenerator(xScale, yScale, curveInterpolation));
-
-    if (!readOnly) {
-      drawActiveRunsIndicators(data);
-    }
   };
 
   linesRef.current.updateAggregatedAreasScales = function (

--- a/aim/web/ui/src/utils/d3/drawLines.ts
+++ b/aim/web/ui/src/utils/d3/drawLines.ts
@@ -41,22 +41,61 @@ function drawLines(args: IDrawLinesArgs): void {
       .attr('d', lineGenerator(xScale, yScale, curve));
 
     if (!readOnly) {
-      linesNodeRef.current
-        ?.selectAll('.inProgressLineIndicator')
-        .attr(
-          'cx',
-          (d: IProcessedData) =>
-            d.data.length && xScale(d.data[d.data.length - 1][0]),
-        )
-        .attr(
-          'cy',
-          (d: IProcessedData) =>
-            d.data.length && yScale(d.data[d.data.length - 1][1]),
-        )
-        .attr('r', 2)
-        .raise();
+      updateActiveRunsIndicators();
     }
   };
+
+  function updateActiveRunsIndicators(): void {
+    linesNodeRef.current
+      ?.selectAll('.inProgressLineIndicator')
+      .attr('cx', (d: IProcessedData) => {
+        if (d.data.length > 0) {
+          const lastPoint = d.data[d.data.length - 1];
+          return xScale(lastPoint[0]).toFixed(2);
+        }
+      })
+      .attr('cy', (d: IProcessedData) => {
+        if (d.data.length > 0) {
+          const lastPoint = d.data[d.data.length - 1];
+          return yScale(lastPoint[1]).toFixed(2);
+        }
+      })
+      .raise();
+  }
+
+  function drawActiveRunsIndicators(data: IProcessedData[]): void {
+    const activeRuns =
+      data?.filter((d: IProcessedData) => d?.run?.props?.active) ?? [];
+
+    linesNodeRef.current
+      ?.selectAll('.inProgressLineIndicator')
+      .data(activeRuns)
+      .join('circle')
+      .attr(
+        'data-selector',
+        (d: IProcessedData) =>
+          `Line-Sel-${highlightMode}-${d.selectors?.[highlightMode]}`,
+      )
+      .attr('clip-path', `url(#${nameKey}-circles-rect-clip-${index})`)
+      .attr('class', 'inProgressLineIndicator')
+      .style('stroke', (d: IProcessedData) => d.color)
+      .style('fill', (d: IProcessedData) => d.color)
+      .attr('id', (d: IProcessedData) => `inProgressLineIndicator-${d.key}`)
+      .attr('cx', (d: IProcessedData) => {
+        if (d.data.length > 0) {
+          const lastPoint = d.data[d.data.length - 1];
+          return xScale(lastPoint[0]).toFixed(2);
+        }
+      })
+      .attr('cy', (d: IProcessedData) => {
+        if (d.data.length > 0) {
+          const lastPoint = d.data[d.data.length - 1];
+          return yScale(lastPoint[1]).toFixed(2);
+        }
+      })
+      .attr('r', 2)
+      .raise();
+  }
 
   linesRef.current.updateLines = function (data: IProcessedData[]): void {
     linesNodeRef.current
@@ -79,35 +118,7 @@ function drawLines(args: IDrawLinesArgs): void {
       .attr('d', lineGenerator(xScale, yScale, curveInterpolation));
 
     if (!readOnly) {
-      let activeRuns =
-        data?.filter((d: IProcessedData) => d?.run?.props?.active) ?? [];
-
-      linesNodeRef.current
-        ?.selectAll('.inProgressLineIndicator')
-        .data(activeRuns)
-        .join('circle')
-        .attr(
-          'data-selector',
-          (d: IProcessedData) =>
-            `Line-Sel-${highlightMode}-${d.selectors?.[highlightMode]}`,
-        )
-        .attr('clip-path', `url(#${nameKey}-circles-rect-clip-${index})`)
-        .attr('class', 'inProgressLineIndicator')
-        .style('stroke', (d: IProcessedData) => d.color)
-        .style('fill', (d: IProcessedData) => d.color)
-        .attr('id', (d: IProcessedData) => `inProgressLineIndicator-${d.key}`)
-        .attr(
-          'cx',
-          (d: IProcessedData) =>
-            d.data.length && xScale(d.data[d.data.length - 1][0]),
-        )
-        .attr(
-          'cy',
-          (d: IProcessedData) =>
-            d.data.length && yScale(d.data[d.data.length - 1][1]),
-        )
-        .attr('r', 2)
-        .raise();
+      drawActiveRunsIndicators(data);
     }
   };
 

--- a/aim/web/ui/src/utils/d3/drawLines.ts
+++ b/aim/web/ui/src/utils/d3/drawLines.ts
@@ -93,7 +93,7 @@ function drawLines(args: IDrawLinesArgs): void {
           return yScale(lastPoint[1]).toFixed(2);
         }
       })
-      .attr('r', 2)
+      .attr('r', 1.8)
       .raise();
   }
 

--- a/aim/web/ui/src/utils/d3/drawParallelHoverAttributes.ts
+++ b/aim/web/ui/src/utils/d3/drawParallelHoverAttributes.ts
@@ -316,8 +316,8 @@ const drawParallelHoverAttributes = ({
       .attr('id', (d: IParallelNearestCircle) => `Circle-${d.key}`)
       .attr('data-key', (d: IParallelNearestCircle) => d.key)
       .attr('clip-path', `url(#${nameKey}-circles-rect-clip-${index})`)
-      .attr('cx', (d: IParallelNearestCircle) => d.x.toFixed(0))
-      .attr('cy', (d: IParallelNearestCircle) => d.y.toFixed(0))
+      .attr('cx', (d: IParallelNearestCircle) => d.x.toFixed(2))
+      .attr('cy', (d: IParallelNearestCircle) => d.y.toFixed(2))
       .attr('r', CircleEnum.Radius)
       .attr('stroke', (d: IParallelNearestCircle) =>
         isVisibleColorIndicator

--- a/aim/web/ui/src/utils/d3/drawPoints.ts
+++ b/aim/web/ui/src/utils/d3/drawPoints.ts
@@ -19,8 +19,8 @@ function drawPoints(args: IDrawPointsArgs): void {
   ): void {
     pointsNodeRef.current
       .selectAll('.Circle')
-      .attr('cx', (p: IPoint) => xScale(p.data.xValues[0]).toFixed(0))
-      .attr('cy', (p: IPoint) => yScale(p.data.yValues[0]).toFixed(0))
+      .attr('cx', (p: IPoint) => xScale(p.data.xValues[0]).toFixed(2))
+      .attr('cy', (p: IPoint) => yScale(p.data.yValues[0]).toFixed(2))
       .attr('r', CircleEnum.Radius);
   };
 
@@ -37,8 +37,8 @@ function drawPoints(args: IDrawPointsArgs): void {
       .attr('id', (p: IPoint) => `Circle-${p.key}`)
       .attr('clip-path', `url(#${nameKey}-lines-rect-clip-${index})`)
       .attr('groupKey', (p: IPoint) => p.groupKey)
-      .attr('cx', (p: IPoint) => xScale(p.data.xValues[0]).toFixed(0))
-      .attr('cy', (p: IPoint) => yScale(p.data.yValues[0]).toFixed(0))
+      .attr('cx', (p: IPoint) => xScale(p.data.xValues[0]).toFixed(2))
+      .attr('cy', (p: IPoint) => yScale(p.data.yValues[0]).toFixed(2))
       .attr('r', CircleEnum.Radius)
       .attr('fill', (p: IPoint) => p.color)
       .attr('stroke', (d: IPoint) => d.color)

--- a/aim/web/ui/src/utils/d3/index.ts
+++ b/aim/web/ui/src/utils/d3/index.ts
@@ -28,8 +28,8 @@ enum AlignmentOptionsEnum {
 }
 
 enum CircleEnum {
-  Radius = 2.6,
-  ActiveRadius = 5,
+  Radius = 2.4,
+  ActiveRadius = 4.8,
 }
 
 enum HighlightEnum {

--- a/aim/web/ui/src/utils/d3/index.ts
+++ b/aim/web/ui/src/utils/d3/index.ts
@@ -29,7 +29,8 @@ enum AlignmentOptionsEnum {
 
 enum CircleEnum {
   Radius = 2,
-  ActiveRadius = 4.8,
+  ActiveRadius = 4.6,
+  InProgress = 1.6,
 }
 
 enum HighlightEnum {


### PR DESCRIPTION
Active runs indicators overlap by hover attributes.
To fix the issue we need to add active runs indicators on hover attributes (on circles).

- add `inProgress` state on hover attributes
- add pulsating animation for `inProgress` circles
- tune pulsating dots animation styles