### PR TITLE
[feat] Add python interface for Link component

### DIFF
--- a/src/aim/web/ui/public/aim_ui_core.py
+++ b/src/aim/web/ui/public/aim_ui_core.py
@@ -625,6 +625,23 @@ class Text(Component):
 
         self.render()
 
+
+class Link(Component):
+    def __init__(self, text, to, key=None, block=None):
+        component_type = "Link"
+        component_key = update_viz_map(component_type, key)
+        super().__init__(component_key, component_type, block)
+
+        self.data = to
+
+        self.options = {
+            "text": text,
+            "to": to,
+        }
+
+        self.render()
+
+
 # AimHighLevelComponents
 
 
@@ -944,6 +961,10 @@ class UI:
     def html(self, *args, **kwargs):
         html = HTML(*args, **kwargs, block=self.block_context)
         return html
+
+    def link(self, *args, **kwargs):
+        link = Link(*args, **kwargs, block=self.block_context)
+        return link
 
     # Aim sequence viz components
     def line_chart(self, *args, **kwargs):

--- a/src/aim/web/ui/public/aim_ui_core.py
+++ b/src/aim/web/ui/public/aim_ui_core.py
@@ -627,7 +627,7 @@ class Text(Component):
 
 
 class Link(Component):
-    def __init__(self, text, to, key=None, block=None):
+    def __init__(self, text, to, new_tab=False, key=None, block=None):
         component_type = "Link"
         component_key = update_viz_map(component_type, key)
         super().__init__(component_key, component_type, block)
@@ -637,6 +637,7 @@ class Link(Component):
         self.options = {
             "text": text,
             "to": to,
+            "new_tab": new_tab
         }
 
         self.render()

--- a/src/aim/web/ui/src/components/kit_v2/Link/Link.tsx
+++ b/src/aim/web/ui/src/components/kit_v2/Link/Link.tsx
@@ -9,6 +9,7 @@ import { ILinkProps } from './Link.d';
  * @param {string} [props.fontSize='$5'] - font size
  * @param {string} [props.fontWeight='$2'] - font weight
  * @param {string} [props.color='$primary100'] - color
+ * @param {boolean} [props.ellipsis=false] - ellipsis
  * @param {boolean} [props.underline=true] - underline
  * @param {CSS} [props.css] - css
  * @param {React.ReactNode} [props.children] - children

--- a/src/aim/web/ui/src/pages/Board/components/VisualizationElements/LinkVizElement.tsx
+++ b/src/aim/web/ui/src/pages/Board/components/VisualizationElements/LinkVizElement.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { Link } from 'components/kit_v2';
+
+function LinkVizElement(props: any) {
+  return (
+    <Link css={{ display: 'flex' }} to={props.options.to}>
+      {props.options.text}
+    </Link>
+  );
+}
+export default LinkVizElement;

--- a/src/aim/web/ui/src/pages/Board/components/VisualizationElements/LinkVizElement.tsx
+++ b/src/aim/web/ui/src/pages/Board/components/VisualizationElements/LinkVizElement.tsx
@@ -4,7 +4,11 @@ import { Link } from 'components/kit_v2';
 
 function LinkVizElement(props: any) {
   return (
-    <Link css={{ display: 'flex' }} to={props.options.to}>
+    <Link
+      css={{ display: 'flex' }}
+      to={props.options.to}
+      target={props.options.new_tab ? '_blank' : undefined}
+    >
       {props.options.text}
     </Link>
   );

--- a/src/aim/web/ui/src/pages/Board/components/VisualizationElements/index.ts
+++ b/src/aim/web/ui/src/pages/Board/components/VisualizationElements/index.ts
@@ -120,6 +120,12 @@ const RadioVizElement = React.lazy(
       /* webpackPrefetch: true, webpackChunkName: "Radio" */ './RadioVizElement'
     ),
 );
+const LinkVizElement = React.lazy(
+  () =>
+    import(
+      /* webpackPrefetch: true, webpackChunkName: "Link" */ './LinkVizElement'
+    ),
+);
 
 export type VizElementKey =
   | 'LineChart'
@@ -131,6 +137,7 @@ export type VizElementKey =
   | 'JSON'
   | 'HTML'
   | 'Text'
+  | 'Link'
   | 'Select'
   | 'RunMessages'
   | 'RunLogs'
@@ -159,6 +166,7 @@ const VizElementsMap: Record<VizElementKey, React.FunctionComponent<any>> = {
   JSON: JSONVizElement,
   HTML: HTMLVizElement,
   Text: TextVizElement,
+  Link: LinkVizElement,
 
   // Aim sequence viz components
   LineChart: LineChartVizElement,


### PR DESCRIPTION
Add python interface for Link component which accepts 2 arguments:
- `text`: link content
- `to`: URL to navigate to