### PR TITLE
[fix] Fix solid stroke rendering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Fix issue with applying solid stroke-dasharray badge in table (KaroMourad)
 - Fix active runs indicators overlapping issue in LineChart (KaroMourad)
 
 ## 3.14.2

--- a/aim/web/ui/src/components/CustomTable/TableColumn.tsx
+++ b/aim/web/ui/src/components/CustomTable/TableColumn.tsx
@@ -964,10 +964,13 @@ function GroupConfig({
                 x2='100%'
                 y2='50%'
                 style={{
-                  strokeDasharray: config.dasharray
-                    .split(' ')
-                    .map((elem) => (elem / 5) * 3)
-                    .join(' '),
+                  strokeDasharray:
+                    config.dasharray === 'none'
+                      ? 'none'
+                      : config.dasharray
+                          .split(' ')
+                          .map((elem) => (elem / 5) * 3)
+                          .join(' '),
                 }}
               />
             </svg>

--- a/aim/web/ui/src/pages/Runs/RunsContainer.tsx
+++ b/aim/web/ui/src/pages/Runs/RunsContainer.tsx
@@ -40,7 +40,7 @@ function RunsContainer(): React.FunctionComponentElement<React.ReactNode> {
   React.useEffect(() => {
     runsAppModel.initialize();
     analytics.pageView(ANALYTICS_EVENT_KEYS.runs.pageView);
-    const unListenHistory = history.listen((location) => {
+    const unListenHistory = history.listen(() => {
       if (!!runsData?.config!) {
         if (
           runsData.config.select !== getStateFromUrl('search') &&


### PR DESCRIPTION
Before rendering `stroke-dasharray` badges in the table, we are processing (decreasing) the stroke styles, to have the ability to draw badges in a short area.
 
 Fix:
 - pass the 'none' values of the `stroke-dasharrays` on processing stroke styles
 