### PR TITLE
[fix] Add new props to Board component in Report

### DIFF
--- a/src/aimcore/web/ui/src/pages/Board/Board.tsx
+++ b/src/aimcore/web/ui/src/pages/Board/Board.tsx
@@ -403,7 +403,10 @@ else:
               /> */}
               <Link
                 css={{ display: 'flex' }}
-                to={`${PathEnum.App}/${boardPath}`}
+                to={
+                  window.location.pathname.replace('/edit', '') +
+                  window.location.search
+                }
                 underline={false}
               >
                 <Button variant='outlined' size='xs'>

--- a/src/aimcore/web/ui/src/pages/Report/Report.tsx
+++ b/src/aimcore/web/ui/src/pages/Report/Report.tsx
@@ -47,6 +47,8 @@ const markdownComponentsOverride = {
             data={{ code: children[0], path: node.position.start.line }}
             editMode={false}
             previewMode
+            stateStr=''
+            externalPackage={null}
           />
         </div>
       );


### PR DESCRIPTION
Added `stateStr` and `externalPackage` props to the `Board` component in the `Report` page to prevent the app from crashing while rendering an embedded board.