### PR TITLE
[fix] Fix querying all data on empty query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix querying all data on empty query (KaroMourad)
+
 ## 3.14.2 Oct 28, 2022
 
 - Add support to sync explorer state through url on Base and Figures Explorers (rubenaprikyan)

--- a/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
+++ b/aim/web/ui/src/services/models/imagesExplore/imagesExploreAppModel.ts
@@ -1843,10 +1843,10 @@ function getQueryStringFromSelect(
   selectData: IImagesExploreAppConfig['select'],
   error?: ISyntaxErrorDetails,
 ) {
+  let query = '()';
   if (selectData === undefined) {
-    return '';
+    return query;
   }
-  let query = '';
   if (selectData.advancedMode) {
     query = selectData.advancedQuery || '';
   } else {
@@ -1881,7 +1881,7 @@ function getQueryStringFromSelect(
       query = `${simpleInput}${selections}`;
     }
   }
-  return query.trim();
+  return query.trim() || '()';
 }
 
 function onSelectAdvancedQueryChange(query: string) {

--- a/aim/web/ui/src/utils/app/getQueryStringFromSelect.ts
+++ b/aim/web/ui/src/utils/app/getQueryStringFromSelect.ts
@@ -9,10 +9,10 @@ export default function getQueryStringFromSelect(
   selectData: ISelectConfig,
   error?: ISyntaxErrorDetails,
 ) {
+  let query = '()';
   if (selectData === undefined) {
-    return '';
+    return query;
   }
-  let query = '';
   if (selectData.advancedMode) {
     query = selectData.advancedQuery || '';
   } else {
@@ -50,5 +50,5 @@ export default function getQueryStringFromSelect(
       query = `${simpleInput}${selections}`;
     }
   }
-  return query.trim();
+  return query.trim() || '()';
 }


### PR DESCRIPTION
when navigating to `/metrics` all the metrics are retrieved instead of asking to select metrics