### PR TITLE
[fix] Fix showing incorrect empty-illustration message in Audios explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 3.15.1
 
 - Fix issue with index container lock for older repos (mihran113)
+- Fix issue with rendering incorrect empty-illustration info in Audios explorer (KaroMourad)
 
 ## 3.15.0 Nov 26, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 3.15.1
+
+- Fix issue with index container lock for older repos (mihran113)
+
 ## 3.15.0 Nov 26, 2022
 
 ### Enhancements:

--- a/aim/storage/locking.py
+++ b/aim/storage/locking.py
@@ -151,6 +151,24 @@ def AutoFileLock(
         return SoftFileLock(f'{lock_file}.softlock', timeout)
 
 
+class DualLock:
+    """ Custom lock that uses both UnixLock and SoftFileLock"""
+    def __init__(self, lock_path: Union[str, os.PathLike], timeout: float = -1):
+        self._lock_path = str(lock_path)
+        self._lock = UnixFileLock(self._lock_path, timeout)
+
+        self._soft_lock_path = f'{self._lock_path}.softlock'
+        self._soft_lock = SoftFileLock(self._soft_lock_path, timeout)
+
+    def acquire(self):
+        self._lock.acquire()
+        self._soft_lock.acquire()
+
+    def release(self):
+        self._soft_lock.release()
+        self._lock.release()
+
+
 class NoopLock:
     """No-op lock implementation using duck-typing"""
     def __init__(self, *args, **kwargs):

--- a/aim/storage/rockscontainer.pyx
+++ b/aim/storage/rockscontainer.pyx
@@ -8,7 +8,7 @@ from typing import Iterator, Optional, Tuple
 
 from aim.ext.cleanup import AutoClean
 from aim.ext.exception_resistant import exception_resistant
-from aim.storage.locking import SoftFileLock, NoopLock
+from aim.storage.locking import SoftFileLock, NoopLock, DualLock
 from aim.storage.types import BLOB
 from aim.storage.container import Container, ContainerKey, ContainerValue, ContainerItemsIterator
 from aim.storage.prefixview import PrefixView
@@ -618,5 +618,5 @@ class RocksContainerItemsIterator(ContainerItemsIterator):
 
 class LockableRocksContainer(RocksContainer):
     def get_lock_cls(self):
-        """Use Unix file-locks or Soft file-locks depending on the FS type."""
-        return SoftFileLock
+        """Use both Unix file-locks and Soft file-locks to cover all the scenarios and avoid corruptions."""
+        return DualLock

--- a/aim/web/ui/src/components/Illustration/Illustration.d.ts
+++ b/aim/web/ui/src/components/Illustration/Illustration.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
+
+export interface IIllustrationProps {
+  content?: string | React.ReactNode;
+  image?: React.FunctionComponentElement<React.ReactNode> | HTMLImageElement;
+  type?: IllustrationType;
+  className?: string;
+  size?: 'small' | 'medium' | 'large' | 'xLarge';
+  showImage?: boolean;
+}
+
+export type IllustrationType = string | PipelineStatusEnum;

--- a/aim/web/ui/src/components/Illustration/Illustration.scss
+++ b/aim/web/ui/src/components/Illustration/Illustration.scss
@@ -1,0 +1,86 @@
+@use '../../styles/abstracts/index' as *;
+
+.Illustration {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  flex-direction: column;
+  &__hidden {
+    display: none;
+  }
+  &__container {
+    height: fit-content;
+    overflow: hidden;
+    padding-bottom: 6 * $space-unit;
+    &__content {
+      text-align: center;
+      .qlAnchor {
+        color: $primary-color;
+        text-decoration: none;
+        margin: 0 $space-xxxs;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+    &__img {
+      & > img {
+        margin: 0 auto;
+        display: block;
+      }
+    }
+
+    &__small {
+      &__content {
+        font-weight: $font-500;
+        font-size: $text-md;
+      }
+      &__img {
+        padding: $space-xs;
+        & > img {
+          width: 3rem;
+        }
+      }
+    }
+    &__medium {
+      &__content {
+        font-weight: $font-500;
+        font-size: $text-md;
+      }
+      &__img {
+        padding: $space-sm;
+        & > img {
+          width: 7.5rem;
+        }
+      }
+    }
+    &__large {
+      &__content {
+        font-weight: $font-500;
+        font-size: $text-lg;
+      }
+      &__img {
+        padding: $space-sm;
+        & > img {
+          width: 14.5rem;
+        }
+      }
+    }
+    &__xLarge {
+      &__content {
+        font-weight: $font-500;
+        font-size: $text-xl;
+        margin-bottom: $space-unit;
+      }
+      &__img {
+        padding: $space-unit;
+        & > img {
+          width: 19.5rem;
+        }
+      }
+    }
+  }
+}

--- a/aim/web/ui/src/components/Illustration/Illustration.tsx
+++ b/aim/web/ui/src/components/Illustration/Illustration.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { Text } from 'components/kit';
+
+import {
+  IIllustrationProps,
+  ILLUSTRATION_TYPES,
+  ILLUSTRATION_LIST,
+  getDefaultIllustrationContent,
+} from '.';
+
+import './Illustration.scss';
+
+function Illustration({
+  type = ILLUSTRATION_TYPES.Never_Executed,
+  content = getDefaultIllustrationContent(type),
+  image,
+  className = '',
+  size = 'xLarge',
+  showImage = true,
+}: IIllustrationProps): React.FunctionComponentElement<React.ReactNode> {
+  const [imgLoaded, setImgLoaded] = React.useState(false);
+
+  return (
+    <div
+      className={classNames('Illustration', {
+        Illustrations__hidden: showImage && !imgLoaded,
+        [className]: !!className,
+      })}
+    >
+      <div className='Illustration__container'>
+        {showImage ? (
+          <div
+            className={`Illustration__container__img Illustration__container__${size}__img `}
+          >
+            {image || (
+              <img
+                onLoad={() => setImgLoaded(true)}
+                src={ILLUSTRATION_LIST[type]}
+                alt='Illustration'
+              />
+            )}
+          </div>
+        ) : null}
+
+        <Text
+          component='p'
+          className={`Illustration__container__content Illustration__container__${size}__content`}
+        >
+          {content}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(Illustration);

--- a/aim/web/ui/src/components/Illustration/config.tsx
+++ b/aim/web/ui/src/components/Illustration/config.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
+
+import emptyBookmarks from 'assets/illustrations/emptyBookmarks.svg';
+import emptySearch from 'assets/illustrations/emptySearch.svg';
+import exploreData from 'assets/illustrations/exploreData.svg';
+import wrongSearch from 'assets/illustrations/wrongSearch.svg';
+
+import { DOCUMENTATIONS } from 'config/references';
+
+import { IllustrationType } from '.';
+
+const ILLUSTRATION_TYPES: Record<string, IllustrationType> = {
+  Never_Executed: PipelineStatusEnum.Never_Executed,
+  Insufficient_Resources: PipelineStatusEnum.Insufficient_Resources,
+  Empty: PipelineStatusEnum.Empty,
+  Failed: PipelineStatusEnum.Failed,
+  Empty_Bookmarks: 'emptyBookmarks',
+};
+
+const ILLUSTRATION_LIST: Record<IllustrationType, string> = {
+  [ILLUSTRATION_TYPES.Never_Executed]: exploreData,
+  [ILLUSTRATION_TYPES.Insufficient_Resources]: exploreData,
+  [ILLUSTRATION_TYPES.Empty]: emptySearch,
+  [ILLUSTRATION_TYPES.Failed]: wrongSearch,
+  [ILLUSTRATION_TYPES.Empty_Bookmarks]: emptyBookmarks,
+};
+
+function getDefaultIllustrationContent(
+  type: IllustrationType = ILLUSTRATION_TYPES.Never_Executed,
+): React.ReactNode {
+  const Never_Executed = (
+    <>
+      It’s super easy to search Aim experiments. Just start typing your query in
+      the search bar above.
+      <br />
+      Look up
+      <a
+        className='qlAnchor'
+        href={DOCUMENTATIONS.EXPLORERS.SEARCH}
+        target='_blank'
+        rel='noreferrer'
+      >
+        search docs
+      </a>
+      to learn more.
+    </>
+  );
+  const Failed = 'Incorrect Query';
+  const Insufficient_Resources = "You don't have any tracked data";
+  const Empty = 'No Results';
+  const Empty_Bookmarks = "You don't have any saved bookmark";
+
+  const CONTENT = {
+    [ILLUSTRATION_TYPES.Never_Executed]: Never_Executed,
+    [ILLUSTRATION_TYPES.Failed]: Failed,
+    [ILLUSTRATION_TYPES.Insufficient_Resources]: Insufficient_Resources,
+    [ILLUSTRATION_TYPES.Empty]: Empty,
+    [ILLUSTRATION_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
+  };
+  return CONTENT[type] || null;
+}
+
+export { ILLUSTRATION_TYPES, ILLUSTRATION_LIST, getDefaultIllustrationContent };

--- a/aim/web/ui/src/components/Illustration/index.ts
+++ b/aim/web/ui/src/components/Illustration/index.ts
@@ -1,0 +1,6 @@
+import Illustration from './Illustration';
+
+export * from './Illustration.d';
+export * from './config';
+
+export default Illustration;

--- a/aim/web/ui/src/components/IllustrationBlock/IllustrationBlock.scss
+++ b/aim/web/ui/src/components/IllustrationBlock/IllustrationBlock.scss
@@ -43,7 +43,7 @@
       font-size: $text-md;
     }
     &__img {
-      padding: toRem(10px);
+      padding: $space-xs;
       img {
         width: toRem(50px);
         height: toRem(57px);
@@ -62,7 +62,7 @@
       font-size: $text-md;
     }
     &__img {
-      padding: toRem(10px);
+      padding: $space-sm;
       img {
         width: toRem(120px);
         margin: 0 auto;
@@ -80,7 +80,7 @@
       font-size: $text-lg;
     }
     &__img {
-      padding: toRem(10px);
+      padding: $space-sm;
       img {
         width: 14.5rem;
         margin: 0 auto;
@@ -94,7 +94,7 @@
       margin-bottom: 1rem;
     }
     &__img {
-      padding: 1rem;
+      padding: $space-unit;
       img {
         width: 19.5rem;
         margin: 0 auto;

--- a/aim/web/ui/src/config/illustrationConfig/illustrationConfig.tsx
+++ b/aim/web/ui/src/config/illustrationConfig/illustrationConfig.tsx
@@ -23,7 +23,7 @@ const Illustrations_List: { [key: string]: string } = {
   [IllustrationsEnum.WrongSearch]: wrongSearch,
   [IllustrationsEnum.EmptyData]: exploreData,
   // for base explorer statuses
-  [PipelineStatusEnum.NeverExecuted]: exploreData,
+  [PipelineStatusEnum.Never_Executed]: exploreData,
   [PipelineStatusEnum.Insufficient_Resources]: exploreData,
   [PipelineStatusEnum.Empty]: emptySearch,
   [PipelineStatusEnum.Failed]: wrongSearch,
@@ -129,7 +129,7 @@ const Illustration_Title_Config: { [key: string]: object | any } = {
     ),
   },
   figures: {
-    [PipelineStatusEnum.NeverExecuted]: (
+    [PipelineStatusEnum.Never_Executed]: (
       <>
         It’s super easy to search Aim experiments. Just start typing your query
         in the search bar above.
@@ -137,7 +137,7 @@ const Illustration_Title_Config: { [key: string]: object | any } = {
         Look up
         <a
           className='qlAnchor'
-          href={DOCUMENTATIONS.EXPLORERS.FIGURES.SEARCH}
+          href={DOCUMENTATIONS.EXPLORERS.SEARCH}
           target='_blank'
           rel='noreferrer'
         >

--- a/aim/web/ui/src/config/references/index.ts
+++ b/aim/web/ui/src/config/references/index.ts
@@ -7,6 +7,8 @@ const DOCUMENTATIONS = {
   SUPPORTED_TYPES:
     'https://aimstack.readthedocs.io/en/latest/quick_start/supported_types.html',
   EXPLORERS: {
+    SEARCH: 'https://aimstack.readthedocs.io/en/latest/ui/pages/explorers.html',
+
     PARAMS: {
       MAIN: 'https://aimstack.readthedocs.io/en/latest/ui/pages/explorers.html#params-explorer',
       SEARCH:
@@ -31,12 +33,6 @@ const DOCUMENTATIONS = {
       MAIN: 'https://aimstack.readthedocs.io/en/latest/ui/pages/run_management.html#runs-explorer',
       SEARCH:
         'https://aimstack.readthedocs.io/en/latest/ui/pages/run_management.html#search-runs',
-    },
-    //@TODO set right docs link after adding Figures docs to the docs
-    FIGURES: {
-      MAIN: 'https://aimstack.readthedocs.io/en/latest/ui/pages/explorers.html',
-      SEARCH:
-        'https://aimstack.readthedocs.io/en/latest/ui/pages/explorers.html',
     },
   },
   INTEGRATIONS: {

--- a/aim/web/ui/src/modules/BaseExplorer/components/Explorer/Explorer.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Explorer/Explorer.tsx
@@ -30,6 +30,7 @@ function Explorer({ configuration, engineInstance }: ExplorerProps) {
       {/* @ts-ignore*/}
       <configuration.components.queryForm engine={engineInstance} />
       <Visualizations
+        getStaticContent={configuration.getStaticContent}
         visualizers={configuration.visualizations}
         engine={engineInstance}
         components={{

--- a/aim/web/ui/src/modules/BaseExplorer/components/ExplorerBar/ExplorerBar.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/ExplorerBar/ExplorerBar.tsx
@@ -17,7 +17,7 @@ function ExplorerBar(props: IExplorerBarProps) {
   const disableResetControls = React.useMemo(
     () =>
       [
-        PipelineStatusEnum.NeverExecuted,
+        PipelineStatusEnum.Never_Executed,
         PipelineStatusEnum.Empty,
         PipelineStatusEnum.Insufficient_Resources,
         PipelineStatusEnum.Executing,

--- a/aim/web/ui/src/modules/BaseExplorer/components/VisualizerPanel/VisualizerPanel.d.ts
+++ b/aim/web/ui/src/modules/BaseExplorer/components/VisualizerPanel/VisualizerPanel.d.ts
@@ -5,6 +5,6 @@ import { IControlsProps, IGroupingProps } from '../../types';
 export interface IVisualizerPanelProps {
   engine: any;
   grouping: React.FunctionComponent<IGroupingProps> | null;
-  controls: React.FunctionComponent<IControlsProps>;
+  controls?: React.FunctionComponent<IControlsProps>;
   visualizationName: string;
 }

--- a/aim/web/ui/src/modules/BaseExplorer/components/VisualizerPanel/VisualizerPanel.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/VisualizerPanel/VisualizerPanel.tsx
@@ -9,7 +9,9 @@ function VisualizerPanel(props: IVisualizerPanelProps) {
   return (
     <div className='VisualizerPanel'>
       {Grouping && <Grouping engine={engine} />}
-      <Controls engine={engine} visualizationName={props.visualizationName} />
+      {Controls && (
+        <Controls engine={engine} visualizationName={props.visualizationName} />
+      )}
     </div>
   );
 }

--- a/aim/web/ui/src/modules/BaseExplorer/getDefaultHydration.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/getDefaultHydration.tsx
@@ -14,6 +14,7 @@ import { AdvancedQueryForm } from './components/QueryForm';
 import Controls from './components/Controls';
 import Grouping, { GroupingItem } from './components/Grouping';
 import { IBaseComponentProps } from './types';
+import getBaseExplorerStaticContent from './utils/getBaseExplorerStaticContent';
 
 const controls: ControlsConfigs = {
   boxProperties: {
@@ -141,6 +142,7 @@ export const defaultHydration = {
       initialState: {},
     },
   },
+  getStaticContent: getBaseExplorerStaticContent,
 };
 
 /**

--- a/aim/web/ui/src/modules/BaseExplorer/index.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/index.tsx
@@ -73,6 +73,8 @@ function createExplorer(
         ...(configuration.states || {}),
       },
       enablePipelineCache: configuration.enablePipelineCache || true,
+      getStaticContent:
+        configuration.getStaticContent || defaultHydration.getStaticContent,
     };
 
     const basePath =

--- a/aim/web/ui/src/modules/BaseExplorer/types.ts
+++ b/aim/web/ui/src/modules/BaseExplorer/types.ts
@@ -4,12 +4,12 @@ import { GroupType } from 'modules/core/pipeline';
 import { GroupingConfigs } from 'modules/core/engine/explorer/groupings';
 import { ControlsConfigs } from 'modules/core/engine/visualizations/controls';
 import { CustomStates } from 'modules/core/utils/store';
+import { VisualizationsConfig } from 'modules/core/engine/visualizations';
+import { EngineNew } from 'modules/core/engine/explorer-engine';
+import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
 import { AimFlatObjectBase } from 'types/core/AimObjects';
-
-import { VisualizationsConfig } from '../core/engine/visualizations';
-import { EngineNew } from '../core/engine/explorer-engine';
 
 export interface IEngineStates {
   [key: string]: {
@@ -75,6 +75,10 @@ export interface IControlsProps extends IBaseComponentProps {
 export interface IVisualizationsProps extends IBaseComponentProps {
   components: IUIComponents;
   visualizers: VisualizationsConfig;
+  getStaticContent?: (
+    type: StaticContentType,
+    defaultContent?: React.ReactNode,
+  ) => React.ReactNode;
 }
 
 export interface IVisualizationProps extends IBaseComponentProps {
@@ -148,7 +152,11 @@ export declare interface ExplorerEngineConfiguration {
   visualizations: ExplorerVisualizationsConfiguration;
 
   /**
-   * Custom States
+   * Explorer level additional custom states
+   * @optional
+   * This property is useful to create custom states for the explorer, and it will be accessible directly from engine
+   * The usage of the state defined on state slice documentation
+   * @default value is {}
    */
   states?: CustomStates;
 }
@@ -209,13 +217,10 @@ export declare interface ExplorerConfiguration
   components?: ExplorerUIComponents;
 
   /**
-   * Explorer level additional custom states
-   * @optional
-   * This property is useful to create custom states for the explorer, and it will be accessible directly from engine
-   * The usage of the state defined on state slice documentation
-   * @default value is {}
+   * Explorer level static content
+   * @param type
    */
-  readonly states?: CustomStates;
+  getStaticContent?: (type: string) => React.ReactNode;
 }
 
 export declare interface ExplorerProps<
@@ -235,3 +240,5 @@ export declare interface ExplorerProps<
    */
   children?: React.ReactChildren;
 }
+
+export type StaticContentType = string | PipelineStatusEnum;

--- a/aim/web/ui/src/modules/BaseExplorer/utils/getBaseExplorerStaticContent.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/utils/getBaseExplorerStaticContent.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import Illustration, {
+  getDefaultIllustrationContent,
+  ILLUSTRATION_TYPES,
+} from 'components/Illustration';
+
+import { StaticContentType } from '../types';
+
+const STATIC_CONTENT_TYPES: Record<string, StaticContentType> = {
+  ...ILLUSTRATION_TYPES,
+  /** add additional static content types here **/
+};
+
+function getBaseExplorerStaticContent(
+  type?: StaticContentType,
+  getIllustrationContent: Function = getDefaultIllustrationContent,
+): React.ReactNode {
+  switch (type) {
+    case STATIC_CONTENT_TYPES.Never_Executed:
+    case STATIC_CONTENT_TYPES.Empty:
+    case STATIC_CONTENT_TYPES.Insufficient_Resources:
+    case STATIC_CONTENT_TYPES.Failed:
+    case STATIC_CONTENT_TYPES.Empty_Bookmarks:
+      return (
+        <Illustration type={type} content={getIllustrationContent(type)} />
+      );
+    default:
+      return null;
+  }
+}
+
+export default getBaseExplorerStaticContent;

--- a/aim/web/ui/src/modules/BaseExplorer/utils/getBaseExplorerStaticContent.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/utils/getBaseExplorerStaticContent.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
 
-import Illustration, {
-  getDefaultIllustrationContent,
-  ILLUSTRATION_TYPES,
-} from 'components/Illustration';
+import Illustration, { ILLUSTRATION_TYPES } from 'components/Illustration';
 
 import { StaticContentType } from '../types';
 
-const STATIC_CONTENT_TYPES: Record<string, StaticContentType> = {
+export const STATIC_CONTENT_TYPES: Record<string, StaticContentType> = {
   ...ILLUSTRATION_TYPES,
   /** add additional static content types here **/
 };
 
 function getBaseExplorerStaticContent(
-  type?: StaticContentType,
-  getIllustrationContent: Function = getDefaultIllustrationContent,
+  type: StaticContentType,
+  content?: React.ReactNode,
 ): React.ReactNode {
   switch (type) {
     case STATIC_CONTENT_TYPES.Never_Executed:
@@ -22,9 +19,7 @@ function getBaseExplorerStaticContent(
     case STATIC_CONTENT_TYPES.Insufficient_Resources:
     case STATIC_CONTENT_TYPES.Failed:
     case STATIC_CONTENT_TYPES.Empty_Bookmarks:
-      return (
-        <Illustration type={type} content={getIllustrationContent(type)} />
-      );
+      return <Illustration type={type} content={content} />;
     default:
       return null;
   }

--- a/aim/web/ui/src/modules/core/engine/pipeline/state.ts
+++ b/aim/web/ui/src/modules/core/engine/pipeline/state.ts
@@ -90,7 +90,7 @@ const initialProgressState: ProgressState = {
 
 function getInitialState<TObject>(): IPipelineState<TObject> {
   const initialState: IPipelineState<TObject> = {
-    status: PipelineStatusEnum.NeverExecuted,
+    status: PipelineStatusEnum.Never_Executed,
     currentPhase: PipelinePhasesEnum.Waiting,
     progress: initialProgressState,
     additionalData: {
@@ -111,7 +111,7 @@ function getInitialState<TObject>(): IPipelineState<TObject> {
 function createState<TStore, TObject>(
   store: StoreApi<ExtractState<TStore, TObject>>,
   initialState: IPipelineState<TObject> = {
-    status: PipelineStatusEnum.NeverExecuted,
+    status: PipelineStatusEnum.Never_Executed,
     currentPhase: PipelinePhasesEnum.Waiting,
     progress: initialProgressState,
     additionalData: {

--- a/aim/web/ui/src/modules/core/engine/types.ts
+++ b/aim/web/ui/src/modules/core/engine/types.ts
@@ -82,7 +82,7 @@ export enum PipelineStatusEnum {
   /*
    * Never queried
    */
-  NeverExecuted = 'Never Executed',
+  Never_Executed = 'Never Executed',
   /*
    * Executing
    */

--- a/aim/web/ui/src/pages/AudiosExplorer/config.ts
+++ b/aim/web/ui/src/pages/AudiosExplorer/config.ts
@@ -3,6 +3,8 @@ import { getDefaultHydration } from 'modules/BaseExplorer';
 import { GroupType, Order } from 'modules/core/pipeline';
 import { defaultHydration } from 'modules/BaseExplorer/getDefaultHydration';
 
+import getAudiosExplorerStaticContent from './getStaticContent';
+
 export const getAudiosDefaultConfig = (): typeof defaultHydration => {
   const defaultConfig = getDefaultHydration();
 
@@ -39,5 +41,6 @@ export const getAudiosDefaultConfig = (): typeof defaultHydration => {
         gap: 0,
       },
     },
+    getStaticContent: getAudiosExplorerStaticContent,
   };
 };

--- a/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import getBaseExplorerStaticContent from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
+import { StaticContentType } from 'modules/BaseExplorer/types';
+
+import { ILLUSTRATION_TYPES } from 'components/Illustration';
+
+import { DOCUMENTATIONS } from 'config/references';
+
+function getAudiosExplorerStaticContent(
+  type?: StaticContentType,
+): React.ReactNode {
+  return getBaseExplorerStaticContent(
+    type,
+    getAudiosExplorerIllustrationContent,
+  );
+}
+
+function getAudiosExplorerIllustrationContent(
+  type: StaticContentType,
+): React.ReactNode {
+  const Never_Executed = (
+    <>
+      It’s super easy to search Aim experiments. Just start typing your query in
+      the search bar above.
+      <br />
+      Look up
+      <a
+        className='qlAnchor'
+        href={DOCUMENTATIONS.EXPLORERS.SEARCH}
+        target='_blank'
+        rel='noreferrer'
+      >
+        search docs
+      </a>
+      to learn more.
+    </>
+  );
+  const Failed = 'Incorrect Query';
+  const Insufficient_Resources = "You don't have any tracked audios";
+  const Empty = 'No Results';
+  const Empty_Bookmarks = "You don't have any saved bookmark";
+
+  const CONTENT = {
+    [ILLUSTRATION_TYPES.Never_Executed]: Never_Executed,
+    [ILLUSTRATION_TYPES.Failed]: Failed,
+    [ILLUSTRATION_TYPES.Insufficient_Resources]: Insufficient_Resources,
+    [ILLUSTRATION_TYPES.Empty]: Empty,
+    [ILLUSTRATION_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
+  };
+  return CONTENT[type] || null;
+}
+
+export default getAudiosExplorerStaticContent;

--- a/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
 
-import getBaseExplorerStaticContent from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
+import getBaseExplorerStaticContent, {
+  STATIC_CONTENT_TYPES,
+} from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
 import { StaticContentType } from 'modules/BaseExplorer/types';
-
-import { ILLUSTRATION_TYPES } from 'components/Illustration';
 
 import { DOCUMENTATIONS } from 'config/references';
 
 function getAudiosExplorerStaticContent(
-  type?: StaticContentType,
+  type: StaticContentType,
 ): React.ReactNode {
-  return getBaseExplorerStaticContent(
-    type,
-    getAudiosExplorerIllustrationContent,
-  );
+  const illustrationContent = getAudiosExplorerIllustrationContent(type);
+  return getBaseExplorerStaticContent(type, illustrationContent);
 }
 
 function getAudiosExplorerIllustrationContent(
@@ -42,11 +40,11 @@ function getAudiosExplorerIllustrationContent(
   const Empty_Bookmarks = "You don't have any saved bookmark";
 
   const CONTENT = {
-    [ILLUSTRATION_TYPES.Never_Executed]: Never_Executed,
-    [ILLUSTRATION_TYPES.Failed]: Failed,
-    [ILLUSTRATION_TYPES.Insufficient_Resources]: Insufficient_Resources,
-    [ILLUSTRATION_TYPES.Empty]: Empty,
-    [ILLUSTRATION_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
+    [STATIC_CONTENT_TYPES.Never_Executed]: Never_Executed,
+    [STATIC_CONTENT_TYPES.Failed]: Failed,
+    [STATIC_CONTENT_TYPES.Insufficient_Resources]: Insufficient_Resources,
+    [STATIC_CONTENT_TYPES.Empty]: Empty,
+    [STATIC_CONTENT_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
   };
   return CONTENT[type] || null;
 }

--- a/aim/web/ui/src/pages/AudiosExplorer/index.tsx
+++ b/aim/web/ui/src/pages/AudiosExplorer/index.tsx
@@ -28,6 +28,7 @@ const AudiosExplorer = renderer(
         },
       },
     },
+    getStaticContent: defaultConfig.getStaticContent,
   },
   __DEV__,
 );

--- a/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
 
-import getBaseExplorerStaticContent from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
+import getBaseExplorerStaticContent, {
+  STATIC_CONTENT_TYPES,
+} from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
 import { StaticContentType } from 'modules/BaseExplorer/types';
-
-import { ILLUSTRATION_TYPES } from 'components/Illustration';
 
 import { DOCUMENTATIONS } from 'config/references';
 
 function getFiguresExplorerStaticContent(
-  type?: StaticContentType,
+  type: StaticContentType,
 ): React.ReactNode {
-  return getBaseExplorerStaticContent(
-    type,
-    getFiguresExplorerIllustrationContent,
-  );
+  const illustrationContent = getFiguresExplorerIllustrationContent(type);
+  return getBaseExplorerStaticContent(type, illustrationContent);
 }
 
 function getFiguresExplorerIllustrationContent(
@@ -42,11 +40,11 @@ function getFiguresExplorerIllustrationContent(
   const Empty_Bookmarks = "You don't have any saved bookmark";
 
   const CONTENT = {
-    [ILLUSTRATION_TYPES.Never_Executed]: Never_Executed,
-    [ILLUSTRATION_TYPES.Failed]: Failed,
-    [ILLUSTRATION_TYPES.Insufficient_Resources]: Insufficient_Resources,
-    [ILLUSTRATION_TYPES.Empty]: Empty,
-    [ILLUSTRATION_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
+    [STATIC_CONTENT_TYPES.Never_Executed]: Never_Executed,
+    [STATIC_CONTENT_TYPES.Failed]: Failed,
+    [STATIC_CONTENT_TYPES.Insufficient_Resources]: Insufficient_Resources,
+    [STATIC_CONTENT_TYPES.Empty]: Empty,
+    [STATIC_CONTENT_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
   };
   return CONTENT[type] || null;
 }

--- a/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import getBaseExplorerStaticContent from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
+import { StaticContentType } from 'modules/BaseExplorer/types';
+
+import { ILLUSTRATION_TYPES } from 'components/Illustration';
+
+import { DOCUMENTATIONS } from 'config/references';
+
+function getFiguresExplorerStaticContent(
+  type?: StaticContentType,
+): React.ReactNode {
+  return getBaseExplorerStaticContent(
+    type,
+    getFiguresExplorerIllustrationContent,
+  );
+}
+
+function getFiguresExplorerIllustrationContent(
+  type: StaticContentType,
+): React.ReactNode {
+  const Never_Executed = (
+    <>
+      It’s super easy to search Aim experiments. Just start typing your query in
+      the search bar above.
+      <br />
+      Look up
+      <a
+        className='qlAnchor'
+        href={DOCUMENTATIONS.EXPLORERS.SEARCH}
+        target='_blank'
+        rel='noreferrer'
+      >
+        search docs
+      </a>
+      to learn more.
+    </>
+  );
+  const Failed = 'Incorrect Query';
+  const Insufficient_Resources = "You don't have any tracked figures";
+  const Empty = 'No Results';
+  const Empty_Bookmarks = "You don't have any saved bookmark";
+
+  const CONTENT = {
+    [ILLUSTRATION_TYPES.Never_Executed]: Never_Executed,
+    [ILLUSTRATION_TYPES.Failed]: Failed,
+    [ILLUSTRATION_TYPES.Insufficient_Resources]: Insufficient_Resources,
+    [ILLUSTRATION_TYPES.Empty]: Empty,
+    [ILLUSTRATION_TYPES.Empty_Bookmarks]: Empty_Bookmarks,
+  };
+  return CONTENT[type] || null;
+}
+
+export default getFiguresExplorerStaticContent;

--- a/aim/web/ui/src/pages/FiguresExplorer/index.tsx
+++ b/aim/web/ui/src/pages/FiguresExplorer/index.tsx
@@ -5,6 +5,8 @@ import Figures from 'modules/BaseExplorer/components/Figures/Figures';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
 
+import getFiguresExplorerStaticContent from './getStaticContent';
+
 const defaultConfig = getDefaultHydration();
 
 const FiguresExplorer = renderer(
@@ -28,6 +30,7 @@ const FiguresExplorer = renderer(
         },
       },
     },
+    getStaticContent: getFiguresExplorerStaticContent,
   },
   __DEV__,
 );


### PR DESCRIPTION
- create a dynamic `Illustration` component
- create a generic `getStaticContent` function for Base explorers, which will get the static content type and will return the corresponding empty-illustration or predefined static content
- create `getStaticContent` function for Base Explorers separately for Audios and Figures and set the function in the corresponding explorer configuration