### PR TITLE
[fix] Correct default value for `context` in run.py track method

### DIFF
--- a/pkgs/aimstack/base/types/run.py
+++ b/pkgs/aimstack/base/types/run.py
@@ -123,7 +123,7 @@ class Run(Container, Caller):
     def log_records(self) -> LogRecordSequence:
         return LogRecordSequence(self, name='__log_records', context={})
 
-    def track(self, value, name: str, step: Optional[int] = None, context: dict = Optional[None], **axis):
+    def track(self, value, name: str, step: Optional[int] = None, context: Optional[dict] = None, **axis):
         context = {} if context is None else context
         seq_type = self._get_sequence_type_from_value(value)
         sequence = self.sequences.typed_sequence(seq_type, name, context)


### PR DESCRIPTION
This is a relatively quick fix on what seems to be a typo!

in `aimstack/base/types/run.py` the context is defined as `type` of `None` resulting in the following error, when context is not provided explicitly.
```shell
[...]
 File "<env_path>/lib/python3.10/site-packages/aimstack/base/types/run.py", line 130, in track
    sequence.track(value, step=step, **axis)
  File "<env_path>/lib/python3.10/site-packages/aim/_sdk/sequence.py", line 240, in track
    self._meta_tree[KeyNames.CONTEXTS, self._ctx_idx] = self._context.to_dict()
  File "src/python/aim/_core/storage/treeview.py", line 82, in aim._core.storage.treeview.TreeView.__setitem__
  File "src/python/aim/_core/storage/containertreeview.py", line 102, in aim._core.storage.containertreeview.ContainerTreeView.set
  File "src/python/aim/_core/storage/treeutils.pyx", line 179, in encode_paths_vals
  File "src/python/aim/_core/storage/treeutils.pyx", line 60, in unfold_tree
  File "<env_path>/lib/python3.10/site-packages/aim/_core/storage/treeutils_non_native.py", line 31, in convert_to_native_object
    raise TypeError(f'Unhandled non-native value `{obj}` of type `{type(obj)}`.')
TypeError: Unhandled non-native value `<class 'NoneType'>` of type `<class 'type'>`.

```

I think this should be defined as an `Optional[dict]` with a default value of `None`