### PR TITLE
comment about ports and set `--workers  1`

### DIFF
--- a/docs/source/using/k8s_deployment.md
+++ b/docs/source/using/k8s_deployment.md
@@ -37,7 +37,8 @@ ENTRYPOINT ["/bin/sh", "-c"]
 # We run aim listening on 0.0.0.0 to expose all ports. Also, we run 
 # using `--dev` to print verbose logs. Port 43800 is the default port of 
 # `aim up` but explicit is better than implicit.
-CMD ["echo \"N\" | aim init --repo /aim && aim up --host 0.0.0.0 --port 43800 --workers 2 --repo /aim"]
+# When using more than one worker for scalability, make sure to include the additional ports.
+CMD ["echo \"N\" | aim init --repo /aim && aim up --host 0.0.0.0 --port 43800 --workers 1 --repo /aim"]
 ```
 
 Assuming you store the above in your current directory, the container can be built


### PR DESCRIPTION
Running the dockerfile with the previous option `--workers 2` instead of 1 threw grpc errors in the python clients `Run(repo="...")` about the unreachable ports 43801 and 43802. I assume that those are additionally needed with port 43800 when running more workers. Publishing 43801 43802 seemingly fixed it with multiple workers when running the container.

I hope the note saves someone time