### PR TITLE
[fix] Fix pipeline custom phase caching issue

### DIFF
--- a/aim/web/ui/src/modules/BaseExplorer/components/BoxVirtualizer/BoxVirtualizer.scss
+++ b/aim/web/ui/src/modules/BaseExplorer/components/BoxVirtualizer/BoxVirtualizer.scss
@@ -46,7 +46,7 @@
   position: sticky;
   left: 0;
   width: 200px;
-  min-height: calc(100% - 30px);
+  min-height: 100%;
   border-right: $border-dark;
   background-color: #fff;
   z-index: 2;

--- a/aim/web/ui/src/modules/BaseExplorer/components/BoxVirtualizer/BoxVirtualizer.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/BoxVirtualizer/BoxVirtualizer.tsx
@@ -115,13 +115,14 @@ function BoxVirtualizer(props: IBoxVirtualizerProps<AimFlatObjectBase>) {
       }
     }
 
-    const horizontalRulerHeight = 30;
+    const horizontalRulerHeight =
+      columnsAxisItems && columnsAxisItems.length > 0 ? 30 : 0;
 
     return {
       width: rightEdge + itemWidth + props.offset,
       height: bottomEdge + itemHeight + props.offset - horizontalRulerHeight,
     };
-  }, [data, props.offset]);
+  }, [data, props.offset, columnsAxisItems]);
 
   return (
     <div className='BoxVirtualizer'>
@@ -147,7 +148,13 @@ function BoxVirtualizer(props: IBoxVirtualizerProps<AimFlatObjectBase>) {
         {rowsAxisItems && rowsAxisItems.length > 0 && (
           <div
             className='BoxVirtualizer__container__verticalRuler'
-            style={{ height: gridSize.height }}
+            style={{
+              height: gridSize.height,
+              minHeight:
+                columnsAxisItems && columnsAxisItems.length > 0
+                  ? 'calc(100% - 30px)'
+                  : '100%',
+            }}
           >
             {rowsAxisItems.map(props.axisItemRenderer?.rows)}
           </div>

--- a/aim/web/ui/src/modules/BaseExplorer/components/Controls/ConfigureAxes/Popover/Alignment.tsx
+++ b/aim/web/ui/src/modules/BaseExplorer/components/Controls/ConfigureAxes/Popover/Alignment.tsx
@@ -55,8 +55,6 @@ function Alignment(props: IAlignmentProps) {
   const updateAxesProps = vizEngine.controls.axesProperties.methods.update;
   const queryable = engine.useStore(engine.instructions.stateSelector);
   const data = engine.useStore(engine.pipeline.dataSelector);
-  const executeCustomPhase: (args: CustomPhaseExecutionArgs) => void =
-    engine.pipeline.executeCustomPhase;
 
   const projectSequenceOptions = getSelectFormOptions(
     queryable.project_sequence_info,
@@ -111,7 +109,7 @@ function Alignment(props: IAlignmentProps) {
 
       const reqBody: IAlignMetricsData = { align_by: metric, runs };
 
-      executeCustomPhase({
+      engine.pipeline.executeCustomPhase({
         createRequest: createAlignMetricsRequest,
         body: reqBody,
         params: { report_progress: true },
@@ -166,6 +164,7 @@ function Alignment(props: IAlignmentProps) {
               metric: '',
             });
 
+            engine.pipeline.resetCustomPhaseArgs();
             clearCache();
 
             return currentResult;
@@ -178,7 +177,13 @@ function Alignment(props: IAlignmentProps) {
         },
       } as CustomPhaseExecutionArgs);
     },
-    [executeCustomPhase, data, engine.notifications, updateAlignment],
+    [
+      engine.pipeline.executeCustomPhase,
+      engine.pipeline.resetCustomPhaseArgs,
+      data,
+      engine.notifications,
+      updateAlignment,
+    ],
   );
 
   const handleAlignmentChange = React.useCallback(

--- a/aim/web/ui/src/modules/core/pipeline/custom/index.ts
+++ b/aim/web/ui/src/modules/core/pipeline/custom/index.ts
@@ -1,4 +1,3 @@
-import { memoize } from 'modules/core/cache';
 import { RunsSearchQueryParams } from 'modules/core/api/runsApi';
 import { buildObjectHash } from 'modules/core/utils/hashing';
 import createInlineCache, { InlineCache } from 'modules/core/cache/inlineCache';


### PR DESCRIPTION
Fixed:
- reset pipeline custom phase arguments if the custom metric alignment is not valid
- set correct min-height of the grid in box-virtualizer 
