### PR TITLE
[fix] Fix the UI crashing issue when opening the Metrics, Params, or Scatters Explorers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.17.1
+- Fix the UI crashing issue when opening the Metrics, Params, or Scatters Explorers (KaroMourad)
+
 ## 3.17.0 Mar 24, 2023
 
 ### Enhancements

--- a/aim/web/ui/src/pages/Metrics/Metrics.tsx
+++ b/aim/web/ui/src/pages/Metrics/Metrics.tsx
@@ -54,10 +54,10 @@ function Metrics(
       ignoreOutliers: props.ignoreOutliers,
       highlightMode: props.highlightMode,
       aggregatedData: props.aggregatedData?.filter(
-        (data) => data.chartIndex === chartData[0].chartIndex,
+        (data) => data.chartIndex === chartData[0]?.chartIndex,
       ),
       zoom: props.zoom,
-      chartTitle: props.chartTitleData[chartData[0].chartIndex!],
+      chartTitle: props.chartTitleData[chartData[0]?.chartIndex!],
       aggregationConfig: props.aggregationConfig,
       alignmentConfig: props.alignmentConfig,
       onZoomChange: props.onZoomChange,

--- a/aim/web/ui/src/pages/Params/Params.tsx
+++ b/aim/web/ui/src/pages/Params/Params.tsx
@@ -122,7 +122,7 @@ const Params = ({
       isVisibleColorIndicator,
       onAxisBrushExtentChange,
       brushExtents,
-      chartTitle: chartTitleData[chartData[0].chartIndex],
+      chartTitle: chartTitleData[chartData.data[0]?.chartIndex],
     }));
   }, [
     highPlotData,

--- a/aim/web/ui/src/pages/Scatters/Scatters.tsx
+++ b/aim/web/ui/src/pages/Scatters/Scatters.tsx
@@ -43,8 +43,8 @@ function Scatters(
   const [isProgressBarVisible, setIsProgressBarVisible] =
     React.useState<boolean>(false);
   const chartProps: any[] = React.useMemo(() => {
-    return (props.scatterPlotData || []).map((data: any) => ({
-      chartTitle: props.chartTitleData[data[0].chartIndex],
+    return (props.scatterPlotData || []).map((chartData: any) => ({
+      chartTitle: props.chartTitleData[chartData.data[0]?.chartIndex],
       trendlineOptions: props.trendlineOptions,
     }));
   }, [props.scatterPlotData, props.chartTitleData, props.trendlineOptions]);


### PR DESCRIPTION
When opening Metrics, Params, or Scatters Explorers with empty chart data the UI crashes.

- Fixed the issue