### PR TITLE
[feat] Revamp import-order groups of eslint configuration

### DIFF
--- a/aim/web/ui/.eslintrc
+++ b/aim/web/ui/.eslintrc
@@ -87,6 +87,11 @@
             "position": "before"
           },
           {
+            "pattern": "modules/**",
+            "group": "parent",
+            "position": "before"
+          },
+          {
             "pattern": "pages/**",
             "group": "parent",
             "position": "before"
@@ -103,6 +108,11 @@
           },
           {
             "pattern": "styles/**",
+            "group": "parent",
+            "position": "before"
+          },
+          {
+            "pattern": "tests/**",
             "group": "parent",
             "position": "before"
           },

--- a/aim/web/ui/src/App.test.tsx
+++ b/aim/web/ui/src/App.test.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 
 import App from './App';
 
+//@TODO: The next action on this may try to solve the testing issues by going further with the components used here.
+
 test('renders learn react link', () => {
   // render(<App />);
   // const linkElement = screen.getByText(/learn react/i);

--- a/aim/web/ui/src/components/Illustration/config.tsx
+++ b/aim/web/ui/src/components/Illustration/config.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-import { PipelineStatusEnum } from 'modules/core/engine/types';
-
 import emptyBookmarks from 'assets/illustrations/emptyBookmarks.svg';
 import emptySearch from 'assets/illustrations/emptySearch.svg';
 import exploreData from 'assets/illustrations/exploreData.svg';
 import wrongSearch from 'assets/illustrations/wrongSearch.svg';
 
 import { DOCUMENTATIONS } from 'config/references';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 import { IllustrationType } from '.';
 

--- a/aim/web/ui/src/components/kit/AudioBox/AudioBox.tsx
+++ b/aim/web/ui/src/components/kit/AudioBox/AudioBox.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import AudioPlayer from 'material-ui-audio-player';
 
-import AudioBoxVolume from 'modules/BaseExplorer/components/AudioBox/AudioBoxVolume';
-import AudioBoxProgress from 'modules/BaseExplorer/components/AudioBox/AudioBoxProgress';
-
 import { Button, Icon, Spinner, Text } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
 import { BATCH_COLLECT_DELAY } from 'config/mediaConfigs/mediaConfigs';
+
+import AudioBoxProgress from 'modules/BaseExplorer/components/AudioBox/AudioBoxProgress';
+import AudioBoxVolume from 'modules/BaseExplorer/components/AudioBox/AudioBoxVolume';
 
 import blobsURIModel from 'services/models/media/blobsURIModel';
 

--- a/aim/web/ui/src/config/illustrationConfig/illustrationConfig.tsx
+++ b/aim/web/ui/src/config/illustrationConfig/illustrationConfig.tsx
@@ -1,5 +1,3 @@
-import { PipelineStatusEnum } from 'modules/core/engine/types';
-
 import emptyBookmarks from 'assets/illustrations/emptyBookmarks.svg';
 import emptySearch from 'assets/illustrations/emptySearch.svg';
 import exploreData from 'assets/illustrations/exploreData.svg';
@@ -7,6 +5,8 @@ import wrongSearch from 'assets/illustrations/wrongSearch.svg';
 
 import { DOCUMENTATIONS } from 'config/references';
 import { RequestStatusEnum } from 'config/enums/requestStatusEnum';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 enum IllustrationsEnum {
   EmptyBookmarks = 'emptyBookmarks',

--- a/aim/web/ui/src/modules/BaseExplorer/components/AudioBox/AudioBox.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/AudioBox/AudioBox.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import AudioPlayer from 'material-ui-audio-player';
 
 import { Tooltip } from '@material-ui/core';
-import { IBoxProps } from 'modules/BaseExplorer/types';
 
 import { Button, Icon, Spinner, Text } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
 import { BATCH_COLLECT_DELAY } from 'config/mediaConfigs/mediaConfigs';
+
+import { IBoxProps } from 'modules/BaseExplorer/types';
 
 import contextToString from 'utils/contextToString';
 import { downloadLink } from 'utils/helper';

--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/CaptionProperties/CaptionProperties.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/CaptionProperties/CaptionProperties.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { IBaseComponentProps } from 'modules/BaseExplorer/types';
-
 import { Button, Icon, Text } from 'components/kit';
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import { IBaseComponentProps } from 'modules/BaseExplorer/types';
 
 import CaptionPropertiesPopover from './CaptionPropertiesPopover';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/Controls.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/Controls.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { omit } from 'lodash-es';
 
-import { ControlsConfigs } from 'modules/core/engine/visualizations/controls';
-
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 
-import { IControlsProps } from '../../types';
+import { ControlsConfigs } from 'modules/core/engine/visualizations/controls';
+import { IControlsProps } from 'modules/BaseExplorer/types';
 
 import './Controls.scss';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/ExplorerBar/ExplorerBar.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/ExplorerBar/ExplorerBar.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback } from 'react';
 
 import { MenuItem } from '@material-ui/core';
-import { IExplorerBarProps } from 'modules/BaseExplorer/types';
-import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 import AppBar from 'components/AppBar/AppBar';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import { Button, Icon } from 'components/kit';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
+import { IExplorerBarProps } from 'modules/BaseExplorer/types';
 
 import './ExplorerBar.scss';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/Grouping/Grouping/Grouping.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Grouping/Grouping/Grouping.tsx
@@ -1,9 +1,9 @@
 import React, { memo } from 'react';
 
-import { IBaseComponentProps } from 'modules/BaseExplorer/types';
-
 import { Text } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import { IBaseComponentProps } from 'modules/BaseExplorer/types';
 
 import './Grouping.scss';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.d.ts
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.d.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { IBaseComponentProps } from 'modules/BaseExplorer/types';
-
 import { IconName } from 'components/kit/Icon';
+
+import { IBaseComponentProps } from 'modules/BaseExplorer/types';
 
 export interface IGroupingItemProps extends IBaseComponentProps {
   groupName: string;

--- a/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingItem/GroupingItem.tsx
@@ -3,11 +3,12 @@ import _ from 'lodash-es';
 import classNames from 'classnames';
 
 import { Tooltip } from '@material-ui/core';
-import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import ControlPopover from 'components/ControlPopover/ControlPopover';
 import { Button, Text, Icon } from 'components/kit';
+
+import { PipelineStatusEnum } from 'modules/core/engine/types';
 
 import { GroupingPopover } from '../GroupingPopover';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingPopover/GroupingPopover.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Grouping/GroupingPopover/GroupingPopover.tsx
@@ -13,10 +13,11 @@ import {
   CheckBoxOutlineBlank,
 } from '@material-ui/icons';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import { Order } from 'modules/core/pipeline';
 
 import { Badge, Icon, Text, ToggleButton } from 'components/kit';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import { Order } from 'modules/core/pipeline';
 
 import { IGroupingSelectOption } from 'types/services/models/metrics/metricsAppModel';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/ProgressBar/ProgressBarWrapper.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/ProgressBar/ProgressBarWrapper.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { PipelineStatusEnum } from 'modules/core/engine/types';
-
 import ProgressBar from 'components/ProgressBar/ProgressBar';
 
-import { IProgressBarProps } from '../../types';
+import { PipelineStatusEnum } from 'modules/core/engine/types';
+import { IProgressBarProps } from 'modules/BaseExplorer/types';
 
 function ProgressBarWrapper(
   props: Omit<IProgressBarProps, 'visualizationName'>,

--- a/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/QueryForm/QueryForm.tsx
@@ -13,6 +13,13 @@ import {
   CheckBox as CheckBoxIcon,
   CheckBoxOutlineBlank,
 } from '@material-ui/icons';
+
+import { Badge, Button, Icon, Text } from 'components/kit';
+import AutocompleteInput from 'components/AutocompleteInput';
+import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
+
+import { getSuggestionsByExplorer } from 'config/monacoConfig/monacoConfig';
+
 import { IQueryFormProps } from 'modules/BaseExplorer/types';
 import { getQueryStringFromSelect } from 'modules/core/utils/getQueryStringFromSelect';
 import { getSelectFormOptions } from 'modules/core/utils/getSelectFormOptions';
@@ -22,12 +29,6 @@ import {
   QueryRangesState,
 } from 'modules/core/engine/explorer/query';
 import getQueryParamsFromState from 'modules/core/utils/getQueryParamsFromState';
-
-import { Badge, Button, Icon, Text } from 'components/kit';
-import AutocompleteInput from 'components/AutocompleteInput';
-import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
-
-import { getSuggestionsByExplorer } from 'config/monacoConfig/monacoConfig';
 
 import { ISelectOption } from 'types/services/models/explorer/createAppModel';
 import { SequenceTypesEnum } from 'types/core/enums';

--- a/aim/web/ui/src/modules/BaseExplorer/components/RangePanel/RangePanel.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/RangePanel/RangePanel.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { Button, Icon, Text } from 'components/kit';
+
 import { QueryFormState } from 'modules/core/engine/explorer/query/state';
 import getQueryParamsFromState from 'modules/core/utils/getQueryParamsFromState';
-
-import { Button, Icon, Text } from 'components/kit';
 
 import { SequenceTypesEnum } from 'types/core/enums';
 

--- a/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/Visualizer.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Visualizer/Visualizer.tsx
@@ -3,10 +3,11 @@ import _ from 'lodash-es';
 import { useDepthMap } from 'hooks';
 
 import { Tooltip } from '@material-ui/core';
-import { GroupType } from 'modules/core/pipeline';
-import { IQueryableData } from 'modules/core/pipeline';
 
 import { Text } from 'components/kit';
+
+import { GroupType } from 'modules/core/pipeline';
+import { IQueryableData } from 'modules/core/pipeline';
 
 import { AimFlatObjectBase } from 'types/core/AimObjects';
 

--- a/aim/web/ui/src/modules/core/engine/blob-uri-system/index.ts
+++ b/aim/web/ui/src/modules/core/engine/blob-uri-system/index.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash-es';
 
-import { createBlobsRequest } from 'modules/core/api/runsApi';
-
 import { throttle } from 'components/Table/utils';
+
+import { createBlobsRequest } from 'modules/core/api/runsApi';
 
 import { SequenceTypesEnum } from 'types/core/enums';
 

--- a/aim/web/ui/src/modules/core/engine/explorer-engine/index.ts
+++ b/aim/web/ui/src/modules/core/engine/explorer-engine/index.ts
@@ -3,6 +3,7 @@ import type { Update } from 'history';
 
 import createVanilla from 'zustand/vanilla';
 import { devtools, subscribeWithSelector } from 'zustand/middleware';
+
 import { PipelineOptions } from 'modules/core/pipeline';
 import { ExplorerEngineConfiguration } from 'modules/BaseExplorer/types';
 import getUrlSearchParam from 'modules/core/utils/getUrlSearchParam';

--- a/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/AudiosExplorer/getStaticContent.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
+import { DOCUMENTATIONS } from 'config/references';
+
 import getBaseExplorerStaticContent, {
   STATIC_CONTENT_TYPES,
 } from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
 import { StaticContentType } from 'modules/BaseExplorer/types';
-
-import { DOCUMENTATIONS } from 'config/references';
 
 function getAudiosExplorerStaticContent(
   type: StaticContentType,

--- a/aim/web/ui/src/pages/Dashboard/components/ActiveRunsTable/useActiveRunsTable.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ActiveRunsTable/useActiveRunsTable.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import _ from 'lodash-es';
 import moment from 'moment';
 
-import { IResourceState } from 'modules/core/utils/createResource';
-
 import RunNameColumn from 'components/Table/RunNameColumn';
 import { Badge } from 'components/kit';
 import ExperimentNameBox from 'components/ExperimentNameBox';
 
 import { TABLE_DATE_FORMAT } from 'config/dates/dates';
+
+import { IResourceState } from 'modules/core/utils/createResource';
 
 import { IRun } from 'types/services/models/metrics/runModel';
 

--- a/aim/web/ui/src/pages/Dashboard/components/DashboardContributionsFeed/useDashboardContributionsFeed.ts
+++ b/aim/web/ui/src/pages/Dashboard/components/DashboardContributionsFeed/useDashboardContributionsFeed.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 import moment from 'moment';
 
-import { IResourceState } from 'modules/core/utils/createResource';
-
 import {
   CONTRIBUTION_DAY_FORMAT,
   CONTRIBUTION_MONTH_FORMAT,
   CONTRIBUTION_TIME_FORMAT,
 } from 'config/dates/dates';
+
+import { IResourceState } from 'modules/core/utils/createResource';
 
 import { IRun } from 'types/services/models/metrics/runModel';
 

--- a/aim/web/ui/src/pages/Dashboard/components/DashboardRight/ReleaseNotes/useReleaseNotes.ts
+++ b/aim/web/ui/src/pages/Dashboard/components/DashboardRight/ReleaseNotes/useReleaseNotes.ts
@@ -2,11 +2,11 @@ import React from 'react';
 import _ from 'lodash-es';
 import { marked } from 'marked';
 
+import { AIM_VERSION } from 'config/config';
+
 import { IReleaseNote } from 'modules/core/api/releaseNotesApi/types';
 import { IResourceState } from 'modules/core/utils/createResource';
 import { fetchReleaseByTagName } from 'modules/core/api/releaseNotesApi';
-
-import { AIM_VERSION } from 'config/config';
 
 import createReleaseNotesEngine from './ReleasesStore';
 

--- a/aim/web/ui/src/pages/Dashboard/components/ExploreSection/DashboardBookmarks/DashboardBookmarks.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ExploreSection/DashboardBookmarks/DashboardBookmarks.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
-import { IDashboardData } from 'modules/core/api/dashboardsApi';
 import { Tooltip } from '@material-ui/core';
 
 import { Button, Icon, Text } from 'components/kit';
 import ListItem from 'components/kit/ListItem/ListItem';
+
+import { IDashboardData } from 'modules/core/api/dashboardsApi';
 
 import { BookmarkIconType } from 'pages/Bookmarks/components/BookmarkCard/BookmarkCard';
 

--- a/aim/web/ui/src/pages/Dashboard/components/ExploreSection/ExperimentsCard/useExperimentsCard.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ExploreSection/ExperimentsCard/useExperimentsCard.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import _ from 'lodash-es';
 
-import { IExperimentData } from 'modules/core/api/experimentsApi';
-import { IResourceState } from 'modules/core/utils/createResource';
 import { Checkbox } from '@material-ui/core';
 
 import { Icon, Text } from 'components/kit';
 import ExperimentNameBox from 'components/ExperimentNameBox';
+
+import { IResourceState } from 'modules/core/utils/createResource';
+import { IExperimentData } from 'modules/core/api/experimentsApi';
 
 import createExperimentEngine from './ExperimentsStore';
 

--- a/aim/web/ui/src/pages/Dashboard/components/ExploreSection/TagsCard/useTagsCard.tsx
+++ b/aim/web/ui/src/pages/Dashboard/components/ExploreSection/TagsCard/useTagsCard.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import _ from 'lodash-es';
 
-import { IResourceState } from 'modules/core/utils/createResource';
 import { Checkbox } from '@material-ui/core';
-import { ITagData } from 'modules/core/api/tagsApi/types';
 
 import { Badge, Icon, Text } from 'components/kit';
+
+import { IResourceState } from 'modules/core/utils/createResource';
+import { ITagData } from 'modules/core/api/tagsApi/types';
 
 import createTagsEngine from './TagsStore';
 

--- a/aim/web/ui/src/pages/Experiment/ExperimentStore.ts
+++ b/aim/web/ui/src/pages/Experiment/ExperimentStore.ts
@@ -1,3 +1,5 @@
+import { notificationContainerStore } from 'components/NotificationContainer';
+
 import {
   getExperimentById,
   getExperiments,
@@ -5,8 +7,6 @@ import {
   IExperimentData,
 } from 'modules/core/api/experimentsApi';
 import createResource from 'modules/core/utils/createResource';
-
-import { notificationContainerStore } from 'components/NotificationContainer';
 
 import * as analytics from 'services/analytics';
 

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentNotesTab/ExperimentNotesEngine.ts
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentNotesTab/ExperimentNotesEngine.ts
@@ -1,3 +1,5 @@
+import { notificationContainerStore } from 'components/NotificationContainer';
+
 import {
   createExperimentNote,
   getExperimentNote,
@@ -5,8 +7,6 @@ import {
   updateExperimentNote,
 } from 'modules/core/api/experimentsApi';
 import createResource from 'modules/core/utils/createResource';
-
-import { notificationContainerStore } from 'components/NotificationContainer';
 
 function createExperimentNotesEngine() {
   const { fetchData, state, destroy } = createResource<GetExperimentNoteResult>(

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentOverviewTab/ExperimentContributionsFeed/useExperimentContributionsFeed.tsx
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentOverviewTab/ExperimentContributionsFeed/useExperimentContributionsFeed.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import moment from 'moment';
 import _ from 'lodash-es';
 
-import { IResourceState } from 'modules/core/utils/createResource';
-import { ExperimentRun } from 'modules/core/api/experimentsApi';
-
 import {
   CONTRIBUTION_DAY_FORMAT,
   CONTRIBUTION_MONTH_FORMAT,
   CONTRIBUTION_TIME_FORMAT,
 } from 'config/dates/dates';
+
+import { IResourceState } from 'modules/core/utils/createResource';
+import { ExperimentRun } from 'modules/core/api/experimentsApi';
 
 import experimentContributionsEngine from '../ExperimentContributions/ExperimentContributionsStore';
 

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentRunsTab/ExperimentRunsTable/useExperimentRunsTable.tsx
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentRunsTab/ExperimentRunsTable/useExperimentRunsTable.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import moment from 'moment';
 import _ from 'lodash-es';
 
-import { IResourceState } from 'modules/core/utils/createResource';
-
 import { Badge } from 'components/kit';
 import RunNameColumn from 'components/Table/RunNameColumn';
 
 import { TABLE_DATE_FORMAT } from 'config/dates/dates';
+
+import { IResourceState } from 'modules/core/utils/createResource';
 
 import { IRun } from 'types/services/models/metrics/runModel';
 

--- a/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
+++ b/aim/web/ui/src/pages/FiguresExplorer/getStaticContent.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
+import { DOCUMENTATIONS } from 'config/references';
+
 import getBaseExplorerStaticContent, {
   STATIC_CONTENT_TYPES,
 } from 'modules/BaseExplorer/utils/getBaseExplorerStaticContent';
 import { StaticContentType } from 'modules/BaseExplorer/types';
-
-import { DOCUMENTATIONS } from 'config/references';
 
 function getFiguresExplorerStaticContent(
   type: StaticContentType,

--- a/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { MenuItem, Tooltip } from '@material-ui/core';
-import getUpdatedUrl from 'modules/core/utils/getUpdatedUrl';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import ControlPopover from 'components/ControlPopover/ControlPopover';
@@ -11,6 +10,8 @@ import { IconName } from 'components/kit/Icon';
 
 import { EXPLORE_SELECTED_RUNS_CONFIG } from 'config/table/tableConfigs';
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
+
+import getUpdatedUrl from 'modules/core/utils/getUpdatedUrl';
 
 import { AppNameEnum } from 'services/models/explorer';
 import * as analytics from 'services/analytics';

--- a/aim/web/ui/src/services/models/runs/util.test.ts
+++ b/aim/web/ui/src/services/models/runs/util.test.ts
@@ -1,9 +1,11 @@
-import { shouldMatchObject } from 'tests/utils';
-
 import { IMenuItem } from 'components/kit/Menu';
+
+import { shouldMatchObject } from 'tests/utils';
 
 import { TraceRawDataItem } from './types';
 import { getMenuItemFromRawInfo, getContextObjFromMenuActiveKey } from './util';
+
+//@TODO: The next action on this may try to solve the testing issues by going further with the components used here.
 
 describe('first', () => {
   it('should match object', () => {});

--- a/aim/web/ui/src/tests/hooks/model/createModel.test.ts
+++ b/aim/web/ui/src/tests/hooks/model/createModel.test.ts
@@ -1,6 +1,6 @@
-import { shouldMatchObject } from 'tests/utils';
-
 import createModel from 'services/models/model';
+
+import { shouldMatchObject } from 'tests/utils';
 
 const initialState = {
   test: {

--- a/aim/web/ui/src/tests/hooks/model/useModel.test.ts
+++ b/aim/web/ui/src/tests/hooks/model/useModel.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { shouldMatchObject } from 'tests/utils';
 
 import useModel from 'hooks/useModel';
 
 import createModel from 'services/models/model';
+
+import { shouldMatchObject } from 'tests/utils';
 
 import { IModel } from 'types/services/models/model';
 


### PR DESCRIPTION
- add `modules` and `tests` patterns for completing ordering imports, in the eslint config import-order 