### PR TITLE
[fix] Resolve issues with unit test failures

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements.txt
 torch
 tensorflow
-deeplake
+deeplake<4.0.0 # update when proper documentation is available
 # hub
 fastapi>=0.87.0
 httpx


### PR DESCRIPTION
Restrict `deeplake` upper version, because they had major changes in the new release and there's no documentation available yet for the new major version: 4.0.0