### PR TITLE
[fix] Fix experiment name formatting issue when adding to the query

### DIFF
--- a/aim/web/ui/src/components/ContributionsFeed/ContributionsFeed.tsx
+++ b/aim/web/ui/src/components/ContributionsFeed/ContributionsFeed.tsx
@@ -37,11 +37,9 @@ function ContributionsFeed({
               >
                 {key.split('_').join(' ')}
               </Text>
-              {Object.keys(data[key]).map((item: string) => {
-                return (
-                  <FeedItem key={item} date={item} data={data[key][item]} />
-                );
-              })}
+              {Object.keys(data[key]).map((item: string) => (
+                <FeedItem key={item} date={item} data={data[key][item]} />
+              ))}
             </div>
           ))}
 

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentOverviewTab/ExperimentContributions/ExperimentContributions.tsx
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentOverviewTab/ExperimentContributions/ExperimentContributions.tsx
@@ -8,6 +8,8 @@ import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
 import { trackEvent } from 'services/analytics';
 
+import { formatValue } from 'utils/formatValue';
+
 import useExperimentContributions from './useExperimentContributions';
 
 import { IExperimentContributionsProps } from '.';
@@ -42,7 +44,9 @@ function ExperimentContributions({
             onCellClick={() => {
               trackEvent(ANALYTICS_EVENT_KEYS.dashboard.activityCellClick);
             }}
-            additionalQuery={` and run.experiment == ${experimentName}`}
+            additionalQuery={` and run.experiment == ${formatValue(
+              experimentName,
+            )}`}
             data={Object.keys(
               experimentContributionsState.data?.activity_map ?? {},
             ).map((k) => [


### PR DESCRIPTION
When navigating to a particular date from the contributions feed heatmap on the Experiment page, the generated query contains the experiment name, which isn't the correct format.

Format the experiment name before adding it to the search query
