### PR TITLE
[feat] Add a filesystem-based backend for artifact storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements:
 - Add feature to delete full experiments (mauricekraus)
 - Add support for python 3.12 (mahnerak)
+- Add filesystem-based backend for artifact storage (gpascale)
 
 ### Fixes:
 - Increase websockets max_size for large images sent to server (jasonmads)

--- a/aim/storage/artifacts/artifact_registry.py
+++ b/aim/storage/artifacts/artifact_registry.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from typing import Type, Dict
 
 from .s3_storage import S3ArtifactStorage
+from .filesystem_storage import FilesystemArtifactStorage
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -29,3 +30,4 @@ class ArtifactStorageRegistry:
 
 registry = ArtifactStorageRegistry()
 registry.register('s3', S3ArtifactStorage)
+registry.register('file', FilesystemArtifactStorage)

--- a/aim/storage/artifacts/filesystem_storage.py
+++ b/aim/storage/artifacts/filesystem_storage.py
@@ -1,0 +1,39 @@
+import pathlib
+import os
+import shutil
+import tempfile
+
+from urllib.parse import urlparse
+from typing import Optional
+
+from .artifact_storage import AbstractArtifactStorage
+
+
+class FilesystemArtifactStorage(AbstractArtifactStorage):
+    def __init__(self, url: str):
+        super().__init__(url)
+        res = urlparse(self.url)
+        path = res.path
+        self._prefix = path
+
+    def upload_artifact(self, file_path: str, artifact_path: str, block: bool = False):
+        dest_path = pathlib.Path(self._prefix) / artifact_path
+        dest_dir = os.path.dirname(dest_path)
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.copy(file_path, dest_path)
+
+    def download_artifact(self, artifact_path: str, dest_dir: Optional[str] = None) -> str:
+        if dest_dir is None:
+            dest_dir = pathlib.Path(tempfile.mkdtemp())
+        else:
+            dest_dir = pathlib.Path(dest_dir)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+        source_path = dest_path = pathlib.Path(self._prefix) / artifact_path
+        dest_path = dest_dir / source_path.name
+        shutil.copy(source_path, dest_path)
+
+        return dest_path.as_posix()
+
+    def delete_artifact(self, artifact_path: str):
+        path = pathlib.Path(self._prefix) / artifact_path
+        shutil.rmtree(path)


### PR DESCRIPTION
Adds `FilesystemArtifactStorage`, a local filesystem-backed implementation of `AbstractArtifactStorage`, and adds it to the registry.

Works very similarly to S3ArtifactStorage, except you would pass a url like `file:///path/to/artifacts` as the uri.