### PR TITLE
[fix] Resolve style inconsistencies in Explorers, Boards, and Reports pages

### DIFF
--- a/aim/web/ui/src/components/kit_v2/FormGroup/FormGroup.tsx
+++ b/aim/web/ui/src/components/kit_v2/FormGroup/FormGroup.tsx
@@ -28,16 +28,16 @@ function FormGroup({
             {section?.sectionFields?.map((row, id: number) => {
               return (
                 <FormGroupRow key={id}>
-                  {row.content && (
-                    <FormGroupContent>{row.content}</FormGroupContent>
+                  {row?.content && (
+                    <FormGroupContent>{row?.content}</FormGroupContent>
                   )}
-                  {row.control && (
-                    <FormGroupControl>{row.control}</FormGroupControl>
+                  {row?.control && (
+                    <FormGroupControl>{row?.control}</FormGroupControl>
                   )}
-                  {row.actions?.map((action, id: number) => {
+                  {row?.actions?.map((action, id: number) => {
                     return (
                       <FormGroupActions key={id}>
-                        <Box>{action.component}</Box>
+                        <Box>{action?.component}</Box>
                       </FormGroupActions>
                     );
                   })}

--- a/aim/web/ui/src/components/kit_v2/Link/Link.d.ts
+++ b/aim/web/ui/src/components/kit_v2/Link/Link.d.ts
@@ -41,6 +41,14 @@ export interface ILinkProps extends NavLinkProps {
    */
   underline?: boolean;
   /**
+   * @description Ellipsis the text of the link
+   * @default false
+   * @type boolean
+   * @example
+   * <Link ellipsis>Some long text</Link>
+   */
+  ellipsis?: boolean;
+  /**
    * @description The children of the link
    * @default null
    * @type React.ReactNode

--- a/aim/web/ui/src/components/kit_v2/Link/Link.style.ts
+++ b/aim/web/ui/src/components/kit_v2/Link/Link.style.ts
@@ -1,9 +1,11 @@
 import { NavLink } from 'react-router-dom';
 
 import { styled, css } from 'config/stitches';
+import { textEllipsis } from 'config/stitches/foundations/layout';
 
 const StyledLink = css({
   textDecoration: 'none',
+  display: 'block',
   variants: {
     underline: {
       true: {
@@ -11,6 +13,10 @@ const StyledLink = css({
           textDecoration: 'underline',
         },
       },
+      false: {},
+    },
+    ellipsis: {
+      true: textEllipsis,
       false: {},
     },
   },

--- a/aim/web/ui/src/components/kit_v2/Link/Link.tsx
+++ b/aim/web/ui/src/components/kit_v2/Link/Link.tsx
@@ -19,6 +19,7 @@ function Link({
   fontSize = '$5',
   fontWeight = '$2',
   color = '$primary100',
+  ellipsis = false,
   underline = true,
   css = {},
   children,
@@ -51,6 +52,7 @@ function Link({
       return (
         <StyledAnchor
           underline={underline}
+          ellipsis={ellipsis}
           css={cssProps}
           href={to}
           target={props.target || '_blank'}
@@ -62,7 +64,13 @@ function Link({
       );
     }
     return (
-      <StyledNavLink underline={underline} css={cssProps} to={to} {...props}>
+      <StyledNavLink
+        ellipsis={ellipsis}
+        underline={underline}
+        css={cssProps}
+        to={to}
+        {...props}
+      >
         {children}
       </StyledNavLink>
     );

--- a/aim/web/ui/src/components/kit_v2/Select/Select.tsx
+++ b/aim/web/ui/src/components/kit_v2/Select/Select.tsx
@@ -172,7 +172,7 @@ const Select = ({
     <Popover
       popperProps={{
         ...popoverProps,
-        css: { p: '$5 0', ...popoverProps.css },
+        css: { p: '$5 0', ...popoverProps?.css },
       }}
       trigger={({ open }) =>
         typeof trigger === 'function'

--- a/aim/web/ui/src/components/kit_v2/Text/Text.d.ts
+++ b/aim/web/ui/src/components/kit_v2/Text/Text.d.ts
@@ -11,7 +11,7 @@ export interface ITextProps
   disabled?: boolean;
   size?: CSS['fontSize'];
   color?: CSS['color'];
-  truncate?: boolean;
+  ellipsis?: boolean;
   textTransform?: CSS['textTransform'];
   lineHeight?: CSS['lineHeight'];
   css?: CSS;

--- a/aim/web/ui/src/components/kit_v2/Text/Text.style.ts
+++ b/aim/web/ui/src/components/kit_v2/Text/Text.style.ts
@@ -1,15 +1,12 @@
 import { Slot } from '@radix-ui/react-slot';
 
 import { styled } from 'config/stitches';
+import { textEllipsis } from 'config/stitches/foundations/layout';
 
 const StyledSlot: any = styled(Slot, {
   variants: {
-    truncate: {
-      true: {
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      },
+    ellipsis: {
+      true: textEllipsis,
     },
   },
 });

--- a/aim/web/ui/src/components/kit_v2/Text/Text.tsx
+++ b/aim/web/ui/src/components/kit_v2/Text/Text.tsx
@@ -26,7 +26,7 @@ const Text = React.forwardRef<React.ElementRef<typeof StyledSlot>, ITextProps>(
       disabled = false,
       textTransform,
       lineHeight,
-      truncate,
+      ellipsis,
       css,
       children,
       ...rest
@@ -36,7 +36,7 @@ const Text = React.forwardRef<React.ElementRef<typeof StyledSlot>, ITextProps>(
     const TagElement = as;
     return (
       <StyledSlot
-        truncate={truncate}
+        ellipsis={ellipsis}
         css={{
           fontSize: size,
           fontWeight: weight,

--- a/aim/web/ui/src/components/kit_v2/Tooltip/Tooltip.tsx
+++ b/aim/web/ui/src/components/kit_v2/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { Slot } from '@radix-ui/react-slot';
 
 import { TooltipArrow, TooltipContent } from './Tooltip.style';
 import { ITooltipProps } from './Tooltip.d';
@@ -46,7 +47,11 @@ function Tooltip({
       skipDelayDuration={skipDelayDuration}
     >
       <TooltipPrimitive.Root {...props}>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Trigger asChild>
+          <Slot>
+            <div>{children}</div>
+          </Slot>
+        </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Portal>
           <TooltipContent
             ref={ref}

--- a/aim/web/ui/src/config/stitches/foundations/layout.ts
+++ b/aim/web/ui/src/config/stitches/foundations/layout.ts
@@ -23,4 +23,11 @@ const TopBar = styled(Box, {
   p: '0 $9',
 });
 
-export { LayoutContainer, TopBar };
+const textEllipsis = {
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: '100%',
+};
+
+export { LayoutContainer, TopBar, textEllipsis };

--- a/aim/web/ui/src/pages/Boards/Boards.style.ts
+++ b/aim/web/ui/src/pages/Boards/Boards.style.ts
@@ -2,7 +2,7 @@ import { styled } from 'config/stitches';
 import { LayoutContainer } from 'config/stitches/foundations/layout';
 
 const BoardsContainer = styled(LayoutContainer, {
-  $$space: '$space$13',
+  $$space: '$space$15',
   py: '$$space',
   height: 'calc(100vh - $$space)',
   overflowY: 'auto',

--- a/aim/web/ui/src/pages/Boards/components/BoardCard/BoardCard.tsx
+++ b/aim/web/ui/src/pages/Boards/components/BoardCard/BoardCard.tsx
@@ -20,6 +20,7 @@ import {
   Popover,
   Separator,
   Text,
+  Tooltip,
 } from 'components/kit_v2';
 
 import { PathEnum } from 'config/enums/routesEnum';
@@ -51,6 +52,9 @@ function BoardCard({
         <Link
           css={{ flex: 1 }}
           fontWeight='$4'
+          fontSize='$6'
+          ellipsis
+          title={name}
           to={PathEnum.Board.replace(':boardId', id)}
         >
           {name}

--- a/aim/web/ui/src/pages/Explorers/Bookmarks/components/BookmarkCard/BookmarkCard.tsx
+++ b/aim/web/ui/src/pages/Explorers/Bookmarks/components/BookmarkCard/BookmarkCard.tsx
@@ -63,8 +63,10 @@ function BookmarkCard({
             </Tooltip>
             <Link
               css={{ ml: '$4', flex: '1' }}
+              ellipsis
               fontSize='$6'
-              fontWeight='$3'
+              fontWeight='$4'
+              title={name}
               onClick={() =>
                 analytics.trackEvent(ANALYTICS_EVENT_KEYS.bookmarks.view)
               }

--- a/aim/web/ui/src/pages/Explorers/Explorers.style.ts
+++ b/aim/web/ui/src/pages/Explorers/Explorers.style.ts
@@ -16,7 +16,7 @@ const ExplorersContentContainer = styled(LayoutContainer, {
 });
 
 const ExplorerCardsWrapper = styled(Box, {
-  gap: '$8',
+  gap: '$13',
   display: 'flex',
   ai: 'center',
   fw: 'wrap',

--- a/aim/web/ui/src/pages/Explorers/components/ExplorerCard/ExplorerCard.style.ts
+++ b/aim/web/ui/src/pages/Explorers/components/ExplorerCard/ExplorerCard.style.ts
@@ -13,6 +13,11 @@ const ExplorerCardContainer = styled(NavLink, {
   textDecoration: 'none',
   position: 'relative',
   transition: 'all 0.18s ease-out',
+  '&:hover': {
+    '.card-title': {
+      textDecoration: 'underline',
+    },
+  },
 });
 
 const ExplorerCardBadge = styled(Text, {

--- a/aim/web/ui/src/pages/Explorers/components/ExplorerCard/ExplorerCard.tsx
+++ b/aim/web/ui/src/pages/Explorers/components/ExplorerCard/ExplorerCard.tsx
@@ -6,6 +6,8 @@ import { IconName } from 'components/kit/Icon';
 
 import { RouteStatusEnum } from 'routes/routes';
 
+import hexToRgbA from 'utils/hexToRgbA';
+
 import { ExplorerCardBadge, ExplorerCardContainer } from './ExplorerCard.style';
 import { IExplorerCardProps } from './ExplorerCard.d';
 
@@ -27,8 +29,10 @@ function ExplorerCard({
     <ExplorerCardContainer
       to={path}
       css={{
-        backgroundColor: `${color}10`,
-        '&:hover': { bs: `0 0 0 1px inset $colors${color}100` },
+        backgroundColor: `${hexToRgbA(color!, 0.1)}`,
+        '&:hover': {
+          bs: `0 0 0 1px inset ${color}`,
+        },
       }}
     >
       {status && (
@@ -52,12 +56,12 @@ function ExplorerCard({
             display='flex'
             ai='center'
             jc='center'
-            css={{ size: '$7', br: '$pill', background: `${color}100` }}
+            css={{ size: '$7', br: '$pill', background: `${color}` }}
           >
             <Icon color='white' name={icon as IconName} />
           </Box>
         )}
-        <Text css={{ ml: '$5' }} size='$5' weight='$3'>
+        <Text className='card-title' css={{ ml: '$5' }} size='$6' weight='$3'>
           {displayName} {isLoading ? null : count ? `(${count})` : null}
         </Text>
       </Box>

--- a/aim/web/ui/src/pages/Reports/ReportCard/ReportCard.tsx
+++ b/aim/web/ui/src/pages/Reports/ReportCard/ReportCard.tsx
@@ -20,6 +20,7 @@ import {
   Popover,
   Separator,
   Text,
+  Tooltip,
 } from 'components/kit_v2';
 
 import { PathEnum } from 'config/enums/routesEnum';
@@ -42,8 +43,11 @@ function ReportCard({
     <ReportCardContainer key={id}>
       <ReportCardHeader>
         <Link
+          ellipsis
           css={{ flex: 1 }}
           fontWeight='$4'
+          fontSize='$6'
+          title={name}
           to={PathEnum.Report.replace(':reportId', id)}
         >
           {name}

--- a/aim/web/ui/src/pages/Reports/Reports.style.ts
+++ b/aim/web/ui/src/pages/Reports/Reports.style.ts
@@ -2,7 +2,7 @@ import { styled } from 'config/stitches';
 import { LayoutContainer } from 'config/stitches/foundations/layout';
 
 const ReportsContainer = styled(LayoutContainer, {
-  $$space: '$space$13',
+  $$space: '$space$15',
   py: '$$space',
   height: 'calc(100vh - $$space)',
   overflowY: 'auto',

--- a/aim/web/ui/src/routes/routes.tsx
+++ b/aim/web/ui/src/routes/routes.tsx
@@ -138,7 +138,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
     icon: 'metrics',
     isExact: true,
     title: pageTitlesEnum.METRICS_EXPLORER,
-    color: '$purple',
+    color: '#7A4CE0',
     category: ExplorersCatsEnum.Trainings,
   },
   PARAMS: {
@@ -151,7 +151,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
     icon: 'params',
     isExact: true,
     title: pageTitlesEnum.PARAMS_EXPLORER,
-    color: '$red',
+    color: '#AF4EAB',
     category: ExplorersCatsEnum.Trainings,
   },
   TEXT_EXPLORER: {
@@ -164,7 +164,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
       'Text Explorer offers visualization of text inputs and outputs in NLP-related experiments.',
     isExact: true,
     title: pageTitlesEnum.TEXT_EXPLORER,
-    color: '$pink',
+    color: '#E149A0',
     category: ExplorersCatsEnum.Trainings,
   },
   PROMPTS_EXPLORER: {
@@ -177,7 +177,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
       'Prompts Explorer enables visualization of LLMs prompts and agents actions in AI systems execution.',
     isExact: true,
     title: pageTitlesEnum.PROMPTS_EXPLORER,
-    color: '$primary',
+    color: '#1473E6',
     category: ExplorersCatsEnum.Prompts,
   },
   IMAGE_EXPLORE: {
@@ -190,7 +190,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
     icon: 'images',
     isExact: true,
     title: pageTitlesEnum.IMAGES_EXPLORER,
-    color: '$orange',
+    color: '#F17922',
     category: ExplorersCatsEnum.Trainings,
   },
   FIGURES_EXPLORER: {
@@ -203,7 +203,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
       'Figures Explorer enables easy comparison of hundreds of Plotly figures.',
     isExact: true,
     title: pageTitlesEnum.FIGURES_EXPLORER,
-    color: '$yellow',
+    color: '#18AB6D',
     category: ExplorersCatsEnum.Trainings,
   },
   AUDIOS_EXPLORER: {
@@ -216,7 +216,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
       'Audio Explorer enables analysis of audio objects in speech-to-text or other speech-related tasks.',
     isExact: true,
     title: pageTitlesEnum.AUDIOS_EXPLORER,
-    color: '$green',
+    color: '#FCB500',
     category: ExplorersCatsEnum.Trainings,
   },
   SCATTERS: {
@@ -229,7 +229,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
     icon: 'scatterplot',
     isExact: true,
     title: pageTitlesEnum.SCATTERS_EXPLORER,
-    color: '$primary',
+    color: '#606986',
     category: ExplorersCatsEnum.Trainings,
   },
   METRICS_EXPLORER: {
@@ -243,7 +243,7 @@ export const explorersRoutes: { [key: string]: IRoute } = {
     isExact: true,
     title: pageTitlesEnum.METRICS_EXPLORER_V2,
     status: RouteStatusEnum.NEW,
-    color: '$purple',
+    color: '#7A4CE0',
     category: ExplorersCatsEnum.Trainings,
   },
 };

--- a/aim/web/ui/src/stories/FormGroup.stories.tsx
+++ b/aim/web/ui/src/stories/FormGroup.stories.tsx
@@ -1,27 +1,25 @@
 import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { IconRotate2 } from '@tabler/icons-react';
 
 import {
   Button,
-  IconButton,
-  Box,
   Text,
   Select,
   ControlsButton,
   Popover,
   ToggleButton,
-  Input,
 } from 'components/kit_v2';
-import FormGroupComponent from 'components/kit_v2/FormGroup/FormGroup';
-import { IFormGroupProps } from 'components/kit_v2/FormGroup/FormGroup.d';
+import FormGroupComponent, {
+  IFormGroupProps,
+} from 'components/kit_v2/FormGroup';
 
 export default {
   title: 'Kit/Data Display',
   component: FormGroupComponent,
   argTypes: {},
 } as ComponentMeta<typeof FormGroupComponent>;
+
 const Template: ComponentStory<typeof FormGroupComponent> = (args) => {
   const [alignment, setAlignment] = React.useState<string>('');
 
@@ -37,7 +35,7 @@ const Template: ComponentStory<typeof FormGroupComponent> = (args) => {
           control: (
             <Select
               trigger={<Button>Select</Button>}
-              // searchable
+              searchable
               popoverProps={{
                 onOpenAutoFocus: (e: any) => {
                   e.stopPropagation();
@@ -73,87 +71,6 @@ const Template: ComponentStory<typeof FormGroupComponent> = (args) => {
                   ],
                 },
               ]}
-            />
-          ),
-        },
-      ],
-    },
-    {
-      sectionFields: [
-        {
-          content: <Text>Y-axis range</Text>,
-          control: (
-            <Box display='flex'>
-              <Input
-                min='0'
-                type='number'
-                css={{ width: '90px', mr: '$5' }}
-                placeholder='Min'
-              />
-              <Input type='number' css={{ width: '90px' }} placeholder='Max' />
-            </Box>
-          ),
-          actions: [
-            {
-              component: (
-                <IconButton
-                  color='secondary'
-                  size='lg'
-                  icon={<IconRotate2 />}
-                  variant='static'
-                />
-              ),
-            },
-          ],
-        },
-        {
-          content: <Text>X-axis range</Text>,
-          control: (
-            <Box display='flex'>
-              <Input css={{ width: '90px', mr: '$5' }} placeholder='Min' />
-              <Input css={{ width: '90px' }} placeholder='Max' />
-            </Box>
-          ),
-          actions: [
-            {
-              component: (
-                <IconButton
-                  color='secondary'
-                  size='lg'
-                  icon={<IconRotate2 />}
-                  variant='static'
-                />
-              ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      sectionFields: [
-        {
-          content: <Text>X-axis scale</Text>,
-          control: (
-            <ToggleButton
-              value='linear'
-              onChange={() => {}}
-              leftLabel='Linear'
-              leftValue='linear'
-              rightLabel='Log'
-              rightValue='log'
-            />
-          ),
-        },
-        {
-          content: <Text>Y-axis scale</Text>,
-          control: (
-            <ToggleButton
-              value='linear'
-              onChange={() => {}}
-              leftLabel='Linear'
-              leftValue='linear'
-              rightLabel='Log'
-              rightValue='log'
             />
           ),
         },

--- a/aim/web/ui/src/stories/Link.stories.tsx
+++ b/aim/web/ui/src/stories/Link.stories.tsx
@@ -5,7 +5,7 @@ import LinkComponent from 'components/kit_v2/Link';
 import { config } from 'config/stitches';
 
 export default {
-  title: 'Kit/Inputs/Link',
+  title: 'Kit/Data Display/Link',
   component: LinkComponent,
   argTypes: {
     color: {


### PR DESCRIPTION
- Match card colors with dashboard theme.
- Set 24px spacing between explorer cards.
- Underline card titles on hover.
- Standardize title font size to 18px across all pages.
- Implement title truncation with ellipsis.