### PR TITLE
[fix] Lower debug messages log level in `reporter/__init__.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.15.2
+- Change logging level for reporter debug messages (alberttorosyan)
+
 ## 3.15.1 Dec 1, 2022
 
 - Fix issue with index container lock for older repos (mihran113)


### PR DESCRIPTION
When setting log level to INFO, RunStatusReporter floods logs with tons of messages. Setting the log level for majority of logger calls to DEBUG as the real purpose of them is debugging.