### PR TITLE
[fix] Fix issue with custom metric alignment caching

### DIFF
--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/ConfigureAxes/Popover/Alignment.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/ConfigureAxes/Popover/Alignment.tsx
@@ -116,7 +116,7 @@ function Alignment(props: IAlignmentProps) {
         body: reqBody,
         params: { report_progress: true },
         ignoreCache: false,
-        processData: (currentResult, alignedDataResponse) => {
+        processData: (currentResult, alignedDataResponse, clearCache) => {
           const alignedDataDict: Record<
             string,
             {
@@ -165,6 +165,9 @@ function Alignment(props: IAlignmentProps) {
               type: AlignmentOptionsEnum.STEP,
               metric: '',
             });
+
+            clearCache();
+
             return currentResult;
           }
 

--- a/aim/web/ui/src/modules/core/cache/inlineCache.ts
+++ b/aim/web/ui/src/modules/core/cache/inlineCache.ts
@@ -2,6 +2,7 @@ export type InlineCache = {
   get: (key: any) => any;
   set: (key: any, value: any) => void;
   clear: () => void;
+  delete: (key: any) => void;
 };
 
 /**
@@ -31,6 +32,9 @@ function createInlineCache(cacheSize?: number): InlineCache {
     },
     clear: function () {
       cache.clear();
+    },
+    delete: function (key: any) {
+      cache.delete(key);
     },
   };
 }

--- a/aim/web/ui/src/modules/core/engine/pipeline/index.ts
+++ b/aim/web/ui/src/modules/core/engine/pipeline/index.ts
@@ -347,6 +347,7 @@ function createPipelineEngine<TStore, TObject>(
       })
       .catch((err) => {
         state.setError(err);
+        state.setCurrentCustomPhaseArgs(null);
         state.changeCurrentPhaseOrStatus(PipelineStatusEnum.Failed);
         if (err && err.message !== 'SyntaxError') {
           notificationsEngine?.error(err.message);

--- a/aim/web/ui/src/modules/core/pipeline/index.ts
+++ b/aim/web/ui/src/modules/core/pipeline/index.ts
@@ -56,6 +56,7 @@ export type CustomPhaseExecutionArgs = {
   processData: (
     currentResult: ProcessedData,
     queryResult: any,
+    clearCache: () => void,
   ) => ProcessedData;
   ignoreCache?: boolean;
 };


### PR DESCRIPTION
- Fixed an issue with the caching of custom metric alignment.

Reproduction steps:
1. Attempt to align the x-axis using a custom metric that is not `alignable` with the current y-axis values. This will cause the x-axis alignment value to be changed to the default "Step" value.
2. Attempt to align the x-axis using the same `non-alignable` value.
3. The issue is that it sets the x-axis value to that custom metric value, which is incorrect.

Expected behavior:
- When the alignment is incorrect, the x-axis alignment value should be set back to the default "Step" value.

Solution:
- Clear the caching when attempting to align the x-axis using a custom metric that is `non-alignable` with the current y values.