### PR TITLE
[feat] Revamp dashboard page project statistics cards

### DIFF
--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
@@ -1,9 +1,10 @@
 import { IconName } from 'components/kit/Icon';
+import ITextProps from 'components/kit/Text/Text.d';
 
 export interface IStatisticsCardProps {
   label: string;
   count: number;
-  title?: string;
+  badge?: { value: string; color?: ITextProps['color'] };
   icon?: IconName;
   iconBgColor?: string;
   cardBgColor?: string;

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.d.ts
@@ -1,10 +1,11 @@
+import * as React from 'react';
+
 import { IconName } from 'components/kit/Icon';
-import ITextProps from 'components/kit/Text/Text.d';
 
 export interface IStatisticsCardProps {
   label: string;
   count: number;
-  badge?: { value: string; color?: ITextProps['color'] };
+  badge?: { value: string; style?: React.CSSProperties };
   icon?: IconName;
   iconBgColor?: string;
   cardBgColor?: string;

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.scss
@@ -37,14 +37,13 @@
       text-transform: capitalize;
     }
   }
-  &__soonBadge {
+  &__badge {
     position: absolute;
     top: -$space-xs;
     right: -$space-xxs;
     text-align: center;
     white-space: nowrap;
     padding: $space-xxxxxs $space-xxxs;
-    color: $pico;
     border-radius: $border-radius-xss;
     background-color: white;
     box-shadow: 0 1px 2px 0 #00000029;

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
@@ -56,10 +56,10 @@ function StatisticsCard({
       {badge?.value && (
         <Text
           component='p'
-          color={badge?.color}
           className='StatisticsCard__badge'
           weight={600}
           size={8}
+          style={badge.style}
         >
           {badge.value}
         </Text>

--- a/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
+++ b/aim/web/ui/src/components/StatisticsCard/StatisticsCard.tsx
@@ -12,7 +12,7 @@ import './StatisticsCard.scss';
 
 function StatisticsCard({
   label,
-  title = '',
+  badge = { value: '' },
   count,
   icon,
   iconBgColor = '#000000',
@@ -53,17 +53,17 @@ function StatisticsCard({
       className={classNames('StatisticsCard', { highlighted })}
       style={styles.card}
     >
-      {!navLink && (
+      {badge?.value && (
         <Text
           component='p'
-          className='StatisticsCard__soonBadge'
+          color={badge?.color}
+          className='StatisticsCard__badge'
           weight={600}
           size={8}
         >
-          Explorer coming soon
+          {badge.value}
         </Text>
       )}
-
       {icon && (
         <div className='StatisticsCard__iconWrapper' style={styles.iconWrapper}>
           <Icon name={icon} color={styles.iconColor} />
@@ -78,7 +78,6 @@ function StatisticsCard({
         >
           {label}
         </Text>
-
         <Text
           className='StatisticsCard__info__count'
           size={16}

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
@@ -1,4 +1,5 @@
 import { IconName } from 'components/kit/Icon';
+import ITextProps from 'components/kit/Text/Text.d';
 
 export interface IProjectStatistic {
   label: string;
@@ -6,5 +7,5 @@ export interface IProjectStatistic {
   iconBgColor?: string;
   icon?: IconName;
   navLink?: string;
-  title?: string;
+  badge?: { value: string; color?: ITextProps['color'] };
 }

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.d.ts
@@ -1,5 +1,6 @@
+import * as React from 'react';
+
 import { IconName } from 'components/kit/Icon';
-import ITextProps from 'components/kit/Text/Text.d';
 
 export interface IProjectStatistic {
   label: string;
@@ -7,5 +8,5 @@ export interface IProjectStatistic {
   iconBgColor?: string;
   icon?: IconName;
   navLink?: string;
-  badge?: { value: string; color?: ITextProps['color'] };
+  badge?: { value: string; style?: React.CSSProperties };
 }

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
@@ -21,7 +21,6 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     icon: 'metrics',
     iconBgColor: '#7A4CE0',
     navLink: routes.METRICS.path,
-    title: 'Metrics Explorer',
   },
   systemMetrics: {
     label: 'Sys. metrics',
@@ -32,7 +31,6 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
       advancedQuery: "metric.name.startswith('__system__') == True",
       advancedMode: true,
     })}`,
-    title: 'Metrics Explorer',
   },
   [SequenceTypesEnum.Figures]: {
     label: 'Figures',
@@ -40,7 +38,6 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     count: 0,
     iconBgColor: '#18AB6D',
     navLink: routes.FIGURES_EXPLORER.path,
-    title: 'Figures Explorer',
   },
   [SequenceTypesEnum.Images]: {
     label: 'Images',
@@ -48,15 +45,17 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     count: 0,
     iconBgColor: '#F17922',
     navLink: routes.IMAGE_EXPLORE.path,
-    title: 'Images Explorer',
   },
   [SequenceTypesEnum.Audios]: {
     label: 'Audios',
     icon: 'audio',
     count: 0,
     iconBgColor: '#FCB500',
-    navLink: '',
-    title: 'Explorer coming soon',
+    navLink: routes.AUDIO_EXPLORER.path,
+    badge: {
+      value: 'New*',
+      color: 'success',
+    },
   },
   [SequenceTypesEnum.Texts]: {
     label: 'Texts',
@@ -64,7 +63,10 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     count: 0,
     iconBgColor: '#E149A0',
     navLink: '',
-    title: 'Explorer coming soon',
+    badge: {
+      value: 'Explorer coming soon',
+      color: 'primary',
+    },
   },
   [SequenceTypesEnum.Distributions]: {
     label: 'Distributions',
@@ -72,7 +74,10 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     count: 0,
     iconBgColor: '#0394B4',
     navLink: '',
-    title: 'Explorer coming soon',
+    badge: {
+      value: 'Explorer coming soon',
+      color: 'primary',
+    },
   },
 };
 
@@ -208,10 +213,10 @@ function ProjectStatistics() {
       </Text>
       <div className='ProjectStatistics__cards'>
         {Object.values(statisticsMap).map(
-          ({ label, title, icon, count, iconBgColor, navLink }) => (
+          ({ label, icon, count, iconBgColor, navLink, badge }) => (
             <StatisticsCard
               key={label}
-              title={title}
+              badge={badge}
               label={label}
               icon={icon}
               count={count}

--- a/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ProjectStatistics/ProjectStatistics.tsx
@@ -53,8 +53,8 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     iconBgColor: '#FCB500',
     navLink: routes.AUDIO_EXPLORER.path,
     badge: {
-      value: 'New*',
-      color: 'success',
+      value: 'New',
+      style: { backgroundColor: '#2bc784', color: '#fff' },
     },
   },
   [SequenceTypesEnum.Texts]: {
@@ -65,7 +65,6 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     navLink: '',
     badge: {
       value: 'Explorer coming soon',
-      color: 'primary',
     },
   },
   [SequenceTypesEnum.Distributions]: {
@@ -76,7 +75,6 @@ const statisticsInitialMap: Record<string, IProjectStatistic> = {
     navLink: '',
     badge: {
       value: 'Explorer coming soon',
-      color: 'primary',
     },
   },
 };


### PR DESCRIPTION
- add a `new` badge to project statistics cards
- add a link to audio explorer