### PR TITLE
[fix] Typo in exception name in `storage/union.pyx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - Fix bug in bookmark page where it was not scrollable if there was too many bookmarks (vinayan3)
+- Fix exception name in `storage/union.pyx` (sulan)
 
 ## 3.23.0 Jul 15, 2024
 

--- a/aim/storage/union.pyx
+++ b/aim/storage/union.pyx
@@ -53,7 +53,7 @@ class ItemsIterator(ContainerItemsIterator):
         for prefix, iterator in self._iterators.items():
             try:
                 iterator.seek_to_first()
-            except (aimrocks.errorsRocksIOError, aimrocks.errors.Corruption):
+            except (aimrocks.errors.RocksIOError, aimrocks.errors.Corruption):
                 logger.debug(f'Detected corrupted db chunk \'{prefix}\'.')
                 corrupted_dbs.add(prefix)
         self._corrupted_dbs.update(corrupted_dbs)


### PR DESCRIPTION
`aimrocks.errors.RocksIOError` instead of `aimrocks.errorsRocksIOError`