### PR TITLE
[fix] Always set the run name when initializing a run in lightning

### DIFF
--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -94,8 +94,6 @@ class AimLogger(Logger):
                     capture_terminal_logs=self._capture_terminal_logs,
                     force_resume=True
                 )
-                if self._run_name is not None:
-                    self._run.name = self._run_name
             else:
                 self._run = Run(
                     repo=self._repo_path,
@@ -105,6 +103,8 @@ class AimLogger(Logger):
                     capture_terminal_logs=self._capture_terminal_logs,
                 )
                 self._run_hash = self._run.hash
+            if self._run_name is not None:
+                self._run.name = self._run_name
         return self._run
 
     @rank_zero_only


### PR DESCRIPTION
Before, the run name would only be set when a run hash has been specified by the user, which is only the case in unusual circumstances, e.g. when a previous model training is resumed at a later time. In effect, run names were never set in my case.

Best,
Marten