### PR TITLE
[fix] replace deprecated api from mlflow

### DIFF
--- a/src/aimcore/cli/convert/processors/mlflow.py
+++ b/src/aimcore/cli/convert/processors/mlflow.py
@@ -43,7 +43,7 @@ def parse_mlflow_logs(repo_inst, tracking_uri, experiment):
 
     if experiment is None:
         # process all experiments
-        experiments = client.list_experiments()
+        experiments = client.search_experiments()
     else:
         try:
             ex = client.get_experiment(experiment)

--- a/src/aimcore/cli/convert/processors/mlflow.py
+++ b/src/aimcore/cli/convert/processors/mlflow.py
@@ -42,8 +42,17 @@ def parse_mlflow_logs(repo_inst, tracking_uri, experiment):
     client = mlflow.tracking.client.MlflowClient(tracking_uri=tracking_uri)
 
     if experiment is None:
+        # Due to MLflow API update, we need to check the version
+        # For versions >= 1.28.0, we need to use search_experiments
+        # Otherwise, we need to use list_experiments
+        from packaging import version
+        MLFLOW_VERSION = version.parse(mlflow.__version__) >= version.parse('1.28.0')
+
         # process all experiments
-        experiments = client.search_experiments()
+        if MLFLOW_VERSION:
+            experiments = client.search_experiments()
+        else:
+            experiments = client.list_experiments()
     else:
         try:
             ex = client.get_experiment(experiment)


### PR DESCRIPTION
To fix #2984, we simply need to replace `list_experiment` with `search_experiments` in [src/aimcore/cli/convert/processors/mlflow.py](https://github.com/aimhubio/aim/blob/1737b2d3573793ad30287d9335952ae7ce58a067/src/aimcore/cli/convert/processors/mlflow.py#L46).

By the way, I've been working at a company for a year, but I've never submitted a PR to an open source project before. I hope this contribution can be of help!