### PR TITLE
[feat] Add loading bar for API requests in boards

### DIFF
--- a/src/aimcore/web/ui/src/pages/Board/Board.style.ts
+++ b/src/aimcore/web/ui/src/pages/Board/Board.style.ts
@@ -263,6 +263,16 @@ const BoardBlockTab = styled('div', {
   gap: '$13',
 });
 
+const LoadingBarStyled = styled('div', {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  height: 2,
+  backgroundColor: '$primary100',
+  zIndex: 9999,
+  transition: 'width 0.2s ease-in-out',
+});
+
 export {
   BoardVisualizerContainer,
   BoardVisualizerPane,
@@ -274,4 +284,5 @@ export {
   BoardConsoleElement,
   BoardBlockTab,
   BoardSpinner,
+  LoadingBarStyled,
 };

--- a/src/aimcore/web/ui/src/pages/Board/Board.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/Board.tsx
@@ -39,6 +39,7 @@ import {
 } from './Board.style';
 import BoardConsole from './components/BoardConsole';
 import FormVizElement from './components/VisualizationElements/FormVizElement';
+import LoadingBar from './components/LoadingBar';
 import useBoardStore from './BoardStore';
 
 const liveUpdateEnabled = false;
@@ -444,6 +445,7 @@ else:
                 processing={state.isProcessing}
                 fullWidth={!editMode && !newMode}
               >
+                <LoadingBar key={boardPath} boardPath={boardPath} />
                 {state.isProcessing !== false && (
                   <BoardSpinner className='BoardVisualizer__main__components__spinner'>
                     <Spinner />

--- a/src/aimcore/web/ui/src/pages/Board/components/LoadingBar.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/components/LoadingBar.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import pyodideEngine from 'services/pyodide/store';
+
+import { LoadingBarStyled } from '../Board.style';
+
+function LoadingBar({ boardPath }: { boardPath: string }) {
+  const [progress, setProgress] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    if (!_.isEmpty(progress)) {
+      let progressTimer = setTimeout(() => {
+        setProgress((oldProgress) => {
+          let newProgress: Record<string, number> = {};
+          for (let key in oldProgress) {
+            if (oldProgress[key] === 100) {
+              continue;
+            }
+
+            if (oldProgress[key] >= 90) {
+              newProgress[key] = 90;
+            } else {
+              newProgress[key] = oldProgress[key] + 10 * Math.random();
+            }
+          }
+
+          return newProgress;
+        });
+      }, 200);
+
+      return () => clearTimeout(progressTimer);
+    }
+  }, [progress]);
+
+  React.useEffect(() => {
+    if (boardPath) {
+      const unsubscribeFromBoardUpdates = pyodideEngine.events.on(
+        boardPath,
+        ({
+          queryDispatchedKey,
+          runActionDispatchedKey,
+          queryKey,
+          runActionKey,
+        }) => {
+          setProgress((oldProgress) => {
+            let newProgress: Record<string, number> = {};
+            if (queryDispatchedKey) {
+              newProgress[queryDispatchedKey] = 0;
+            }
+
+            if (runActionDispatchedKey) {
+              newProgress[runActionDispatchedKey] = 0;
+            }
+
+            if (queryKey) {
+              newProgress[queryKey] = 100;
+            }
+
+            if (runActionKey) {
+              newProgress[runActionKey] = 100;
+            }
+
+            return {
+              ...oldProgress,
+              ...newProgress,
+            };
+          });
+        },
+      );
+
+      return () => {
+        unsubscribeFromBoardUpdates();
+      };
+    }
+  }, [boardPath]);
+
+  return (
+    <LoadingBarStyled
+      style={
+        _.isEmpty(progress)
+          ? {
+              width: 0,
+              opacity: 0,
+            }
+          : {
+              width: `${Math.min(...Object.values(progress))}%`,
+              opacity: 1,
+            }
+      }
+    />
+  );
+}
+
+export default LoadingBar;

--- a/src/aimcore/web/ui/src/pages/Board/serverAPI/find.ts
+++ b/src/aimcore/web/ui/src/pages/Board/serverAPI/find.ts
@@ -49,6 +49,14 @@ export function find(
     );
   }
 
+  pyodideEngine.events.fire(
+    boardPath as string,
+    {
+      queryDispatchedKey: queryKey,
+    },
+    { savePayload: false },
+  );
+
   findRequest
     .call({
       type_,

--- a/src/aimcore/web/ui/src/pages/Board/serverAPI/runAction.ts
+++ b/src/aimcore/web/ui/src/pages/Board/serverAPI/runAction.ts
@@ -28,6 +28,14 @@ export function runAction(
     return getQueryResultsCacheMap().get(runActionKey).data;
   }
 
+  pyodideEngine.events.fire(
+    boardPath,
+    {
+      runActionDispatchedKey: runActionKey,
+    },
+    { savePayload: false },
+  );
+
   runActionRequest
     .call(actionName, reqBody)
     .then((res: any) => {

--- a/src/aimcore/web/ui/src/pages/Board/serverAPI/search.ts
+++ b/src/aimcore/web/ui/src/pages/Board/serverAPI/search.ts
@@ -52,6 +52,14 @@ export function search(
     );
   }
 
+  pyodideEngine.events.fire(
+    boardPath as string,
+    {
+      queryDispatchedKey: queryKey,
+    },
+    { savePayload: false },
+  );
+
   searchRequest
     .call({
       q: query,


### PR DESCRIPTION
Use `pyodideEngine` events to dispatch the start and the end of API requests.

The loading bar component keeps track of progress for all pending requests.
It displays the minimum of all the current requests' progress values.