### PR TITLE
[feat] Add quick navigation to explorers from the run page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.16.3
 
 - Fix issue with toggling lines visibility during live update (roubkar)
-- Add navigation link to Experiment page from Run page (roubkar)
+- Add navigation link to Experiment page from the Run page (roubkar)
+- Add navigation to explorers from the Run page (roubkar)
 
 ## 3.16.2 Mar 3, 2023
 

--- a/aim/web/ui/src/config/table/tableConfigs.ts
+++ b/aim/web/ui/src/config/table/tableConfigs.ts
@@ -129,6 +129,7 @@ export const AVOID_COLUMNS_TO_HIDE_LIST = new Set([
 
 export const EXPLORE_SELECTED_RUNS_CONFIG: Record<string, AppNameEnum[]> = {
   [AppNameEnum.RUNS]: [
+    AppNameEnum.RUNS,
     AppNameEnum.METRICS,
     AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,
@@ -136,27 +137,29 @@ export const EXPLORE_SELECTED_RUNS_CONFIG: Record<string, AppNameEnum[]> = {
   ],
   [AppNameEnum.METRICS]: [
     AppNameEnum.RUNS,
+    AppNameEnum.METRICS,
     AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,
     AppNameEnum.AUDIOS,
   ],
   [AppNameEnum.PARAMS]: [
     AppNameEnum.RUNS,
-    AppNameEnum.IMAGES,
     AppNameEnum.METRICS,
+    AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,
     AppNameEnum.AUDIOS,
   ],
   [AppNameEnum.SCATTERS]: [
     AppNameEnum.RUNS,
-    AppNameEnum.IMAGES,
     AppNameEnum.METRICS,
+    AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,
     AppNameEnum.AUDIOS,
   ],
   [AppNameEnum.IMAGES]: [
     AppNameEnum.RUNS,
     AppNameEnum.METRICS,
+    AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,
     AppNameEnum.AUDIOS,
   ],
@@ -175,6 +178,7 @@ export const EXPLORE_SELECTED_RUNS_CONFIG: Record<string, AppNameEnum[]> = {
     AppNameEnum.AUDIOS,
   ],
   run: [
+    AppNameEnum.RUNS,
     AppNameEnum.METRICS,
     AppNameEnum.IMAGES,
     AppNameEnum.FIGURES,

--- a/aim/web/ui/src/config/table/tableConfigs.ts
+++ b/aim/web/ui/src/config/table/tableConfigs.ts
@@ -174,4 +174,10 @@ export const EXPLORE_SELECTED_RUNS_CONFIG: Record<string, AppNameEnum[]> = {
     AppNameEnum.FIGURES,
     AppNameEnum.AUDIOS,
   ],
+  run: [
+    AppNameEnum.METRICS,
+    AppNameEnum.IMAGES,
+    AppNameEnum.FIGURES,
+    AppNameEnum.AUDIOS,
+  ],
 };

--- a/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.d.ts
+++ b/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.d.ts
@@ -4,4 +4,5 @@ export interface ICompareSelectedRunsPopoverProps {
   appName: AppNameEnum;
   disabled?: boolean;
   query: string;
+  buttonText?: string;
 }

--- a/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/Table/CompareSelectedRunsPopover/CompareSelectedRunsPopover.tsx
@@ -26,6 +26,7 @@ function CompareSelectedRunsPopover({
   appName,
   query,
   disabled = false,
+  buttonText,
 }: ICompareSelectedRunsPopoverProps): React.FunctionComponentElement<React.ReactNode> {
   const history = useHistory();
 
@@ -108,7 +109,7 @@ function CompareSelectedRunsPopover({
           >
             <Icon fontSize={18} name='compare' />
             <Text size={14} tint={disabled ? 50 : 100}>
-              Compare
+              {buttonText ?? 'Compare'}
             </Text>
           </Button>
         )}
@@ -129,7 +130,7 @@ function CompareSelectedRunsPopover({
                   >
                     {item}
                   </Text>
-                  <Tooltip title='Compare in new tab'>
+                  <Tooltip title={`${buttonText ?? 'Compare'} in a new tab`}>
                     <div>
                       <Icon
                         box

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.scss
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.scss
@@ -37,6 +37,14 @@
         &__runInfoBox {
           max-width: 50%;
         }
+        &__explore {
+          display: flex;
+          flex: 1;
+          align-items: center;
+          justify-content: flex-end;
+          margin-right: 1rem;
+          margin-bottom: 1rem;
+        }
         &__actionContainer {
           width: 4.5rem;
           display: flex;

--- a/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
+++ b/aim/web/ui/src/pages/RunDetail/RunDetail.tsx
@@ -28,9 +28,12 @@ import Spinner from 'components/kit/Spinner';
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 import { DATE_WITH_SECONDS } from 'config/dates/dates';
 
+import CompareSelectedRunsPopover from 'pages/Metrics/components/Table/CompareSelectedRunsPopover';
+
 import runDetailAppModel from 'services/models/runs/runDetailAppModel';
 import * as analytics from 'services/analytics';
 import notesModel from 'services/models/notes/notesModel';
+import { AppNameEnum } from 'services/models/explorer';
 
 import { setDocumentTitle } from 'utils/document/documentTitle';
 import { processDurationTime } from 'utils/processDurationTime';
@@ -395,6 +398,13 @@ function RunDetail(): React.FunctionComponentElement<React.ReactNode> {
                     />
                   )}
                 </div>
+              </div>
+              <div className='RunDetail__runDetailContainer__appBarContainer__appBarBox__explore'>
+                <CompareSelectedRunsPopover
+                  appName={'run' as AppNameEnum} // @TODO: change to AppNameEnum.RUN
+                  query={`run.hash == "${runHash}"`}
+                  buttonText={'Explore'}
+                />
               </div>
               <div className='RunDetail__runDetailContainer__appBarContainer__appBarBox__actionContainer'>
                 <NavLink to={`${url}/settings`}>


### PR DESCRIPTION
- Added compare popover to the run page header
- Added `buttonText` property to compare popover
- Added missing explorer names to the compare selected runs config