### PR TITLE
[fix] Update `up` docs, build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ These command will create a folder named `ComponentName` with all the necessary 
 Aim documentation is built using [Sphix](https://www.sphinx-doc.org) and is hosted at
 [Read the Docs](https://aimstack.readthedocs.io).
 The documentation sources are located at `docs/` directory. In order to build documentation locally
-run the following commands
+run the following commands with a Python interpreter version <= 3.10:
 ```shell
 pip install -r requirements.dev.txt
 cd docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,3 @@ sphinx_rtd_theme
 m2r2==0.3.3.post2
 sphinx-copybutton
 Cython==3.0.10
-
--r ./../requirements.txt

--- a/docs/source/refs/cli.md
+++ b/docs/source/refs/cli.md
@@ -52,10 +52,10 @@ $ aim up [ARGS]
 
 | Args                        | Description                                                                                                      |
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `-h` &#124; `--host <host>` | Specify host address.                                                                                            |
-| `-p` &#124; `--port <port>` | Specify port to listen to.                                                                                       |
+| `-h, --host <host>`         | Specify host address.                                                                                            |
+| `-p, --port <port>`         | Specify port to listen to. _Default is 43800._                                                                   |
 | `--repo <repo_path>`        | Path to parent directory of `.aim` repo. _Current working directory by default_.                                 |
-| `--dev`                     | Run UI in development mode.                                                                                      |
+| `--dev`                     | Run UI in development mode—enables hot-reloading only, _not meant for end-users_.                                |
 | `--profiler`                | Enables API profiling which logs run trace inside `.aim/profiler` directory.                                     |
 | `--log-level`               | Specifies log level for python logging package. _`WARNING` by default, `DEBUG` when `--dev` option is provided_. |
 
@@ -71,8 +71,8 @@ $ aim server [ARGS]
 | Args                         | Description                                                                                                      |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `--repo <repo_path>`         | Path to parent directory of `.aim` repo. _Current working directory by default_.                                 |
-| `-h` &#124; `--host <host>`  | Specify host address.                                                                                            |
-| `-p` &#124; `--port <port>`  | Specify port to listen to. _Default is 53800_.                                                                   |
+| `-h, --host <host>`          | Specify host address.                                                                                            |
+| `-p, --port <port>`          | Specify port to listen to. _Default is 53800_.                                                                   |
 | `--ssl-keyfile`              | Specify path to keyfile for secure connection.                                                                   |
 | `--ssl-certfile`             | Specify path to cert. file for secure connection.                                                                |
 | `--dev`                      | Run UI in development mode.                                                                                      |                                


### PR DESCRIPTION
- clarifies the purpose of the `--dev` flag for `aim up`
- fixes formatting issue—replaces `|` with `,`
- updates doc build instructions 

fixes #3200 .