### PR TITLE
[feat] Add data live-update functionality to Board

### DIFF
--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -46,14 +46,14 @@ def memoize(func):
     return wrapper
 
 
-query_result_cache = {}
+query_results_cache = {}
 
 
 def query_filter(type_, query="", count=None, start=None, stop=None, isSequence=False):
     query_key = f'{type_}_{query}_{count}_{start}_{stop}'
 
-    if query_key in query_result_cache:
-        return query_result_cache[query_key]
+    if query_key in query_results_cache:
+        return query_results_cache[query_key]
 
     try:
         data = search(board_path, type_, query, count, start, stop, isSequence)
@@ -67,7 +67,7 @@ def query_filter(type_, query="", count=None, start=None, stop=None, isSequence=
             items.append(d)
         data.destroy()
 
-        query_result_cache[query_key] = items
+        query_results_cache[query_key] = items
 
         return items
     except:  # noqa

--- a/src/aimcore/web/ui/src/pages/App/App.d.ts
+++ b/src/aimcore/web/ui/src/pages/App/App.d.ts
@@ -1,9 +1,16 @@
 import { BoardData } from 'modules/core/api/boardsApi';
 
-export interface AppStructureProps {
+export interface AppSidebarProps {
   boards: string[];
   editMode: boolean;
 }
+
+export type AppSidebarNode = {
+  title: string | React.ReactNode;
+  key: string;
+  value: string;
+  children?: AppSidebarNode[];
+};
 
 export interface AppWrapperProps {
   boardPath: string;

--- a/src/aimcore/web/ui/src/pages/App/App.tsx
+++ b/src/aimcore/web/ui/src/pages/App/App.tsx
@@ -1,120 +1,13 @@
 import * as React from 'react';
-import { Route, useLocation } from 'react-router-dom';
-
-import { IconBrandPython, IconPencil } from '@tabler/icons-react';
+import { Route } from 'react-router-dom';
 
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
-import {
-  Box,
-  Breadcrumb,
-  ToastProvider,
-  Toast,
-  Tree,
-  Icon,
-  Text,
-  Link,
-  Button,
-} from 'components/kit_v2';
+import { ToastProvider, Toast } from 'components/kit_v2';
 
-import { TopBar } from 'config/stitches/foundations/layout';
 import { PathEnum } from 'config/enums/routesEnum';
 
-import Board from 'pages/Board/Board';
-import useBoardStore from 'pages/Board/BoardStore';
-
-import { AppStructureProps, AppWrapperProps } from './App.d';
 import useApp from './useApp';
-import { AppContainer, BoardWrapper, BoardLink } from './App.style';
-
-interface Node {
-  title: string | React.ReactNode;
-  key: string;
-  value: string;
-  children?: Node[];
-}
-
-const AppStructure: React.FC<any> = ({
-  boards,
-  editMode,
-}: AppStructureProps) => {
-  const location = useLocation();
-
-  const treeData = React.useMemo((): {
-    tree: Node[];
-    expandedKeys: string[];
-    selectedKeys: string[];
-  } => {
-    let tree: Node[] = [];
-    let expandedKeys: string[] = [];
-    let selectedKeys: string[] = [];
-    let lookup: Record<string, Node> = {};
-
-    // Step 1: Create nodes and build a lookup
-    for (let i = 0; i < boards.length; i++) {
-      const boardPath = `${PathEnum.App}/${boards[i]}`;
-      const isActive = location.pathname.replace('/edit', '') === boardPath;
-      let path = boards[i].split('/');
-      for (let j = 0; j < path.length; j++) {
-        const isLast = j === path.length - 1;
-        let part = path.slice(0, j + 1).join('/');
-        if (isActive) {
-          expandedKeys.push(`${i}-${j}`);
-          if (isLast) {
-            selectedKeys.push(`${i}-${j}`);
-          }
-        }
-        if (!lookup[part]) {
-          let node: Node = {
-            title: isLast ? (
-              <BoardLink
-                key={path[j]}
-                to={`${boardPath}${editMode ? '/edit' : ''}`}
-              >
-                <Icon size='md' icon={<IconBrandPython />} />
-                <Text css={{ ml: '$4' }}>{path[j]}</Text>
-              </BoardLink>
-            ) : (
-              <Text>{path[j]}</Text>
-            ),
-            value: path[j],
-            key: `${i}-${j}`,
-            ...(!isLast && { children: [] }),
-          };
-          lookup[part] = node;
-        }
-      }
-    }
-
-    // Step 2: Build the tree
-    for (let path in lookup) {
-      let node = lookup[path];
-      if (path.indexOf('/') !== -1) {
-        let parentPath = path.substring(0, path.lastIndexOf('/'));
-        lookup[parentPath].children?.push(node);
-      } else {
-        tree.push(node);
-      }
-    }
-    return { tree, expandedKeys, selectedKeys };
-  }, [boards, editMode, location.pathname]);
-
-  return (
-    <Box
-      width={200}
-      css={{
-        borderRight: '1px solid $border30',
-        backgroundColor: '#fff',
-        p: '$3 $4',
-      }}
-    >
-      <Tree
-        selectedKeys={treeData.selectedKeys}
-        expandedKeys={treeData.expandedKeys}
-        data={treeData.tree}
-      />
-    </Box>
-  );
-};
+import AppPage from './components/AppPage';
 
 function App(): React.FunctionComponentElement<React.ReactNode> {
   const { data, isLoading, notifications } = useApp();
@@ -123,20 +16,7 @@ function App(): React.FunctionComponentElement<React.ReactNode> {
     <ErrorBoundary>
       {isLoading ? null : (
         <Route path={[`${PathEnum.App}/*`, `${PathEnum.App}/*/edit`]} exact>
-          {(props: any) => {
-            let boardPath = '';
-            if (props.match?.params?.[0]) {
-              boardPath = props.match.params[0];
-            }
-            const editMode = props.location.pathname.endsWith('/edit');
-            return (
-              <AppWrapper
-                boardList={data}
-                boardPath={boardPath}
-                editMode={editMode!}
-              />
-            );
-          }}
+          {(props) => <AppPage {...props} data={data} />}
         </Route>
       )}
       <ToastProvider
@@ -157,93 +37,6 @@ function App(): React.FunctionComponentElement<React.ReactNode> {
         ))}
       </ToastProvider>
     </ErrorBoundary>
-  );
-}
-
-function AppWrapper({ boardPath, editMode, boardList }: AppWrapperProps) {
-  const path = boardPath?.replace('/edit', '');
-  const board = useBoardStore((state) => state.boards?.[path]);
-  const fetchBoard = useBoardStore((state) => state.fetchBoard);
-  // const updateBoard = useBoardStore((state) => state.editBoard);
-
-  React.useEffect(() => {
-    if (boardPath && !board) {
-      fetchBoard(path);
-    }
-  }, [boardPath]);
-
-  // const saveBoard = (board: any) => {
-  //   updateBoard(boardPath, {
-  //     ...board,
-  //   });
-  // };
-
-  const breadcrumbItems = React.useMemo(() => {
-    const splitPath = path.split('/');
-    let items = [
-      {
-        name: 'App',
-        path: '/app',
-      },
-      {
-        name: splitPath.map((path, index) => {
-          const isLast = index === splitPath.length - 1;
-          return (
-            <Text
-              color={editMode ? '$textPrimary50' : '$textPrimary'}
-              key={index}
-              size='$3'
-              css={{ mx: '$2' }}
-            >
-              {isLast ? path.slice(0, path.length - 3) : `${path} /`}
-            </Text>
-          );
-        }),
-        path: `/app/${path}`,
-      },
-    ];
-    if (editMode) {
-      items.push({
-        name: 'Edit',
-        path: `/app/${path}/edit`,
-      });
-    }
-
-    return items;
-  }, [editMode, path]);
-
-  return (
-    <AppContainer>
-      <TopBar id='app-top-bar'>
-        <Box flex='1 100%'>
-          <Breadcrumb items={breadcrumbItems} />
-        </Box>
-        {board && !editMode && (
-          <Link
-            css={{ display: 'flex' }}
-            to={`${PathEnum.App}/${boardPath}/edit`}
-            underline={false}
-          >
-            <Button variant='outlined' size='xs' rightIcon={<IconPencil />}>
-              Edit
-            </Button>
-          </Link>
-        )}
-      </TopBar>
-      <Box display='flex' height='calc(100% - 28px)'>
-        <AppStructure boards={boardList} editMode={editMode} />
-        <BoardWrapper>
-          {board && (
-            <Board
-              key={board.path + editMode}
-              data={board}
-              editMode={editMode}
-              // saveBoard={saveBoard}
-            />
-          )}
-        </BoardWrapper>
-      </Box>
-    </AppContainer>
   );
 }
 

--- a/src/aimcore/web/ui/src/pages/App/components/AppPage.tsx
+++ b/src/aimcore/web/ui/src/pages/App/components/AppPage.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import AppWrapper from './AppWrapper';
+
+function AppPage({ match, location, data }: any) {
+  let boardPath = '';
+  if (match?.params?.[0]) {
+    boardPath = match.params[0];
+  }
+  const editMode = location.pathname.endsWith('/edit');
+
+  React.useEffect(() => {
+    if (boardPath) {
+      document.title = `${boardPath} | Aim`;
+    }
+  }, [boardPath]);
+
+  return (
+    <AppWrapper boardList={data} boardPath={boardPath} editMode={editMode!} />
+  );
+}
+
+export default AppPage;

--- a/src/aimcore/web/ui/src/pages/App/components/AppSidebar.tsx
+++ b/src/aimcore/web/ui/src/pages/App/components/AppSidebar.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { IconBrandPython } from '@tabler/icons-react';
+
+import { Box, Tree, Icon, Text } from 'components/kit_v2';
+
+import { PathEnum } from 'config/enums/routesEnum';
+
+import { AppSidebarNode, AppSidebarProps } from '../App.d';
+import { BoardLink } from '../App.style';
+
+const AppSidebar: React.FC<any> = ({ boards, editMode }: AppSidebarProps) => {
+  const location = useLocation();
+
+  const treeData = React.useMemo((): {
+    tree: AppSidebarNode[];
+    expandedKeys: string[];
+    selectedKeys: string[];
+  } => {
+    let tree: AppSidebarNode[] = [];
+    let expandedKeys: string[] = [];
+    let selectedKeys: string[] = [];
+    let lookup: Record<string, AppSidebarNode> = {};
+
+    // Step 1: Create nodes and build a lookup
+    for (let i = 0; i < boards.length; i++) {
+      const boardPath = `${PathEnum.App}/${boards[i]}`;
+      const isActive = location.pathname.replace('/edit', '') === boardPath;
+      let path = boards[i].split('/');
+      for (let j = 0; j < path.length; j++) {
+        const isLast = j === path.length - 1;
+        let part = path.slice(0, j + 1).join('/');
+        if (isActive) {
+          expandedKeys.push(`${i}-${j}`);
+          if (isLast) {
+            selectedKeys.push(`${i}-${j}`);
+          }
+        }
+        if (!lookup[part]) {
+          let node: AppSidebarNode = {
+            title: isLast ? (
+              <BoardLink
+                key={path[j]}
+                to={`${boardPath}${editMode ? '/edit' : ''}`}
+              >
+                <Icon size='md' icon={<IconBrandPython />} />
+                <Text css={{ ml: '$4' }}>{path[j]}</Text>
+              </BoardLink>
+            ) : (
+              <Text>{path[j]}</Text>
+            ),
+            value: path[j],
+            key: `${i}-${j}`,
+            ...(!isLast && { children: [] }),
+          };
+          lookup[part] = node;
+        }
+      }
+    }
+
+    // Step 2: Build the tree
+    for (let path in lookup) {
+      let node = lookup[path];
+      if (path.indexOf('/') !== -1) {
+        let parentPath = path.substring(0, path.lastIndexOf('/'));
+        lookup[parentPath].children?.push(node);
+      } else {
+        tree.push(node);
+      }
+    }
+    return { tree, expandedKeys, selectedKeys };
+  }, [boards, editMode, location.pathname]);
+
+  return (
+    <Box
+      width={200}
+      css={{
+        borderRight: '1px solid $border30',
+        backgroundColor: '#fff',
+        p: '$3 $4',
+      }}
+    >
+      <Tree
+        selectedKeys={treeData.selectedKeys}
+        expandedKeys={treeData.expandedKeys}
+        data={treeData.tree}
+      />
+    </Box>
+  );
+};
+
+export default AppSidebar;

--- a/src/aimcore/web/ui/src/pages/App/components/AppWrapper.tsx
+++ b/src/aimcore/web/ui/src/pages/App/components/AppWrapper.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+
+import { IconPencil } from '@tabler/icons-react';
+
+import { Box, Breadcrumb, Text, Link, Button } from 'components/kit_v2';
+
+import { TopBar } from 'config/stitches/foundations/layout';
+import { PathEnum } from 'config/enums/routesEnum';
+
+import Board from 'pages/Board/Board';
+import useBoardStore from 'pages/Board/BoardStore';
+
+import { AppWrapperProps } from '../App.d';
+import { AppContainer, BoardWrapper } from '../App.style';
+
+import AppSidebar from './AppSidebar';
+
+function AppWrapper({ boardPath, editMode, boardList }: AppWrapperProps) {
+  const path = boardPath?.replace('/edit', '');
+  const board = useBoardStore((state) => state.boards?.[path]);
+  const fetchBoard = useBoardStore((state) => state.fetchBoard);
+  // const updateBoard = useBoardStore((state) => state.editBoard);
+
+  React.useEffect(() => {
+    if (boardPath && !board) {
+      fetchBoard(path);
+    }
+  }, [boardPath]);
+
+  // const saveBoard = (board: any) => {
+  //   updateBoard(boardPath, {
+  //     ...board,
+  //   });
+  // };
+
+  const breadcrumbItems = React.useMemo(() => {
+    const splitPath = path.split('/');
+    let items = [
+      {
+        name: 'App',
+        path: '/app',
+      },
+      {
+        name: splitPath.map((path, index) => {
+          const isLast = index === splitPath.length - 1;
+          return (
+            <Text
+              color={editMode ? '$textPrimary50' : '$textPrimary'}
+              key={index}
+              size='$3'
+              css={{ mx: '$2' }}
+            >
+              {isLast ? path.slice(0, path.length - 3) : `${path} /`}
+            </Text>
+          );
+        }),
+        path: `/app/${path}`,
+      },
+    ];
+    if (editMode) {
+      items.push({
+        name: 'Edit',
+        path: `/app/${path}/edit`,
+      });
+    }
+
+    return items;
+  }, [editMode, path]);
+
+  return (
+    <AppContainer>
+      <TopBar id='app-top-bar'>
+        <Box flex='1 100%'>
+          <Breadcrumb items={breadcrumbItems} />
+        </Box>
+        {board && !editMode && (
+          <Link
+            css={{ display: 'flex' }}
+            to={`${PathEnum.App}/${boardPath}/edit`}
+            underline={false}
+          >
+            <Button variant='outlined' size='xs' rightIcon={<IconPencil />}>
+              Edit
+            </Button>
+          </Link>
+        )}
+      </TopBar>
+      <Box display='flex' height='calc(100% - 28px)'>
+        <AppSidebar boards={boardList} editMode={editMode} />
+        <BoardWrapper>
+          {board && (
+            <Board
+              key={board.path + editMode}
+              data={board}
+              editMode={editMode}
+              // saveBoard={saveBoard}
+            />
+          )}
+        </BoardWrapper>
+      </Box>
+    </AppContainer>
+  );
+}
+
+export default AppWrapper;

--- a/src/aimcore/web/ui/src/pages/Board/search.ts
+++ b/src/aimcore/web/ui/src/pages/Board/search.ts
@@ -23,13 +23,12 @@ export function search(
   isSequence: boolean,
   cb?: () => void,
 ) {
-  const queryKey = `${type_}_${query}_${count}_${start}_${stop}`;
+  const queryKey = `${type_}_${query ?? 'None'}_${count ?? 'None'}_${
+    start ?? 'None'
+  }_${stop ?? 'None'}`;
 
-  if (
-    getQueryResultsCacheMap().has(boardPath) &&
-    getQueryResultsCacheMap().get(boardPath).has(queryKey)
-  ) {
-    return getQueryResultsCacheMap().get(boardPath).get(queryKey).data;
+  if (getQueryResultsCacheMap().has(queryKey)) {
+    return getQueryResultsCacheMap().get(queryKey).data;
   }
 
   searchRequest
@@ -117,11 +116,7 @@ export function search(
               isSequence,
             };
 
-            if (!getQueryResultsCacheMap().has(boardPath)) {
-              getQueryResultsCacheMap().set(boardPath, new Map());
-            }
-
-            getQueryResultsCacheMap().get(boardPath).set(queryKey, {
+            getQueryResultsCacheMap().set(queryKey, {
               data: result,
               params: queryParams,
             });
@@ -129,7 +124,7 @@ export function search(
             pyodideEngine.events.fire(
               boardPath as string,
               {
-                query: queryKey,
+                queryKey,
               },
               { savePayload: false },
             );

--- a/src/aimcore/web/ui/src/pages/Board/search.ts
+++ b/src/aimcore/web/ui/src/pages/Board/search.ts
@@ -1,18 +1,17 @@
 import { createFetchDataRequest } from 'modules/core/api/dataFetchApi';
-import {
-  DecodingError,
-  FetchingError,
-} from 'modules/core/pipeline/query/QueryError';
-import AdapterError from 'modules/core/pipeline/adapter/AdapterError';
+// import {
+//   DecodingError,
+//   FetchingError,
+// } from 'modules/core/pipeline/query/QueryError';
+// import AdapterError from 'modules/core/pipeline/adapter/AdapterError';
 
 import pyodideEngine from 'services/pyodide/store';
+import { getQueryResultsCacheMap } from 'services/pyodide/pyodide';
 
 import { parseStream } from 'utils/encoder/streamEncoding';
 import { filterMetricsValues } from 'utils/app/filterMetricData';
 
-const searchRequests = createFetchDataRequest();
-
-const queryResultCacheMap: Record<string, any> = {};
+const searchRequest = createFetchDataRequest();
 
 export function search(
   boardPath: string,
@@ -22,14 +21,18 @@ export function search(
   start: number,
   stop: number,
   isSequence: boolean,
+  cb?: () => void,
 ) {
   const queryKey = `${type_}_${query}_${count}_${start}_${stop}`;
 
-  if (queryResultCacheMap.hasOwnProperty(queryKey)) {
-    return queryResultCacheMap[queryKey];
+  if (
+    getQueryResultsCacheMap().has(boardPath) &&
+    getQueryResultsCacheMap().get(boardPath).has(queryKey)
+  ) {
+    return getQueryResultsCacheMap().get(boardPath).get(queryKey).data;
   }
 
-  searchRequests
+  searchRequest
     .call({
       q: query,
       type_: type_,
@@ -100,7 +103,28 @@ export function search(
               result = objectList;
             }
 
-            queryResultCacheMap[queryKey] = result;
+            if (cb) {
+              cb();
+            }
+
+            const queryParams = {
+              boardPath,
+              type_,
+              query,
+              count,
+              start,
+              stop,
+              isSequence,
+            };
+
+            if (!getQueryResultsCacheMap().has(boardPath)) {
+              getQueryResultsCacheMap().set(boardPath, new Map());
+            }
+
+            getQueryResultsCacheMap().get(boardPath).set(queryKey, {
+              data: result,
+              params: queryParams,
+            });
 
             pyodideEngine.events.fire(
               boardPath as string,

--- a/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
+++ b/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
@@ -17,16 +17,17 @@ export function getQueryResultsCacheMap() {
   return queryResultsCacheMap;
 }
 
-export function clearQueryResultsCache(boardPath?: string, key?: string) {
+export function clearQueryResultsCache(key?: string) {
   let pyodide = pyodideEngine.getPyodideCurrent();
   let namespace = pyodideEngine.getPyodideNamespace();
 
   if (pyodide) {
-    if (boardPath && key) {
+    if (key) {
       pyodide.runPython(`query_results_cache.pop('${key}', None)`, {
         globals: namespace,
       });
-      queryResultsCacheMap.get(boardPath).delete(key);
+
+      queryResultsCacheMap.delete(key);
     } else {
       pyodide.runPython('query_results_cache.clear()', { globals: namespace });
       queryResultsCacheMap = new Map();


### PR DESCRIPTION
Added same query repeating logic with time delay (5s) after the initial (prev) query is resolved.
This PR includes also the following changes:
- File restructuring in `App` directory
- Cache management for queried data:
  - Cleaning cache on board unmounting (page leave, or embedded board removal)
  - Cleaning cache on live-update query resolved