### PR TITLE
[fix] Leave color information in tracked terminal logs

### DIFF
--- a/aim/ext/resource/tracker.py
+++ b/aim/ext/resource/tracker.py
@@ -197,7 +197,7 @@ class ResourceTracker(object):
         # handle the buffered data and store
 
         lines = data.split(b'\n')
-        ansi_csi_re = re.compile(b"\001?\033\\[((?:\\d|;)*)([a-zA-Z])\002?")
+        ansi_csi_re = re.compile(b"\001?\033\\[((?:\\d|;)*)([a-dA-D])\002?")
 
         def _handle_csi(line):
             def _remove_csi(line):

--- a/examples/pytorch_lightning_track.py
+++ b/examples/pytorch_lightning_track.py
@@ -103,7 +103,7 @@ def cli_main():
     # ------------
     # testing
     # ------------
-    trainer.test(test_dataloaders=test_loader)
+    trainer.test(dataloaders=test_loader)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix csi(cursor state) handling: do not remove color information as it is handled by UI side.
 Remove from line only cursor up/down/right/left commands.