### PR TITLE
Added additional example to clarify performance diff

### DIFF
--- a/docs/source/using/search.md
+++ b/docs/source/using/search.md
@@ -75,9 +75,10 @@ Run parameters could be accessed both via chained properties and attributes.
 
 .. note::
 
-The two following examples are equal:
+The three following examples are functionally equal:
 - run.hparams.learning_rate == 32
 - run["hparams", "learning_rate"] == 32
+- run["hparams"]["learning_rate"] == 32 (not performant)
 
 .. warning::
 AimQL has been designed to be highly performant.

--- a/docs/source/using/search.md
+++ b/docs/source/using/search.md
@@ -76,9 +76,9 @@ Run parameters could be accessed both via chained properties and attributes.
 .. note::
 
 The three following examples are functionally equal:
-- run.hparams.learning_rate == 32
-- run["hparams", "learning_rate"] == 32
-- run["hparams"]["learning_rate"] == 32 (not performant)
+- run.hparams.learning_rate == 32 (recommended)
+- run["hparams", "learning_rate"] == 32 (recommended)
+- run["hparams"]["learning_rate"] == 32 
 
 .. warning::
 AimQL has been designed to be highly performant.


### PR DESCRIPTION
I thought the `object[item, item]` syntax was a typo, but I think this change makes it more clear (if I understand it correctly).