### PR TITLE
[fix] Update `upgrade` command for logging repo

### DIFF
--- a/aim/sdk/repo_utils.py
+++ b/aim/sdk/repo_utils.py
@@ -20,7 +20,7 @@ def get_repo(repo: Optional[Union[str, 'Repo', pathlib.Path]]) -> 'Repo':
         if repo_status == RepoStatus.UPDATE_REQUIRED:
             logger.error(f'Trying to open repository {repo}, which is out of date. '
                          f'Please upgrade repository with the following command: '
-                         f'`aim upgrade --repo {repo} 2to3`.')
+                         f'`aim storage --repo {repo} upgrade 2to3`.')
             raise RuntimeError()
         elif repo_status == RepoStatus.MISSING:
             repo = Repo.from_path(repo, init=True)


### PR DESCRIPTION
`aim upgrade <repo_path> 2to3` command is now `aim storage <repo_path> upgrade 2to3`[1]. Updated the `repo_utils.py` to reflect the same.

References:
[1] https://aimstack.readthedocs.io/en/latest/refs/cli.html#storage