### PR TITLE
[fix] Remove no longer available --force-init flag from cli manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes:
 - Increase websockets max_size for large images sent to server (jasonmads)
+- Correct flags when running Aim UI in Jupiter notebooks (synapticarbors)
 
 ## 3.20.1 Jun 3, 2024
 

--- a/aim/cli/manager/manager.py
+++ b/aim/cli/manager/manager.py
@@ -51,7 +51,7 @@ def run_up(args):
             args_list.append(p + '=' + args[p])
 
     child_process = subprocess.Popen(
-        ['aim', UP_NAME] + args_list + ['--force-init'],
+        ['aim', UP_NAME] + args_list,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE
     )


### PR DESCRIPTION
Currently the jupyter-lab extension is broken due to the `--force-init` flag that is added to the `aim up` call. See https://github.com/aimhubio/aim/issues/3123

This flag was removed from the cli in https://github.com/aimhubio/aim/commit/3373cbbea1f9d213c3113fdaea2d2b16951dfe2b

I've tested this with a local install of 3.20.1. 