### PR TITLE
[refactor] Improve performance of dict flattening for board runs

### DIFF
--- a/pkgs/aimstack/asp/boards/run.py
+++ b/pkgs/aimstack/asp/boards/run.py
@@ -27,14 +27,14 @@ else:
 
 @memoize
 def flatten(dictionary, parent_key='', separator='.'):
-    items = []
+    flattened = {}
     for key, value in dictionary.items():
-        new_key = parent_key + separator + key if parent_key else key
+        new_key = f"{parent_key}{separator}{key}" if parent_key else key
         if isinstance(value, MutableMapping):
-            items.extend(flatten(value, new_key, separator=separator).items())
+            flattened.update(flatten(value, new_key, separator=separator))
         else:
-            items.append((new_key, value))
-    return dict(items)
+            flattened[new_key] = value
+    return flattened
 
 
 @memoize

--- a/pkgs/aimstack/asp/boards/runs.py
+++ b/pkgs/aimstack/asp/boards/runs.py
@@ -9,14 +9,14 @@ runs = Run.filter(query)
 
 
 def flatten(dictionary, parent_key='', separator='.'):
-    items = []
+    flattened = {}
     for key, value in dictionary.items():
-        new_key = parent_key + separator + key if parent_key else key
+        new_key = f"{parent_key}{separator}{key}" if parent_key else key
         if isinstance(value, MutableMapping):
-            items.extend(flatten(value, new_key, separator=separator).items())
+            flattened.update(flatten(value, new_key, separator=separator))
         else:
-            items.append((new_key, value))
-    return dict(items)
+            flattened[new_key] = value
+    return flattened
 
 
 @memoize


### PR DESCRIPTION
Performance improvements for utility dict flattening: 

1. f-strings are faster even for three items.
2. Using one dict to avoid allocation of intermediate dicts.

*Bonus point (not included)*: changing `MutableMapping` to `dict` in type checking will make it twice as fast.