### PR TITLE
[fix] Keep state in URL for edit mode

### DIFF
--- a/src/aimcore/web/ui/src/pages/App/components/AppWrapper.tsx
+++ b/src/aimcore/web/ui/src/pages/App/components/AppWrapper.tsx
@@ -88,11 +88,13 @@ function AppWrapper({
         {board && !editMode && (
           <Link
             css={{ display: 'flex' }}
-            to={`${PathEnum.App}/${boardPath}/edit`}
+            to={`${PathEnum.App}/${boardPath}/edit${
+              stateStr ? '?state=' + encodeURIComponent(stateStr) : ''
+            }`}
             underline={false}
           >
             <Button variant='outlined' size='xs' rightIcon={<IconPencil />}>
-              Edit
+              Playground
             </Button>
           </Link>
         )}

--- a/src/aimcore/web/ui/src/pages/Board/Board.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/Board.tsx
@@ -70,14 +70,14 @@ function Board({
   const boxContainer = React.useRef<HTMLDivElement>(
     document.createElement('div'),
   );
-  const tobBarRef = React.useRef<HTMLDivElement>(
-    document.querySelector('#app-top-bar'),
-  );
+
   const setEditorValue = useBoardStore((state) => state.setEditorValue);
 
   const boardPath = data.path;
 
   const timerId = React.useRef(0);
+
+  const tobBar = document.querySelector('#app-top-bar');
 
   let liveUpdateTimersRef = React.useRef<Record<string, number>>({});
   let queryKeysForCacheCleaningRef = React.useRef<Record<string, boolean>>({});
@@ -380,7 +380,7 @@ else:
     <ErrorBoundary>
       <Box as='section' height='100vh' className='Board'>
         {(editMode || newMode) &&
-          tobBarRef.current &&
+          tobBar &&
           createPortal(
             <Box
               className='Board__appBar__controls'
@@ -411,7 +411,7 @@ else:
                 </Button>
               </Link>
             </Box>,
-            tobBarRef.current,
+            tobBar,
           )}
         <BusyLoaderWrapper
           isLoading={pyodideIsLoading || isLoading || !mounted}

--- a/src/aimcore/web/ui/src/pages/Board/components/VisualizationElements/BoardLinkVizElement.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/components/VisualizationElements/BoardLinkVizElement.tsx
@@ -9,6 +9,11 @@ import useApp from 'pages/App/useApp';
 function BoardLinkVizElement(props: any) {
   const { data: boardsList } = useApp();
 
+  const url = new URL(window.location.href);
+
+  const isEditMode =
+    url.pathname.startsWith('/app/') && url.pathname.endsWith('/edit');
+
   const packageName = props.options.package_name;
   const stateParam = props.options.state_param;
 
@@ -33,7 +38,9 @@ function BoardLinkVizElement(props: any) {
         textDecoration: 'underline',
         textDecorationColor: '$textPrimary50',
       }}
-      to={`/app/${boardPath}${stateParam ? '?state=' + stateParam : ''}`}
+      to={`/app/${boardPath}${isEditMode ? '/edit' : ''}${
+        stateParam ? '?state=' + stateParam : ''
+      }`}
       target={props.options.new_tab ? '_blank' : undefined}
     >
       <Button


### PR DESCRIPTION
- Rename `Edit` to `Playground` in boards
- Keep board state in URL while switching to the playground
- Stay in the playground while navigating through board links