### PR TITLE
[feat] Separate Base explorer default config from Figures explorer config

### DIFF
--- a/aim/web/ui/src/modules/BaseExplorer/getDefaultHydration.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/getDefaultHydration.tsx
@@ -37,7 +37,7 @@ const controls: ControlsConfigs = {
     state: {
       initialState: {
         displayBoxCaption: true,
-        selectedFields: ['run.name', 'figures.name', 'figures.context'],
+        selectedFields: [],
       },
       persist: 'url',
     },
@@ -67,8 +67,8 @@ const groupings: GroupingConfigs = {
       };
     },
     defaultApplications: {
-      fields: ['run.hash', 'figures.name'],
-      orders: [Order.ASC, Order.ASC],
+      fields: [],
+      orders: [],
     },
     // state: {
     //   // observable state, to listen on base visualizer
@@ -101,8 +101,8 @@ const groupings: GroupingConfigs = {
       };
     },
     defaultApplications: {
-      fields: ['record.step'],
-      orders: [Order.DESC],
+      fields: [],
+      orders: [],
     },
     // state: {
     //   // observable state, to listen on base visualizer

--- a/aim/web/ui/src/pages/FiguresExplorer/config.ts
+++ b/aim/web/ui/src/pages/FiguresExplorer/config.ts
@@ -4,16 +4,16 @@ import { getDefaultHydration } from 'modules/BaseExplorer';
 import { GroupType, Order } from 'modules/core/pipeline';
 import { defaultHydration } from 'modules/BaseExplorer/getDefaultHydration';
 
-import getAudiosExplorerStaticContent from './getStaticContent';
+import getFiguresExplorerStaticContent from './getStaticContent';
 
-export const getAudiosDefaultConfig = (): typeof defaultHydration => {
+export const getFiguresDefaultConfig = (): typeof defaultHydration => {
   const defaultConfig = getDefaultHydration();
 
   const groupings = produce(defaultConfig.groupings, (draft: any) => {
     draft[GroupType.COLUMN].defaultApplications.orders = [Order.ASC, Order.ASC];
     draft[GroupType.COLUMN].defaultApplications.fields = [
       'run.hash',
-      'audios.name',
+      'figures.name',
     ];
     draft[GroupType.ROW].defaultApplications.orders = [Order.DESC];
     draft[GroupType.ROW].defaultApplications.fields = ['record.step'];
@@ -22,8 +22,8 @@ export const getAudiosDefaultConfig = (): typeof defaultHydration => {
   const controls = produce(defaultConfig.controls, (draft: any) => {
     draft.captionProperties.state.initialState.selectedFields = [
       'run.name',
-      'audios.name',
-      'audios.context',
+      'figures.name',
+      'figures.context',
     ];
   });
 
@@ -39,6 +39,6 @@ export const getAudiosDefaultConfig = (): typeof defaultHydration => {
         gap: 0,
       },
     },
-    getStaticContent: getAudiosExplorerStaticContent,
+    getStaticContent: getFiguresExplorerStaticContent,
   };
 };

--- a/aim/web/ui/src/pages/FiguresExplorer/index.tsx
+++ b/aim/web/ui/src/pages/FiguresExplorer/index.tsx
@@ -1,13 +1,14 @@
 import type { FunctionComponent } from 'react';
 
-import renderer, { getDefaultHydration } from 'modules/BaseExplorer';
+import renderer from 'modules/BaseExplorer';
 import Figures from 'modules/BaseExplorer/components/Figures/Figures';
 
 import { AimObjectDepths, SequenceTypesEnum } from 'types/core/enums';
 
 import getFiguresExplorerStaticContent from './getStaticContent';
+import { getFiguresDefaultConfig } from './config';
 
-const defaultConfig = getDefaultHydration();
+const defaultConfig = getFiguresDefaultConfig();
 
 const FiguresExplorer = renderer(
   {


### PR DESCRIPTION
Figures explorer grouping fields and caption control fields are hardcoded in Base explorer default configuration.

- removed hardcoded fields from the Base explorer default configuration
- add a separate config file for Figures explorer default configuration