### PR TITLE
[fix] Resolve DictVisualizer collapsed keys reset issue

### DIFF
--- a/src/aimcore/web/ui/src/components/kit/DictVisualizer/DictVisualizer.tsx
+++ b/src/aimcore/web/ui/src/components/kit/DictVisualizer/DictVisualizer.tsx
@@ -67,7 +67,7 @@ function DictVisualizer(props: IDictVisualizerProps) {
 
       setRows(newRows);
     }
-  }, [collapsedItems, initialRows]);
+  }, [collapsedItems, initialRows, props.src]);
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
During re-render when JSON object reference is being changed the collapsed keys are not being taken into account.
Added `props.src` as a dependency for `useEffect` for dict's rows collecting.