### PR TITLE
[fix] Copy the keys of RunStatusReporter.timed_tasks before iterating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.26.2 Dec 5, 2024
+- Fix bug in RunStatusReporter raising non-deterministic RuntimeError exception
+
 ## 3.26.1 Dec 3, 2024
 - Re-upload after PyPI size limitation fix
 

--- a/aim/sdk/reporter/__init__.py
+++ b/aim/sdk/reporter/__init__.py
@@ -655,7 +655,7 @@ class RunStatusReporter:
         logger.debug(f'notifying {self}')
 
         with self.reporter_lock:
-            flag_names = [flag_name] if flag_name is not None else self.timed_tasks
+            flag_names = [flag_name] if flag_name is not None else list(self.timed_tasks)
             with self.flush_condition:
                 for flag_name in flag_names:
                     logger.debug(f'flushing {flag_name}')


### PR DESCRIPTION
Iterating the dictionary self.timed_tasks sometimes raises the following exception:

> RuntimeError: dictionary changed size during iteration

This PR resolves https://github.com/aimhubio/aim/issues/3181

https://github.com/GuHongyang actually included the fix to the issue they opened ( #3181 )