### PR TITLE
[fix] Force reacquire lock in torch lightning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add support for `sqlalchemy 2.0` (mihran113)
 - Add `min/max/first` values tracking for metrics (mihran113)
+- Fix bug in pytorch lightning raising lock timeout (inc0)
+
 ## 3.17.6 
 
 - Switch to patched version of official `pynvml` (mihran113)

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -81,7 +81,8 @@ class AimLogger(Logger):
                     self._run_hash,
                     repo=self._repo_path,
                     system_tracking_interval=self._system_tracking_interval,
-                    capture_terminal_logs=self._capture_terminal_logs
+                    capture_terminal_logs=self._capture_terminal_logs,
+                    force_resume=True
                 )
                 if self._run_name is not None:
                     self._run.name = self._run_name


### PR DESCRIPTION
When running testing on a Run, this line failed with error similar to #2999 . It was quite hard to debug, but it seems this is the culprit. It appears that Run was already locked and it failed with traceback when trying to run pytorch lightning training+testing run