### PR TITLE
[fix] Use `packaging.version` to parse version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add epoch tracking for PyTorch Lightning (tmynn)
 - Add PaddlePaddle integration (tmynn)
 - Add Optuna integration (tmynn)
+- Use `packaging` to parse version strings(jangop)
 
 ## 3.14.3 Oct 29, 2022
 

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -2,13 +2,12 @@ import os
 from typing import Any, Dict, Optional, Union
 from argparse import Namespace
 
+import packaging.version
+
 try:
     import pytorch_lightning as pl
 
-    def versiontuple(v):
-        return tuple(map(int, (v.split("."))))
-
-    if versiontuple(pl.__version__) < (1, 7):
+    if packaging.version.parse(pl.__version__) < packaging.version.parse("1.7"):
         from pytorch_lightning.loggers.base import (
             LightningLoggerBase as Logger,
             rank_zero_experiment,

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ REQUIRED = [
     # fastapi to support python3.6
     'async-exit-stack>=1.0.0; python_version<"3.7"',
     'async-generator>=1.0; python_version<"3.7"',
+    'packaging>=15.0',
 ]
 
 if platform.machine() != 'arm64':


### PR DESCRIPTION
Closes #2316.

