### PR TITLE
[fix] Fix the group property name visibility in the images and audio tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.14.4
 
-- Display the group property name in the images and audio tabs (VkoHov)
+- Fix the group property name visibility in the images and audio tabs (VkoHov)
 
 ## 3.14.3 Oct 29, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.14.4
+
+- Display the group property name in the images and audio tabs (VkoHov)
+
 ## 3.14.3 Oct 29, 2022
 
 - Fix search for empty queries in explorers (KaroMourad)

--- a/aim/web/ui/src/services/models/runs/util.ts
+++ b/aim/web/ui/src/services/models/runs/util.ts
@@ -287,6 +287,7 @@ export function processImagesData(
   const groupingSelectOptions = params
     ? getGroupingSelectOptions({
         params: getObjectPaths(params, params),
+        sequenceName: 'images',
       })
     : [];
   let images: IProcessedImageData[] = [];
@@ -342,6 +343,7 @@ export function processAudiosData(
   const groupingSelectOptions = params
     ? getGroupingSelectOptions({
         params: getObjectPaths(params, params),
+        sequenceName: 'audios',
       })
     : [];
   let audiosSetData: any[] = [];

--- a/aim/web/ui/src/utils/app/getGroupingSelectOptions.ts
+++ b/aim/web/ui/src/utils/app/getGroupingSelectOptions.ts
@@ -11,7 +11,7 @@ export default function getGroupingSelectOptions({
   params: string[];
   runProps?: string[];
   contexts?: string[];
-  sequenceName?: null | 'metric' | 'images';
+  sequenceName?: null | 'metric' | 'images' | 'audios';
 }): IGroupingSelectOption[] {
   let options = [
     {
@@ -74,7 +74,7 @@ export default function getGroupingSelectOptions({
       : options.concat(nameOption);
   }
 
-  if (sequenceName === 'images') {
+  if (sequenceName === 'images' || sequenceName === 'audios') {
     const recordOptions = [
       {
         group: 'record',


### PR DESCRIPTION
Fix the group property name visibility in the images and audio tabs on the run page