### PR TITLE
Fix searching on <Enter> on Windows

### DIFF
--- a/aim/web/ui/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/aim/web/ui/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -186,7 +186,7 @@ function AutocompleteInput({
           //   : formattedValue;
           onChange(formattedValue, ev);
         }
-        if (ev.changes[0].text === '\n') {
+        if (/^\r?\n$/.test(ev.changes[0].text)) {
           formattedValue = hasSelection
             ? editorValue.replace(/[\n\r]/g, '')
             : formattedValue;


### PR DESCRIPTION
Windows browsers send `\r\n` instead of just `\n` when `Enter` is pressed in the search box. This PR changes the way we detect this keypress so that searching can be triggered in the same way on Windows as on other platforms.