### PR TITLE
[feat] Block pyodide execution while fetching logs

### DIFF
--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -49,6 +49,10 @@ def memoize(func):
 query_results_cache = {}
 
 
+class WaitForQueryError(Exception):
+    pass
+
+
 def query_filter(type_, query="", count=None, start=None, stop=None, isSequence=False):
     query_key = f'{type_}_{query}_{count}_{start}_{stop}'
 
@@ -68,10 +72,12 @@ def query_filter(type_, query="", count=None, start=None, stop=None, isSequence=
         data.destroy()
 
         query_results_cache[query_key] = items
-
         return items
-    except:  # noqa
-        return []
+    except Exception as e:
+        if 'WAIT_FOR_QUERY_RESULT' in str(e):
+            raise WaitForQueryError()
+        else:
+            raise e
 
 
 class Sequence():
@@ -1296,7 +1302,7 @@ class Code(Component):
         self.options = {
             "language": language
         }
-    
+
         self.render()
 
 

--- a/src/aimcore/web/ui/src/pages/Board/Board.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/Board.tsx
@@ -175,6 +175,9 @@ board_path=${boardPath === undefined ? 'None' : `"${boardPath}"`}
           isProcessing: false,
         }));
       } catch (ex: any) {
+        if (ex.type === 'WaitForQueryError') {
+          return;
+        }
         // eslint-disable-next-line no-console
         console.log(ex);
         setState((s: any) => ({


### PR DESCRIPTION
Catch `WAIT_FOR_QUERY_RESULT` error and raise an exception to stop the execution to avoid wrong usage of fallback data