### PR TITLE
[fix] Add fallback json rendering for None value

### DIFF
--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -1740,6 +1740,10 @@ class UI:
         return plotly_chart
 
     def json(self, *args, **kwargs):
+        if (len(args) > 0 and (args[0] is None)) or ("data" in kwargs and (kwargs["data"] is None)):
+            text = Text('None', mono=True, block=self.block_context)
+            return text
+        
         json = JSON(*args, **kwargs, block=self.block_context)
         return json
 


### PR DESCRIPTION
When passing `None` to `ui.json` a `Something went wrong` error is being thrown.

Use fallback monospace text rendering to prevent the board page from crashing.