### PR TITLE
[fix] torch.inference_mode inplace of torch.no_grad

### DIFF
--- a/examples/pytorch_track.py
+++ b/examples/pytorch_track.py
@@ -118,8 +118,7 @@ for epoch in range(num_epochs):
 
 
 # Test the model
-model.eval()
-with torch.no_grad():
+with torch.inference_mode():
     correct = 0
     total = 0
     for images, labels in test_loader:

--- a/examples/pytorch_track.py
+++ b/examples/pytorch_track.py
@@ -12,8 +12,8 @@ from aim.pytorch import track_gradients_dists, track_params_dists
 # Initialize a new Run
 aim_run = Run()
 
-# Device configuration
-device = torch.device('cpu')
+# moving model to gpu if available
+device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 # Hyper parameters
 num_epochs = 5

--- a/examples/pytorch_track_images.py
+++ b/examples/pytorch_track_images.py
@@ -13,8 +13,8 @@ from tqdm import tqdm
 # Initialize a new Run
 aim_run = Run()
 
-# Device configuration
-device = torch.device('cpu')
+# moving model to gpu if available
+device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 # Hyper parameters
 num_epochs = 5

--- a/examples/pytorch_track_images.py
+++ b/examples/pytorch_track_images.py
@@ -122,8 +122,7 @@ for epoch in range(num_epochs):
 
 
 # Test the model
-model.eval()
-with torch.no_grad():
+with torch.inference_mode():
     correct = 0
     total = 0
     for images, labels in tqdm(test_loader, total=len(test_loader)):


### PR DESCRIPTION
Changed inference context to `torch.inference_mode()` in test stage. 

Setting `device` automatically with `torch.cuda.is_availble`. 