### PR TITLE
[doc] Add missing `

### DIFF
--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -799,7 +799,7 @@ class Run(BasicRun):
 
     Args:
          run_hash (:obj:`str`, optional): Run's hash. If skipped, generated automatically.
-         repo (:obj:`Union[Repo,str], optional): Aim repository path or Repo object to which Run object is bound.
+         repo (:obj:`Union[Repo,str]`, optional): Aim repository path or Repo object to which Run object is bound.
             If skipped, default Repo is used.
          read_only (:obj:`bool`, optional): Run creation mode.
             Default is False, meaning Run object can be used to track metrics.


### PR DESCRIPTION
I found a minor typo-ish part on the [`run` section](https://aimstack.readthedocs.io/en/latest/refs/sdk.html#aim.sdk.run.Run) as follows.

![Screenshot 2023-02-07 at 14 38 32](https://user-images.githubusercontent.com/7121753/217158090-9d45b06c-b75c-44ab-b306-b3cc307e85b4.png)

