### PR TITLE
[feat] Enable resending requests ignoring cache

### DIFF
--- a/pkgs/aimstack/asp/boards/audios.py
+++ b/pkgs/aimstack/asp/boards/audios.py
@@ -3,12 +3,14 @@ import math
 
 c_hash = session_state.get('container_hash')
 
+search_signal = "search"
+
 if c_hash is None:
     ui.header("Audios")
-    form = ui.form("Search")
+    form = ui.form("Search", signal=search_signal)
     query = form.text_input(value="")
 
-audios = AudioSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query)
+audios = AudioSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key="", separator="."):

--- a/pkgs/aimstack/asp/boards/figures.py
+++ b/pkgs/aimstack/asp/boards/figures.py
@@ -3,12 +3,14 @@ import math
 
 c_hash = session_state.get('container_hash')
 
+search_signal = "search"
+
 if c_hash is None:
     ui.header("Figures")
-    form = ui.form("Search")
+    form = ui.form("Search", signal=search_signal)
     query = form.text_input(value="")
 
-figures = FigureSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query)
+figures = FigureSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key='', separator='.'):

--- a/pkgs/aimstack/asp/boards/images.py
+++ b/pkgs/aimstack/asp/boards/images.py
@@ -3,13 +3,15 @@ import math
 
 c_hash = session_state.get('container_hash')
 
+search_signal = "search"
+
 if c_hash is None:
     ui.header("Images")
-    form = ui.form("Search")
+    form = ui.form("Search", signal=search_signal)
     query = form.text_input(value="")
 
 
-images = ImageSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query)
+images = ImageSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key='', separator='.'):

--- a/pkgs/aimstack/asp/boards/metrics.py
+++ b/pkgs/aimstack/asp/boards/metrics.py
@@ -4,12 +4,14 @@ import math
 
 c_hash = session_state.get('container_hash')
 
+search_signal = Signal('search', properties=["focused_row"])
+
 if c_hash is None:
     ui.header("Metrics")
-    form = ui.form("Search")
+    form = ui.form("Search", signal=search_signal.name)
     query = form.text_input(value="")
 
-metrics = Metric.filter(f'c.hash=="{c_hash}"' if c_hash else query)
+metrics = Metric.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal.name)
 
 
 def flatten(dictionary, parent_key='', separator='.'):
@@ -95,7 +97,7 @@ if metrics:
     )
     row2.table(table_data, {
         'container.hash': lambda val: ui.board_link('run.py', val, state={'container_hash': val}),
-    })
+    }, selectable_rows=True, signal=search_signal.name)
 
 else:
     ui.text('No metrics found')

--- a/pkgs/aimstack/asp/boards/metrics.py
+++ b/pkgs/aimstack/asp/boards/metrics.py
@@ -4,14 +4,14 @@ import math
 
 c_hash = session_state.get('container_hash')
 
-search_signal = Signal('search', properties=["focused_row"])
+search_signal = "search"
 
 if c_hash is None:
     ui.header("Metrics")
-    form = ui.form("Search", signal=search_signal.name)
+    form = ui.form("Search", signal=search_signal)
     query = form.text_input(value="")
 
-metrics = Metric.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal.name)
+metrics = Metric.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key='', separator='.'):
@@ -97,7 +97,7 @@ if metrics:
     )
     row2.table(table_data, {
         'container.hash': lambda val: ui.board_link('run.py', val, state={'container_hash': val}),
-    }, selectable_rows=True, signal=search_signal.name)
+    })
 
 else:
     ui.text('No metrics found')

--- a/pkgs/aimstack/asp/boards/runs.py
+++ b/pkgs/aimstack/asp/boards/runs.py
@@ -1,8 +1,12 @@
 from asp import Run
 
-form = ui.form('Search')
+search_signal = "search"
+
+form = ui.form('Search', signal=search_signal)
+
 query = form.text_input(value='')
-runs = Run.filter(query)
+
+runs = Run.filter(query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key='', separator='.'):

--- a/pkgs/aimstack/asp/boards/texts.py
+++ b/pkgs/aimstack/asp/boards/texts.py
@@ -3,12 +3,14 @@ import math
 
 c_hash = session_state.get('container_hash')
 
+search_signal = "search"
+
 if c_hash is None:
     ui.header('Texts')
-    form = ui.form("Search")
+    form = ui.form("Search", signal=search_signal)
     query = form.text_input(value="")
 
-texts = TextSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query)
+texts = TextSequence.filter(f'c.hash=="{c_hash}"' if c_hash else query, signal=search_signal)
 
 
 def flatten(dictionary, parent_key='', separator='.'):

--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -76,7 +76,7 @@ def dispatch_signal(signal_name=None, properties=None):
     if signal_name is not None:
         signal = signals_store.get(signal_name, None)
         signal_properties = signal.get("properties", None)
-        print('-----', properties, signal_properties)
+
         if (signal is None) or (
             properties is not None and 
             signal_properties is not None and 

--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -2,7 +2,7 @@
 # Bindings for fetching Aim Objects
 ####################
 
-from js import search, runFunction, findItem, encodeURIComponent
+from js import search, runFunction, findItem, clearQueryResultsCache, encodeURIComponent
 import json
 import hashlib
 
@@ -48,6 +48,47 @@ def memoize(func):
 
 query_results_cache = {}
 
+signals_store = {}
+
+
+class Signal:
+    def __init__(self, name, properties=None):
+        self.name = name
+        self.properties = properties
+
+        signals_store[self.name] = {
+            "properties": self.properties,
+            "query_keys": [],
+        }
+
+
+def register_signal(signal=None, query_key=None):
+    if (signal is not None) and (query_key is not None): 
+        if (signal not in signals_store):
+            signals_store[signal] = {
+                "properties": None,
+                "query_keys": [query_key]
+            }
+        else:
+            signals_store[signal]["query_keys"].append(query_key)
+
+def dispatch_signal(signal_name=None, properties=None):
+    if signal_name is not None:
+        signal = signals_store.get(signal_name, None)
+        signal_properties = signal.get("properties", None)
+        print('-----', properties, signal_properties)
+        if (signal is None) or (
+            properties is not None and 
+            signal_properties is not None and 
+            not any(key in properties for key in signal_properties)
+            ):
+            return
+        
+        for key in signal.get("query_keys", []):
+            clearQueryResultsCache(key)
+
+        signals_store[signal_name]["query_keys"] = []
+
 
 class WaitForQueryError(Exception):
     pass
@@ -69,8 +110,11 @@ def process_properties(obj: dict):
     return obj
 
 
-def query_filter(type_, query="", count=None, start=None, stop=None, is_sequence=False):
+def query_filter(type_, query="", count=None, start=None, stop=None, is_sequence=False, signal=None):
     query_key = f"{type_}_{query}_{count}_{start}_{stop}"
+
+    if (signal is not None): 
+        register_signal(signal, query_key)
 
     if query_key in query_results_cache:
         return query_results_cache[query_key]
@@ -92,8 +136,11 @@ def query_filter(type_, query="", count=None, start=None, stop=None, is_sequence
             raise e
 
 
-def run_function(func_name, params):
+def run_function(func_name, params, signal=None):
     run_function_key = f"{func_name}_{json.dumps(params)}"
+
+    if (signal is not None): 
+        register_signal(signal, run_function_key)
 
     if run_function_key in query_results_cache:
         return query_results_cache[run_function_key]
@@ -111,11 +158,15 @@ def run_function(func_name, params):
             raise e
 
 
-def find_item(type_, is_sequence=False, hash_=None, name=None, ctx=None):
+def find_item(type_, is_sequence=False, hash_=None, name=None, ctx=None, signal=None):
     if ctx is not None:
         ctx = json.dumps(ctx)
     
     query_key = f"{type_}_{hash_}_{name}_{ctx}"
+
+
+    if (signal is not None): 
+        register_signal(signal, query_key)
 
     if query_key in query_results_cache:
         return query_results_cache[query_key]
@@ -368,7 +419,7 @@ class Block(Element):
 
 
 class Component(Element):
-    def __init__(self, key, type_, block):
+    def __init__(self, key, type_, signal, block):
         super().__init__(block)
         self.key = key
         self.type = type_
@@ -381,6 +432,8 @@ class Component(Element):
             else {}
         )
         self.no_facet = True
+
+        self.signal = signal
 
     def set_state(self, value, persist=True):
         should_batch = (
@@ -408,6 +461,9 @@ class Component(Element):
 
             set_state({state_key: state_slice}, self.board_path, persist=False)
         else:
+            if self.signal is not None:
+                dispatch_signal(self.signal, list(value.keys()))
+                    
             state_slice = (
                 state[self.board_path][self.key]
                 if (self.board_path in state and self.key in state[self.board_path])
@@ -475,11 +531,11 @@ class AimSequenceComponent(Component):
 
 class LineChart(AimSequenceComponent):
     def __init__(
-        self, data, x, y, color=[], stroke_style=[], options={}, key=None, block=None
+        self, data, x, y, color=[], stroke_style=[], options={}, key=None, signal=None, block=None
     ):
         component_type = "LineChart"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
         stroke_map, stroke_data = group(
@@ -531,11 +587,11 @@ class LineChart(AimSequenceComponent):
 
 class NivoLineChart(AimSequenceComponent):
     def __init__(
-        self, data, x, y, color=[], stroke_style=[], options={}, key=None, block=None
+        self, data, x, y, color=[], stroke_style=[], options={}, key=None, signal=None, block=None
     ):
         component_type = "NivoLineChart"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
         stroke_map, stroke_data = group(
@@ -565,10 +621,10 @@ class NivoLineChart(AimSequenceComponent):
 
 
 class BarChart(AimSequenceComponent):
-    def __init__(self, data, x, y, color=[], options={}, key=None, block=None):
+    def __init__(self, data, x, y, color=[], options={}, key=None, signal=None, block=None):
         component_type = "BarChart"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
         bars = []
@@ -603,11 +659,11 @@ class BarChart(AimSequenceComponent):
 
 class ScatterPlot(AimSequenceComponent):
     def __init__(
-        self, data, x, y, color=[], stroke_style=[], options={}, key=None, block=None
+        self, data, x, y, color=[], stroke_style=[], options={}, key=None, signal=None, block=None
     ):
         component_type = "ScatterPlot"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
         stroke_map, stroke_data = group(
@@ -646,11 +702,12 @@ class ParallelPlot(AimSequenceComponent):
         stroke_style=[],
         options={},
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "ParallelPlot"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
         stroke_map, stroke_data = group(
@@ -683,10 +740,10 @@ class ParallelPlot(AimSequenceComponent):
 
 
 class ImagesList(AimSequenceComponent):
-    def __init__(self, data, key=None, block=None):
+    def __init__(self, data, key=None, signal=None, block=None):
         component_type = "Images"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         images = []
 
@@ -702,10 +759,10 @@ class ImagesList(AimSequenceComponent):
 
 
 class AudiosList(AimSequenceComponent):
-    def __init__(self, data, key=None, block=None):
+    def __init__(self, data, key=None, signal=None, block=None):
         component_type = "Audios"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         audios = []
 
@@ -721,10 +778,10 @@ class AudiosList(AimSequenceComponent):
 
 
 class TextsList(AimSequenceComponent):
-    def __init__(self, data, color=[], key=None, block=None):
+    def __init__(self, data, color=[], key=None, signal=None, block=None):
         component_type = "Texts"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         color_map, color_data = group("color", data, color, component_key)
 
@@ -746,10 +803,10 @@ class TextsList(AimSequenceComponent):
 
 
 class FiguresList(AimSequenceComponent):
-    def __init__(self, data, key=None, block=None):
+    def __init__(self, data, key=None, signal=None, block=None):
         component_type = "Figures"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         figures = []
 
@@ -765,10 +822,10 @@ class FiguresList(AimSequenceComponent):
 
 
 class Union(Component):
-    def __init__(self, components, key=None, block=None):
+    def __init__(self, components, key=None, signal=None, block=None):
         component_type = "Union"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         for i, elem in reversed(list(enumerate(current_layout))):
             for comp in components:
@@ -794,10 +851,10 @@ class Union(Component):
 
 
 class Plotly(Component):
-    def __init__(self, fig, key=None, block=None):
+    def __init__(self, fig, key=None, signal=None, block=None):
         component_type = "Plotly"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # TODO: validate plotly figure
         # fig = validate(fig, dict, "fig")
@@ -808,10 +865,10 @@ class Plotly(Component):
 
 
 class JSON(Component):
-    def __init__(self, data, key=None, block=None):
+    def __init__(self, data, key=None, signal=None, block=None):
         component_type = "JSON"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         # TODO validate data is a JSON
@@ -822,10 +879,10 @@ class JSON(Component):
 
 
 class DataFrame(Component):
-    def __init__(self, data, key=None, block=None):
+    def __init__(self, data, key=None, signal=None, block=None):
         component_type = "DataFrame"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         # TODO: validate data is a dataframe
@@ -836,10 +893,10 @@ class DataFrame(Component):
 
 
 class Table(Component):
-    def __init__(self, data, renderer={}, selectable_rows=False, key=None, block=None):
+    def __init__(self, data, renderer={}, selectable_rows=False, key=None, signal=None, block=None):
         component_type = "Table"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         data = validate(data, dict, "data")
@@ -934,11 +991,12 @@ class Text(Component):
         color="$textPrimary",
         mono=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "Text"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         text = validate(text, str, "text")
@@ -962,10 +1020,10 @@ class Text(Component):
 
 
 class Link(Component):
-    def __init__(self, text, to, new_tab=False, key=None, block=None):
+    def __init__(self, text, to, new_tab=False, key=None, signal=None, block=None):
         component_type = "Link"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         text = validate(text, str, "text")
@@ -980,9 +1038,9 @@ class Link(Component):
 
 
 class TypographyComponent(Component):
-    def __init__(self, text, component_type, options=None, key=None, block=None):
+    def __init__(self, text, component_type, options=None, key=None, signal=None, block=None):
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         self.data = text
         self.options = options
@@ -991,30 +1049,30 @@ class TypographyComponent(Component):
 
 
 class Header(TypographyComponent):
-    def __init__(self, text, key=None, block=None):
+    def __init__(self, text, key=None, signal=None, block=None):
         # validate all arguments passed in
         text = validate(text, str, "text")
 
         # set the properties/options for this component
         options = {"component": "h2", "size": "$9"}
-        super().__init__(text, "Header", options, key, block)
+        super().__init__(text, "Header", options, key, signal, block)
 
 
 class SubHeader(TypographyComponent):
-    def __init__(self, text, key=None, block=None):
+    def __init__(self, text, key=None, signal=None, block=None):
         # validate all arguments passed in
         text = validate(text, str, "text")
 
         # set the properties/options for this component
         options = {"component": "h3", "size": "$6"}
-        super().__init__(text, "SubHeader", options, key, block)
+        super().__init__(text, "SubHeader", options, key, signal, block)
 
 
 class Code(Component):
-    def __init__(self, text, language="python", key=None, block=None):
+    def __init__(self, text, language="python", key=None, signal=None, block=None):
         component_type = "Code"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         text = validate(text, str, "text")
@@ -1027,10 +1085,10 @@ class Code(Component):
 
 
 class HTML(Component):
-    def __init__(self, text, key=None, block=None):
+    def __init__(self, text, key=None, signal=None, block=None):
         component_type = "HTML"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         data = validate(text, str, "data")
@@ -1041,10 +1099,10 @@ class HTML(Component):
 
 
 class Markdown(Component):
-    def __init__(self, text, key=None, block=None):
+    def __init__(self, text, key=None, signal=None, block=None):
         component_type = "Markdown"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         data = validate(text, str, "data")
@@ -1058,10 +1116,10 @@ class Markdown(Component):
 
 
 class Explorer(Component):
-    def __init__(self, name, query="", key=None, block=None):
+    def __init__(self, name, query="", key=None, signal=None, block=None):
         component_type = "Explorer"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         self.data = name
 
@@ -1126,11 +1184,12 @@ class Slider(Component):
         step=None,
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "Slider"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1185,11 +1244,12 @@ class RangeSlider(Component):
         step=None,
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "RangeSlider"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1235,10 +1295,10 @@ class RangeSlider(Component):
 
 
 class TextInput(Component):
-    def __init__(self, label="", value="", disabled=False, key=None, block=None):
+    def __init__(self, label="", value="", disabled=False, key=None, signal=None, block=None):
         component_type = "TextInput"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1279,11 +1339,12 @@ class NumberInput(Component):
         step=None,
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "NumberInput"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1337,11 +1398,12 @@ class Select(Component):
         searchable=None,
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "Select"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1389,11 +1451,12 @@ class MultiSelect(Component):
         searchable=None,
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "Select"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1440,11 +1503,11 @@ class MultiSelect(Component):
 
 class Switch(Component):
     def __init__(
-        self, label="", checked=False, size="md", disabled=False, key=None, block=None
+        self, label="", checked=False, size="md", disabled=False, key=None, signal=None, block=None
     ):
         component_type = "Switch"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1487,11 +1550,12 @@ class TextArea(Component):
         caption="",
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "TextArea"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1537,11 +1601,12 @@ class Radio(Component):
         orientation="vertical",
         disabled=False,
         key=None,
+        signal=None,
         block=None,
     ):
         component_type = "Radio"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1577,10 +1642,10 @@ class Radio(Component):
 
 
 class Checkbox(Component):
-    def __init__(self, label="", checked=False, disabled=False, key=None, block=None):
+    def __init__(self, label="", checked=False, disabled=False, key=None, signal=None, block=None):
         component_type = "Checkbox"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1620,11 +1685,12 @@ class ToggleButton(Component):
         index=0,
         disabled=False,
         block=None,
+        signal=None,
         key=None,
     ):
         component_type = "ToggleButton"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         batch_state = get_component_batch_state(component_key, block)
 
@@ -1663,10 +1729,10 @@ class ToggleButton(Component):
 
 
 class Board(Component):
-    def __init__(self, path, state={}, block=None, key=None):
+    def __init__(self, path, state={}, key=None, signal=None, block=None):
         component_type = "Board"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         path = validate(path, str, "path")
@@ -1689,11 +1755,11 @@ class Board(Component):
 
 class BoardLink(Component):
     def __init__(
-        self, path, text="Go To Board", new_tab=False, state={}, block=None, key=None
+        self, path, text="Go To Board", new_tab=False, state={}, key=None, signal=None, block=None
     ):
         component_type = "BoardLink"
         component_key = update_viz_map(component_type, key)
-        super().__init__(component_key, component_type, block)
+        super().__init__(component_key, component_type, signal, block)
 
         # validate all arguments passed in
         path = validate(path, str, "path")
@@ -1919,8 +1985,10 @@ class Tabs(Block, UI):
 
 
 class Form(Block, UI):
-    def __init__(self, submit_button_label="Submit", block=None):
+    def __init__(self, submit_button_label="Submit", signal=None, block=None):
         super().__init__("form", block=block)
+
+        self.signal = signal
 
         self.options = {"submit_button_label": submit_button_label}
         self.callbacks = {"on_submit": self.submit}
@@ -1928,8 +1996,11 @@ class Form(Block, UI):
         self.render()
 
     def submit(self):
+        if self.signal is not None:
+            dispatch_signal(self.signal)
+
         batch_id = f'__form__{self.block_context["id"]}'
-        state_update = state[board_path][batch_id]
+        state_update = state[board_path].get(batch_id, {})
         set_state(state_update, board_path=self.board_path)
 
 

--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -52,9 +52,9 @@ signals_store = {}
 
 
 # Signals are being used to invalidate query results cache on specific state updates
-# By binding queries and components with them same signal you can control when to invalidate query results cache
+# By binding queries and components with the same signal you can control when to invalidate query results cache
 # You can use signals as primitive strings or as Signal class instances
-# With Signal class you can also specify properties that should be present in state update to invalidate query results cache
+# With Signal class, you can also specify properties that should be present in state update to invalidate query results cache
 
 class Signal:
     def __init__(self, name, properties=None):

--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -52,7 +52,7 @@ signals_store = {}
 
 
 # Signals are being used to invalidate query results cache on specific state updates
-# By binding queries and components with them same singal you can control when to invalidate query results cache
+# By binding queries and components with them same signal you can control when to invalidate query results cache
 # You can use signals as primitive strings or as Signal class instances
 # With Signal class you can also specify properties that should be present in state update to invalidate query results cache
 

--- a/src/aimcore/web/ui/public/aim_ui_core.py
+++ b/src/aimcore/web/ui/public/aim_ui_core.py
@@ -51,6 +51,11 @@ query_results_cache = {}
 signals_store = {}
 
 
+# Signals are being used to invalidate query results cache on specific state updates
+# By binding queries and components with them same singal you can control when to invalidate query results cache
+# You can use signals as primitive strings or as Signal class instances
+# With Signal class you can also specify properties that should be present in state update to invalidate query results cache
+
 class Signal:
     def __init__(self, name, properties=None):
         self.name = name
@@ -63,6 +68,8 @@ class Signal:
 
 
 def register_signal(signal=None, query_key=None):
+    """Binds query key to signal. When signal is dispatched, query results cache will be invalidated"""
+
     if (signal is not None) and (query_key is not None): 
         if (signal not in signals_store):
             signals_store[signal] = {
@@ -73,6 +80,8 @@ def register_signal(signal=None, query_key=None):
             signals_store[signal]["query_keys"].append(query_key)
 
 def dispatch_signal(signal_name=None, properties=None):
+    """Dispatches signal. Cleares query results cache for all query keys bound to signal"""
+
     if signal_name is not None:
         signal = signals_store.get(signal_name, None)
         signal_properties = signal.get("properties", None)

--- a/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
+++ b/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
@@ -317,32 +317,52 @@ export async function loadPyodideInstance() {
       let dataTypeName = containerType.slice(`${packageName}.`.length);
 
       jsModule[dataTypeName] = {
-        filter: (query: string = '', signal: string = '') => {
-          if (signal === '') {
-            signal = 'None';
-          } else {
+        filter: (...args: any[]) => {
+          let queryArgs: Record<string, string | number> = {
+            query: '',
+          };
+          for (let i = 0; i < args.length; i++) {
+            if (typeof args[i] === 'object') {
+              Object.assign(queryArgs, args[i]);
+            } else {
+              queryArgs[i] = args[i];
+            }
+          }
+
+          let query = JSON.stringify(queryArgs[0] ?? queryArgs['query']);
+          let signal = queryArgs[1] ?? queryArgs['signal'] ?? 'None';
+
+          if (signal !== 'None') {
             signal = JSON.stringify(signal);
           }
 
           let val = pyodide.runPython(
-            `query_filter('${containerType}', ${JSON.stringify(
-              query,
-            )}, None, None, None, False, ${signal})`,
+            `query_filter('${containerType}', ${query}, None, None, None, False, ${signal})`,
             { globals: namespace },
           );
           return val;
         },
-        find: (hash_: string, signal: string = '') => {
-          if (signal === '') {
-            signal = 'None';
-          } else {
+        find: (...args: any[]) => {
+          let queryArgs: Record<string, string | number> = {
+            hash_: '',
+          };
+          for (let i = 0; i < args.length; i++) {
+            if (typeof args[i] === 'object') {
+              Object.assign(queryArgs, args[i]);
+            } else {
+              queryArgs[i] = args[i];
+            }
+          }
+
+          let hash_ = JSON.stringify(queryArgs[0] ?? queryArgs['hash_']);
+          let signal = queryArgs[1] ?? queryArgs['signal'] ?? 'None';
+
+          if (signal !== 'None') {
             signal = JSON.stringify(signal);
           }
 
           let val = pyodide.runPython(
-            `find_item('${containerType}', False, ${JSON.stringify(
-              hash_,
-            )}, ${signal})`,
+            `find_item('${containerType}', False, ${hash_}, ${signal})`,
             { globals: namespace },
           );
           return val;

--- a/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
+++ b/src/aimcore/web/ui/src/services/pyodide/pyodide.ts
@@ -15,6 +15,7 @@ declare global {
     search: Function;
     runFunction: Function;
     findItem: Function;
+    clearQueryResultsCache: Function;
     updateLayout: Function;
     setState: Function;
     pyodideEngine: typeof pyodideEngine;
@@ -24,6 +25,7 @@ declare global {
 window.search = search;
 window.runFunction = runFunction;
 window.findItem = find;
+window.clearQueryResultsCache = clearQueryResultsCache;
 
 let queryResultsCacheMap: Map<string, any> = new Map();
 let pendingQueriesMap: Map<string, Map<string, any>> = new Map();
@@ -38,9 +40,12 @@ export function clearQueryResultsCache(key?: string) {
 
   if (pyodide) {
     if (key) {
-      pyodide.runPython(`query_results_cache.pop('${key}', None)`, {
-        globals: namespace,
-      });
+      pyodide.runPython(
+        `query_results_cache.pop(${JSON.stringify(key)}, None)`,
+        {
+          globals: namespace,
+        },
+      );
 
       queryResultsCacheMap.delete(key);
     } else {
@@ -255,12 +260,18 @@ export async function loadPyodideInstance() {
             }
           }
 
+          let query = JSON.stringify(queryArgs[0] ?? queryArgs['query']);
+          let count = queryArgs[1] ?? queryArgs['count'] ?? 'None';
+          let start = queryArgs[2] ?? queryArgs['start'] ?? 'None';
+          let stop = queryArgs[3] ?? queryArgs['stop'] ?? 'None';
+          let signal = queryArgs[4] ?? queryArgs['signal'] ?? 'None';
+
+          if (signal !== 'None') {
+            signal = JSON.stringify(signal);
+          }
+
           let val = pyodide.runPython(
-            `query_filter('${sequenceType}', ${JSON.stringify(
-              queryArgs[0] ?? queryArgs['query'],
-            )}, ${queryArgs[1] ?? queryArgs['count'] ?? 'None'}, ${
-              queryArgs[2] ?? queryArgs['start'] ?? 'None'
-            }, ${queryArgs[3] ?? queryArgs['stop'] ?? 'None'}, True)`,
+            `query_filter('${sequenceType}', ${query}, ${count}, ${start}, ${stop}, True, ${signal})`,
             { globals: namespace },
           );
 
@@ -284,11 +295,16 @@ export async function loadPyodideInstance() {
           let hash_ = queryArgs[0] ?? queryArgs['hash_'];
           let name = queryArgs[1] ?? queryArgs['name'];
           let ctx = queryArgs[2] ?? queryArgs['context'];
+          let signal = queryArgs[3] ?? queryArgs['signal'] ?? 'None';
+
+          if (signal !== 'None') {
+            signal = JSON.stringify(signal);
+          }
 
           let val = pyodide.runPython(
             `find_item('${sequenceType}', True, ${JSON.stringify(
               hash_,
-            )}, ${JSON.stringify(name)}, ${ctx})`,
+            )}, ${JSON.stringify(name)}, ${ctx}, ${signal})`,
             { globals: namespace },
           );
 
@@ -301,18 +317,32 @@ export async function loadPyodideInstance() {
       let dataTypeName = containerType.slice(`${packageName}.`.length);
 
       jsModule[dataTypeName] = {
-        filter: (query: string = '') => {
+        filter: (query: string = '', signal: string = '') => {
+          if (signal === '') {
+            signal = 'None';
+          } else {
+            signal = JSON.stringify(signal);
+          }
+
           let val = pyodide.runPython(
             `query_filter('${containerType}', ${JSON.stringify(
               query,
-            )}, None, None, None, False)`,
+            )}, None, None, None, False, ${signal})`,
             { globals: namespace },
           );
           return val;
         },
-        find: (hash_: string) => {
+        find: (hash_: string, signal: string = '') => {
+          if (signal === '') {
+            signal = 'None';
+          } else {
+            signal = JSON.stringify(signal);
+          }
+
           let val = pyodide.runPython(
-            `find_item('${containerType}', False, ${JSON.stringify(hash_)})`,
+            `find_item('${containerType}', False, ${JSON.stringify(
+              hash_,
+            )}, ${signal})`,
             { globals: namespace },
           );
           return val;
@@ -332,8 +362,15 @@ export async function loadPyodideInstance() {
             funcArgs[i] = args[i];
           }
         }
+
+        if (funcArgs['signal']) {
+          funcArgs['signal'] = JSON.stringify(funcArgs['signal']);
+        }
+
         let val = pyodide.runPython(
-          `run_function('${func_name}', ${JSON.stringify(funcArgs)})`,
+          `run_function('${func_name}', ${JSON.stringify(
+            _.omit(funcArgs, ['signal']),
+          )}, ${funcArgs['signal']})`,
           { globals: namespace },
         );
         return val;


### PR DESCRIPTION
- Signals are being used to invalidate query results cache on specific state updates
- By binding queries and components with the same signal you can control when to invalidate query results cache
- You can use signals as primitive strings or as Signal class instances
- With Signal class, you can also specify properties that should be present in state update to invalidate query results cache
