### PR TITLE
[feat] Allow HF callback to initialize Aim run at init end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements:
 - Replace grpc with http/ws as transport for aim tracking server (mihran113)
 - Remove `aim storage upgrade 2to3` command (mihran113)
+- Allow HF callback to initialize run at on_init_end for tracking custom metrics with callback (dushyantbehl)
 
 ### Fixes
 - Allow the web UI to serve assets symlinked into the static files directory (martenlienen)

--- a/aim/sdk/adapters/hugging_face.py
+++ b/aim/sdk/adapters/hugging_face.py
@@ -77,11 +77,14 @@ class AimCallback(TrainerCallback):
         #     model_config = model.config.to_dict()
         #     self._run['model'] = model_config
 
+    def on_init_end(self, args, state, control, **kwargs):
+        # Initialize the Aim run on init end so people can track any
+        # additional metric (like model load time) in the same aim run.
+        self.setup(state=state)
+
     def on_train_begin(self, args, state, control, model=None, **kwargs):
-        if not state.is_world_process_zero:
-            return
-        if not self._run:
-            self.setup(args, state, model)
+        # Call setup with args and model to store args and model parameters
+        self.setup(args, state, model)
 
     def on_train_end(self, args, state, control, **kwargs):
         if not state.is_world_process_zero:


### PR DESCRIPTION
Current implementation of HF callback in Aim initializes the `Run` object at training begin time. This means if the users want to track any additional metrics they need to do so before training finishes while using `HFTrainer` object. 

This small change which initializes the `Run` object on `init_end` makes the run object available to user of this callback via `callback.experiment` and allows them to track any extra metrics or parameters with the same run other than the standard metrics output by HF.