### PR TITLE
[fix] show table diff for when elements are container types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix multiple progress bars handling for terminal logs capturing (mihran113)
 - Handle resources when multiple `Ctrl-C`s are pressed (alberttorosyan)
 - Remove non unicode symbols from `aim up` command logs (mihran113)
+- Fix "Show Table Diff" for list type elements in runs, params and scatters explorers (kumarshreshtha)
 
 ## 3.14.4 Nov 11, 2022
 

--- a/aim/web/ui/src/services/models/explorer/createAppModel.ts
+++ b/aim/web/ui/src/services/models/explorer/createAppModel.ts
@@ -2769,7 +2769,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
               const value = getValue(metric.run.params, paramKey, '-');
               rowValues[paramKey] = formatValue(value);
               if (columnsValues.hasOwnProperty(paramKey)) {
-                if (!columnsValues[paramKey].includes(value)) {
+                if (
+                  _.findIndex(columnsValues[paramKey], (paramValue) =>
+                    _.isEqual(value, paramValue),
+                  ) === -1
+                ) {
                   columnsValues[paramKey].push(value);
                 }
               } else {
@@ -3554,7 +3558,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
                 const value = getValue(metric.run.params, paramKey, '-');
                 rowValues[paramKey] = formatValue(value);
                 if (columnsValues.hasOwnProperty(paramKey)) {
-                  if (!columnsValues[paramKey].includes(value)) {
+                  if (
+                    _.findIndex(columnsValues[paramKey], (paramValue) =>
+                      _.isEqual(value, paramValue),
+                    ) === -1
+                  ) {
                     columnsValues[paramKey].push(value);
                   }
                 } else {
@@ -5257,7 +5265,11 @@ function createAppModel(appConfig: IAppInitialConfig) {
                 const value = getValue(metric.run.params, paramKey, '-');
                 rowValues[paramKey] = formatValue(value);
                 if (columnsValues.hasOwnProperty(paramKey)) {
-                  if (!columnsValues[paramKey].includes(value)) {
+                  if (
+                    _.findIndex(columnsValues[paramKey], (paramValue) =>
+                      _.isEqual(value, paramValue),
+                    ) === -1
+                  ) {
                     columnsValues[paramKey].push(value);
                   }
                 } else {


### PR DESCRIPTION
Fixes the condition for equality checks in runs, params and scatters explorers . As pointed by @roubkar the condition was broken for runs, params, and scatters explorers but worked for metrics. So we use the same condition checking as metrics in the remaining 3 places.