### PR TITLE
[feat] Add feature to delete full experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements:
+- Add feature to delete full experiments (mauricekraus)
+
 ## 3.20.1 Jun 3, 2024
 
 ### Enhancements:

--- a/aim/storage/structured/entities.py
+++ b/aim/storage/structured/entities.py
@@ -268,6 +268,10 @@ class ObjectFactory:
         ...
 
     @abstractmethod
+    def delete_experiment(self, _id: str) -> bool:
+        ...
+
+    @abstractmethod
     def tags(self) -> TagCollection:
         ...
 

--- a/aim/storage/structured/sql_engine/entities.py
+++ b/aim/storage/structured/sql_engine/entities.py
@@ -370,6 +370,22 @@ class ModelMappedExperiment(IExperiment, metaclass=ModelMappedClassMeta):
             joinedload(ExperimentModel.runs),
         ])
         return ModelMappedExperimentCollection(session, query=q)
+    
+    @classmethod
+    def delete_experiment(cls, _id: str,  **kwargs) -> bool:
+        session = kwargs.get('session')
+        if not session:
+            return False
+        try:
+            exp = session.query(ExperimentModel).filter(ExperimentModel.uuid == _id).first()
+            # delete all runs and notes and experiment
+            session.query(RunModel).filter(RunModel.experiment_id == exp.id).delete()
+            session.query(NoteModel).filter(NoteModel.experiment_id == exp.id).delete()
+            rows_affected = session.query(ExperimentModel).filter(ExperimentModel.uuid == _id).delete()
+            session_commit_or_flush(session)
+        except Exception:
+            return False
+        return rows_affected > 0
 
     @classmethod
     def search(cls, term: str, **kwargs) -> Collection[IExperiment]:

--- a/aim/storage/structured/sql_engine/entities.py
+++ b/aim/storage/structured/sql_engine/entities.py
@@ -370,9 +370,9 @@ class ModelMappedExperiment(IExperiment, metaclass=ModelMappedClassMeta):
             joinedload(ExperimentModel.runs),
         ])
         return ModelMappedExperimentCollection(session, query=q)
-    
+
     @classmethod
-    def delete_experiment(cls, _id: str,  **kwargs) -> bool:
+    def delete_experiment(cls, _id: str, **kwargs) -> bool:
         session = kwargs.get('session')
         if not session:
             return False

--- a/aim/storage/structured/sql_engine/factory.py
+++ b/aim/storage/structured/sql_engine/factory.py
@@ -63,6 +63,9 @@ class ModelMappedFactory(ObjectFactory):
     def create_experiment(self, name: str) -> Experiment:
         return ModelMappedExperiment.from_name(name, session=self._session or self.get_session())
 
+    def delete_experiment(self, _id: str) -> bool:
+        return ModelMappedExperiment.delete_experiment(_id, session=self._session or self.get_session())
+
     def tags(self) -> TagCollection:
         return ModelMappedTag.all(session=self._session or self.get_session())
 

--- a/aim/web/api/experiments/views.py
+++ b/aim/web/api/experiments/views.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from collections import Counter
 from fastapi import Request, HTTPException, Depends, Header
+from aim.web.api.runs.utils import get_project_repo
 from aim.web.api.utils import APIRouter  # wrapper for fastapi.APIRouter
 from typing import Optional
 
@@ -75,9 +76,11 @@ async def get_experiment_api(exp_id: str, factory=Depends(object_factory)):
     }
     return response
 
+
 @experiment_router.delete('/{exp_id}/')
-async def delete_experiment_api(exp_id: str, factory=Depends(object_factory)):
-    success = factory.delete_experiment(exp_id)
+async def delete_experiment_api(exp_id: str):
+    repo = get_project_repo()
+    success = repo.delete_experiment(exp_id)
     if not success:
         raise HTTPException(status_code=400, detail=(
             f'Failed to delete experiment \'{exp_id}\'.'

--- a/aim/web/api/experiments/views.py
+++ b/aim/web/api/experiments/views.py
@@ -75,6 +75,18 @@ async def get_experiment_api(exp_id: str, factory=Depends(object_factory)):
     }
     return response
 
+@experiment_router.delete('/{exp_id}/')
+async def delete_experiment_api(exp_id: str, factory=Depends(object_factory)):
+    success = factory.delete_experiment(exp_id)
+    if not success:
+        raise HTTPException(status_code=400, detail=(
+            f'Failed to delete experiment \'{exp_id}\'.'
+        ))
+
+    return {
+        'status': 'OK'
+    }
+
 
 @experiment_router.put('/{exp_id}/', response_model=ExperimentUpdateOut)
 async def update_experiment_properties_api(exp_id: str, exp_in: ExperimentUpdateIn, factory=Depends(object_factory)):

--- a/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
+++ b/aim/web/ui/src/config/analytics/analyticsKeysMap.ts
@@ -273,6 +273,7 @@ export const ANALYTICS_EVENT_KEYS = {
       },
       settings: {
         tabView: '[Experiment] [Settings] Tab view',
+        deleteExperiment: '[Experiment] [Settings] Delete experiment',
       },
     },
     table: {

--- a/aim/web/ui/src/modules/core/api/experimentsApi/index.ts
+++ b/aim/web/ui/src/modules/core/api/experimentsApi/index.ts
@@ -64,6 +64,18 @@ async function updateExperimentById(
 }
 
 /**
+ * function deleteExperimentById
+ * this call is used for deleting an experiment by id.
+ * @param id - experiment hash
+ * @returns {Promise<{status: string}>}
+ */
+async function deleteExperimentById(id: string): Promise<{ status: string }> {
+  return (
+    await api.makeAPIDeleteRequest(`${ENDPOINTS.EXPERIMENTS.DELETE}${id}`)
+  ).body;
+}
+
+/**
  * function createExperiment
  * this call is used for create an experiment.
  * @param  reqBody -  query body params
@@ -201,6 +213,7 @@ export {
   getExperimentById,
   updateExperimentById,
   createExperiment,
+  deleteExperimentById,
   getRunsOfExperiment,
   getExperimentContributions,
   getExperimentNote,

--- a/aim/web/ui/src/pages/Experiment/Experiment.tsx
+++ b/aim/web/ui/src/pages/Experiment/Experiment.tsx
@@ -75,6 +75,7 @@ function Experiment(): React.FunctionComponentElement<React.ReactNode> {
     experimentsState,
     getExperimentsData,
     updateExperiment,
+    deleteExperiment,
   } = useExperimentState(experimentId);
   const { notificationState, onNotificationDelete } =
     useNotificationContainer();
@@ -114,6 +115,7 @@ function Experiment(): React.FunctionComponentElement<React.ReactNode> {
       props: {
         experimentName: experimentData?.name ?? '',
         updateExperiment,
+        deleteExperiment,
         description: experimentData?.description ?? '',
       },
       Component: ExperimentSettingsTab,

--- a/aim/web/ui/src/pages/Experiment/ExperimentStore.ts
+++ b/aim/web/ui/src/pages/Experiment/ExperimentStore.ts
@@ -4,6 +4,7 @@ import {
   getExperimentById,
   getExperiments,
   updateExperimentById,
+  deleteExperimentById,
   IExperimentData,
 } from 'modules/core/api/experimentsApi';
 import createResource from 'modules/core/utils/createResource';
@@ -21,6 +22,30 @@ function experimentEngine() {
     state: experimentsState,
     destroy: destroyExperiments,
   } = createResource<IExperimentData[]>(getExperiments);
+
+  function deleteExperiment() {
+    const experimentData = experimentState.getState().data;
+    if (!experimentData) return;
+    destroyExperiment();
+    destroyExperiments();
+    experimentState.setState({ data: null });
+    deleteExperimentById(experimentData.id)
+      .then(() => {
+        notificationContainerStore.onNotificationAdd({
+          id: Date.now(),
+          messages: ['Experiment successfully deleted'],
+          severity: 'success',
+        });
+        analytics.trackEvent('[Experiment] Delete Experiment');
+      })
+      .catch((err) => {
+        notificationContainerStore.onNotificationAdd({
+          id: Date.now(),
+          messages: [err.message || 'Something went wrong'],
+          severity: 'error',
+        });
+      });
+  }
 
   function updateExperiment(name: string, description: string) {
     const experimentData = experimentState.getState().data;
@@ -58,6 +83,7 @@ function experimentEngine() {
     experimentsState,
     destroyExperiments,
     updateExperiment,
+    deleteExperiment,
   };
 }
 

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.d.ts
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.d.ts
@@ -2,4 +2,5 @@ export interface IExperimentSettingsTabProps {
   experimentName: string;
   description: string;
   updateExperiment: (name: string, description: string) => void;
+  deleteExperiment: () => void;
 }

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.scss
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.scss
@@ -4,5 +4,21 @@
   padding: $space-lg 0;
   &__actionCardsCnt {
     margin: 0 toRem(164px);
+
+    &__btn__delete {
+      .MuiButton-label {
+        display: initial;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+      }
+
+      background-color: $error-color;
+
+      &:hover {
+        background-color: $error-color;
+      }
+    }
+
   }
 }

--- a/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.tsx
+++ b/aim/web/ui/src/pages/Experiment/components/ExperimentSettingsTab/ExperimentSettingsTab.tsx
@@ -1,7 +1,10 @@
 import React, { memo } from 'react';
+import { useHistory } from 'react-router-dom';
 
+import ConfirmModal from 'components/ConfirmModal/ConfirmModal';
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import NameAndDescriptionCard from 'components/NameAndDescriptionCard';
+import { ActionCard, Icon } from 'components/kit';
 
 import { ANALYTICS_EVENT_KEYS } from 'config/analytics/analyticsKeysMap';
 
@@ -15,13 +18,25 @@ function ExperimentSettingsTab({
   experimentName,
   description,
   updateExperiment,
+  deleteExperiment,
 }: IExperimentSettingsTabProps): React.FunctionComponentElement<React.ReactNode> {
+  const history = useHistory();
+  const [openDeleteModal, setOpenDeleteModal] = React.useState<boolean>(false);
+
   React.useEffect(() => {
     analytics.pageView(ANALYTICS_EVENT_KEYS.experiment.tabs.settings.tabView);
   }, []);
 
   function onSave(name: string, description: string) {
     updateExperiment(name, description);
+  }
+
+  function onExperimentDelete() {
+    analytics.trackEvent(
+      ANALYTICS_EVENT_KEYS.experiment.tabs.settings.deleteExperiment,
+    );
+    history.push('/experiments');
+    deleteExperiment();
   }
 
   return (
@@ -34,7 +49,28 @@ function ExperimentSettingsTab({
             defaultDescription={description ?? ''}
             onSave={onSave}
           />
+          <ActionCard
+            title='Delete Experiment'
+            description='Once you delete an experiment, there is no going back. Please be certain.'
+            btnTooltip='Delete Experiment'
+            btnText='Delete'
+            onAction={() => setOpenDeleteModal(true)}
+            btnProps={{
+              variant: 'contained',
+              className: 'ExperimentSettingsTab__actionCardsCnt__btn__delete',
+            }}
+          />
         </div>
+        <ConfirmModal
+          open={openDeleteModal}
+          onCancel={() => setOpenDeleteModal(false)}
+          onSubmit={onExperimentDelete}
+          text='Are you sure you want to delete this experiment?'
+          icon={<Icon name='delete' />}
+          title='Delete Experiment'
+          statusType='error'
+          confirmBtnText='Delete'
+        />
       </div>
     </ErrorBoundary>
   );

--- a/aim/web/ui/src/pages/Experiment/useExperimentState.tsx
+++ b/aim/web/ui/src/pages/Experiment/useExperimentState.tsx
@@ -30,6 +30,7 @@ function useExperimentState(experimentId: string) {
     experimentsState,
     getExperimentsData: engine.fetchExperimentsData,
     updateExperiment: engine.updateExperiment,
+    deleteExperiment: engine.deleteExperiment,
   };
 }
 

--- a/aim/web/ui/src/services/api/endpoints.ts
+++ b/aim/web/ui/src/services/api/endpoints.ts
@@ -17,6 +17,7 @@ const ENDPOINTS = {
     BASE: '/experiments',
     GET: '',
     CREATE: '',
+    DELETE: '',
     SEARCH: 'search',
     GET_ACTIVITY: 'activity',
     GET_NOTE: 'note',

--- a/aim/web/ui/src/services/api/experiments/experimentsService.ts
+++ b/aim/web/ui/src/services/api/experiments/experimentsService.ts
@@ -8,6 +8,7 @@ const endpoints = {
   EXPERIMENTS: 'experiments',
   GET_EXPERIMENT_BY_ID: (id: string) => `experiments/${id}`,
   UPDATE_EXPERIMENT_BY_ID: (id: string) => `experiments/${id}`,
+  DELETE_EXPERIMENT_BY_ID: (id: string) => `experiments/${id}`,
   SEARCH_EXPERIMENT: (query: string) => `experiments/search=${query}`,
   GET_RUNS_BY_EXPERIMENT_ID: (id: string) => `experiments/${id}/runs`,
 };
@@ -22,6 +23,10 @@ function searchExperiment(query: string): IApiRequest<IExperimentData> {
 
 function getExperimentById(id: string): IApiRequest<IExperimentData> {
   return API.get(endpoints.GET_EXPERIMENT_BY_ID(id));
+}
+
+function deleteExperimentById(id: string): IApiRequest<{ status: string }> {
+  return API.delete(endpoints.DELETE_EXPERIMENT_BY_ID(id));
 }
 
 function updateExperimentById(
@@ -52,6 +57,7 @@ const experimentsService = {
   updateExperimentById,
   createExperiment,
   getRunsOfExperiment,
+  deleteExperimentById,
 };
 
 export default experimentsService;

--- a/examples/optuna_track.py
+++ b/examples/optuna_track.py
@@ -27,8 +27,8 @@ aim_callback = AimCallback(
 @aim_callback.track_in_aim()
 def objective(trial):
     x = trial.suggest_float('x', -10, 10)
-    aim_callback.experiment.track_auto(2, name='power')
-    aim_callback.experiment.track_auto(x - 2, name='base of metric')
+    aim_callback.experiment.track(2, name='power')
+    aim_callback.experiment.track(x - 2, name='base of metric')
 
     return (x - 2) ** 2
 


### PR DESCRIPTION
This pull request introduces the ability to delete entire experiments directly from the user interface.

### Key Changes:
#### Delete Full Experiments:

Users can now delete entire experiments without having to manually select and delete individual runs.
This resolves the issue of having empty experiments after all runs are deleted, providing a more streamlined workflow.
Delete all runs of an experiment:

#### UI Consistency:

![image](https://github.com/aimhubio/aim/assets/19814368/d2c0797e-3ec7-442c-92d0-069672eac028)


The delete functionality for experiments is currently available only on the experiment settings tab, making it consistent with the existing run detail  deletion process.

How we should delete experiments from the dashboard needs further discussion (due to the space constraints)

Issues Resolved:
Closes #2528 , #2803 
