### PR TITLE
[feat] Add skip option in init commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.22.1 Jul 4, 2024
+
+### Enhancements:
+- Add a `-s`/`--skip-if-exists` option to the `init` command to avoid reinitializing a repo if one already exists (stevenjlm)
+
 ## 3.22.0 Jun 20, 2024
 
 ### Enhancements:

--- a/aim/cli/init/commands.py
+++ b/aim/cli/init/commands.py
@@ -11,7 +11,8 @@ from aim.sdk.utils import clean_repo_path
                                                         dir_okay=True,
                                                         writable=True))
 @click.option('-y', '--yes', is_flag=True, help='Automatically confirm prompt')
-def init(repo, yes):
+@click.option('-s', '--skip-if-exists', is_flag=True, help='Skips initialization if the repo already exists')
+def init(repo, yes, skip_if_exists):
     """
     Initializes new repository in the --repo directory.
     Initializes new repository in the current working directory if --repo argument is not provided:
@@ -20,8 +21,15 @@ def init(repo, yes):
     repo_path = clean_repo_path(repo) or os.getcwd()
     re_init = False
     if Repo.exists(repo_path):
-        if yes:
+        if yes and skip_if_exists:
+            raise click.BadParameter('Conflicting init options.'
+                                     'Either specify -y/--yes or -s/--skip-if-exists')
+        elif yes:
             re_init = True
+        elif skip_if_exists:
+            click.echo(
+                'Repo exists at {}. Skipped initialization.'.format(repo.root_path))
+            return
         else:
             re_init = click.confirm('Aim repository is already initialized. '
                                     'Do you want to re-initialize to empty Aim repository?')

--- a/aim/cli/init/commands.py
+++ b/aim/cli/init/commands.py
@@ -11,7 +11,7 @@ from aim.sdk.utils import clean_repo_path
                                                         dir_okay=True,
                                                         writable=True))
 @click.option('-y', '--yes', is_flag=True, help='Automatically confirm prompt')
-@click.option('-s', '--skip-if-exists', is_flag=True, help='Skips initialization if the repo already exists')
+@click.option('-s', '--skip-if-exists', is_flag=True, help='Skip initialization if the repo already exists')
 def init(repo, yes, skip_if_exists):
     """
     Initializes new repository in the --repo directory.


### PR DESCRIPTION
PR for #3177 
Adds a skip option for init in case the repo already exists.

Note: It does not seem like click has a standard way of dealing with conflicting options, so I decided to throw an error if "yes" and "skip-if-exists" are both specified.