### PR TITLE
[feat] Add custom-state persistence functionality using URL on BaseExplorer

### DIFF
--- a/aim/web/ui/src/modules/core/engine/custom-states/index.ts
+++ b/aim/web/ui/src/modules/core/engine/custom-states/index.ts
@@ -1,16 +1,27 @@
-import { omit } from 'lodash-es';
+import { isEmpty, omit } from 'lodash-es';
 
 import {
   createStateSlices,
   CustomStates,
   PreCreatedStateSlice,
 } from 'modules/core/utils/store';
+import getUrlSearchParam from 'modules/core/utils/getUrlSearchParam';
+import browserHistory from 'modules/core/services/browserHistory';
+import getUpdatedUrl from 'modules/core/utils/getUpdatedUrl';
 
-import { StoreSliceMethods } from '../types';
+import { encode } from 'utils/encoder/encoder';
 
-export interface CustomStatesEngine {
+import {
+  PersistenceTypesEnum,
+  StatePersistOption,
+  StoreSliceMethods,
+} from '../types';
+
+export type CustomStatesEngine = {
   [key: string]: Omit<PreCreatedStateSlice, 'methods'> & StoreSliceMethods;
-}
+} & {
+  initialize: () => () => void;
+};
 
 function createCustomStatesEngine(store: any, config: CustomStates = {}) {
   const customStates: {
@@ -25,20 +36,124 @@ function createCustomStatesEngine(store: any, config: CustomStates = {}) {
     [key: string]: any;
   } = {};
 
+  const intializers: (() => void)[] = [];
+
   Object.keys(customStates).forEach((name: string) => {
     const state: PreCreatedStateSlice = customStates[name];
     initialState[name] = state.initialState;
+    const originalMethods = state.methods(store.setState, store.getState);
+    // @ts-ignore
+    const overrideMethods = { ...originalMethods };
+    const persistenceKey = ['cs', name].join('-');
+
+    const persistenceType = config[name].persist;
+    if (persistenceType) {
+      if (persistenceType === PersistenceTypesEnum.Url) {
+        const stateFromStorage = getUrlSearchParam(persistenceKey) || {};
+
+        // update state
+        if (!isEmpty(stateFromStorage)) {
+          originalMethods.update(stateFromStorage);
+        }
+        overrideMethods.update = (d: any) => {
+          originalMethods.update(d);
+          const url = getUpdatedUrl(persistenceKey, encode(d));
+
+          if (url !== `${window.location.pathname}${window.location.search}`) {
+            browserHistory.push(url, null);
+          }
+        };
+
+        overrideMethods.reset = () => {
+          originalMethods.reset();
+
+          const url = getUpdatedUrl(persistenceKey, encode({}));
+
+          if (url !== `${window.location.pathname}${window.location.search}`) {
+            browserHistory.push(url, null);
+          }
+        };
+      }
+    }
     engine[name] = {
       ...omit(state, 'methods'),
-      ...state.methods(store.setState, store.getState),
+      ...overrideMethods,
     };
+
+    intializers.push(
+      createInitializer(
+        persistenceKey,
+        originalMethods.update,
+        originalMethods.reset,
+        config[name].persist,
+      ),
+    );
   });
+
+  /**
+   * Initialize custom states
+   * @param {String} key - key to identify in storage
+   * @param {Function} update - state update method
+   * @param {Function} reset - state reset method
+   * @param {PersistenceTypesEnum} persist @optional - persistence type
+   */
+  function createInitializer(
+    key: string,
+    update: StoreSliceMethods['update'],
+    reset: StoreSliceMethods['reset'],
+    persist?: StatePersistOption,
+  ) {
+    return (): (() => void) => {
+      if (persist === PersistenceTypesEnum.Url) {
+        const stateFromStorage = getUrlSearchParam(key) || {};
+
+        // update state
+        if (!isEmpty(stateFromStorage)) {
+          update(stateFromStorage);
+        }
+        const removeListener = browserHistory.listenSearchParam(
+          key,
+          (data: unknown) => {
+            // update state
+            if (!isEmpty(data)) {
+              update(data);
+            } else {
+              reset();
+            }
+          },
+          ['PUSH'],
+        );
+
+        return () => {
+          removeListener();
+        };
+      }
+      return () => {};
+    };
+  }
+
+  const initialize = () => {
+    const finalizers: (() => void)[] = [];
+    // call initializers
+    intializers.forEach((init) => {
+      const finalizer = init();
+      // @ts-ignore
+      finalizers.push(finalizer);
+    });
+    // call finalizers
+    return () => {
+      finalizers.forEach((finalizer) => {
+        finalizer();
+      });
+    };
+  };
 
   return {
     state: {
       initialState,
     },
     engine,
+    initialize,
   };
 }
 

--- a/aim/web/ui/src/modules/core/engine/explorer-engine/index.ts
+++ b/aim/web/ui/src/modules/core/engine/explorer-engine/index.ts
@@ -233,7 +233,11 @@ function createEngine<TObject = any>(
       ...initialState,
       ...customStates.state.initialState,
     };
-    customStatesEngine = customStates.engine;
+    // @ts-ignore
+    customStatesEngine = {
+      ...customStates.engine,
+      initialize: customStates.initialize,
+    };
 
     /**
      * Explorer Additional, includes query and groupings
@@ -313,6 +317,7 @@ function createEngine<TObject = any>(
     const finalizeGrouping = groupings.initialize();
     const finalizePipeline = pipeline.initialize();
     const finalizeVisualizations = visualizations.initialize(name);
+    const finalizeCustomStates = customStatesEngine.initialize();
 
     // subscribe to history
     instructions
@@ -355,6 +360,7 @@ function createEngine<TObject = any>(
       finalizeGrouping();
       finalizePipeline();
       finalizeVisualizations();
+      finalizeCustomStates();
       removeHistoryListener && removeHistoryListener();
 
       finalize();


### PR DESCRIPTION
**New functionalities**
- added an initializer on `custom-states`. The initializer is responsible to register `browserHistory` listener by the `key`. The `key` is generated using the prefix `cs-` and name of the state. The initializer returns a function by calling it you will be able to unregister listeners.
- Enhanced the `update` and `reset` methods of state slices to update the url if `persist` key is `url`.

**How to use with BaseExplorer renderer**

1. Configure `persist` key with your custom state

```js
  ...rendererConfig,
   customStates: {
       test: {
          initialState: {
              val: true
          }
          persist: 'url'
       }  
   }
```

2. Call `update` method of the state
```js
   engine.test.update({ val: false });
```
After calling this function the engine updates the url by encoding the state object using base64. The looks like `?cs-test=O-<base64Encoding>`, where `cs-test` is the persistence key and `base64Encoding` is the encoded version of the object.

Later the `initializer` will use this persistence key when url history change happens or loading the explorer at first time.
