### PR TITLE
[fix] Increase websockets max_size for large images sent to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+### Fixes:
+- Increase websockets max_size for large images sent to server (jasonmads)
+
 ## 3.20.1 Jun 3, 2024
 
 ### Enhancements:

--- a/aim/cli/utils.py
+++ b/aim/cli/utils.py
@@ -93,7 +93,7 @@ def build_uvicorn_command(app,
                           ssl_certfile=None,
                           log_level='warning',
                           ):
-    cmd = [sys.executable, '-m', 'uvicorn',
+    cmd = [sys.executable, '-m', 'uvicorn', '--ws-max-size', '1073741824',
            '--host', host, '--port', f'{port}',
            '--workers', f'{workers}']
 

--- a/aim/ext/transport/client.py
+++ b/aim/ext/transport/client.py
@@ -274,13 +274,15 @@ class Client:
         del self._thread_local.atomic_instructions[hash_]
 
     def refresh_ws(self):
-        self._ws = connect(f'{self._ws_protocol}{self._tracking_endpoint}/{self.uri}/write-instruction/')
+        self._ws = connect(f'{self._ws_protocol}{self._tracking_endpoint}/{self.uri}/write-instruction/',
+                           max_size=None)
 
     @property
     def ws(self):
         if self._ws is None:
             self._ws = connect(f'{self._ws_protocol}{self._tracking_endpoint}/{self.uri}/write-instruction/',
-                               additional_headers=self.request_headers)
+                               additional_headers=self.request_headers,
+                               max_size=None)
 
         return self._ws
 


### PR DESCRIPTION
Set `max_size` in `connect` to `None` (unlimited) and `1073741824` (1024*1024*1024) for `unicorn`

This addresses issue #3154 of large validation images getting 1009 (message too big) errors when trying to upload.
Values chosen are arbitrary and very high. 