### PR TITLE
[feat] Add exception-free mode to Aim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.16.2
+- Add exception-free mode to Aim (alberttorosyan)
 - Expose `capture_terminal_logs` argument for `aim.sdk.adapters` classes (mihran113)
 
 ## 3.16.1

--- a/aim/sdk/run.py
+++ b/aim/sdk/run.py
@@ -35,6 +35,7 @@ from aim.ext.utils import (
     get_installed_packages,
     get_git_info,
 )
+from aim.ext.exception_resistant import noexcept
 
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 from typing import TYPE_CHECKING
@@ -334,6 +335,7 @@ class BasicRun(BaseRun, StructuredRunMixin):
     def idx_to_ctx(self, idx: int) -> Context:
         return self._tracker.idx_to_ctx(idx)
 
+    @noexcept
     def __setitem__(self, key: str, val: Any):
         """Set Run top-level meta-parameter.
 
@@ -364,6 +366,7 @@ class BasicRun(BaseRun, StructuredRunMixin):
         """
         return self._collect(key)
 
+    @noexcept
     def set(self, key, val: Any, strict: bool = True):
         self.meta_run_attrs_tree.set(key, val, strict)
         self.meta_attrs_tree.set(key, val, strict)
@@ -385,6 +388,7 @@ class BasicRun(BaseRun, StructuredRunMixin):
         del self.meta_attrs_tree[key]
         del self.meta_run_attrs_tree[key]
 
+    @noexcept
     def track(
         self,
         value,
@@ -812,6 +816,7 @@ class Run(BasicRun):
             git info, environment variables, etc.
     """
 
+    @noexcept
     def __init__(self, run_hash: Optional[str] = None, *,
                  repo: Optional[Union[str, 'Repo']] = None,
                  read_only: bool = False,

--- a/aim/sdk/training_flow.py
+++ b/aim/sdk/training_flow.py
@@ -60,6 +60,21 @@ class TrainingFlow(Caller):
     ):
         """Is called after the training phase is successfully finished."""
 
+    @event
+    def exception_raised(
+        self, *,
+        exception: Exception,
+        **kwargs
+    ):
+        """Is called when exception is raised from Aim codebase. """
+
+    def handle_exceptions(self):
+        from aim.ext.exception_resistant import set_exception_callback
+
+        def callback(e: Exception, func: callable):
+            self.exception_raised(exception=e, function=func)
+        set_exception_callback(callback)
+
     # @event
     # def run_available_experimental(
     #     self, *,

--- a/aim/utils/__init__.py
+++ b/aim/utils/__init__.py
@@ -1,0 +1,1 @@
+from aim.ext.exception_resistant import enable_safe_mode, disable_safe_mode  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "cython == 3.0.0a11", "aimrocks == 0.3.1"]
+requires = ["setuptools", "cython == 3.0.0a11", "aimrocks == 0.4.0"]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ SETUP_REQUIRED = [
 REQUIRED = [
     f'aim-ui=={__version__}',
     'aimrecords==0.0.7',
-    'aimrocks==0.3.1',
+    'aimrocks==0.4.0',
     'cachetools>=4.0.0',
     'click>=7.0',
     'cryptography>=3.0',


### PR DESCRIPTION
Introduce the safe mode into tracking with Aim.
- In order to mark the function as "safe-mode-enabled", decorate it with  `@noexcept`
- In order to enable/disable safe mode:
```python
from aim.utils import enable_safe_mode

enable_safe_mode()
...
```

_By default, in safe mode the raised exception and the function name will be logged with WARNING log level._

- In order to customize the exception handling need to register the callback on `TrainingFlow` instance
```python
class ExceptionHanlderCallback:
    @on.exception_raised
    def handle_exception(self, exception, function, **kwargs):
        # handling logic here

flow.register(ExceptionHanlderCallback())
```

and call

```python
flow.handle_exceptions()
```