### PR TITLE
[feat] Store Run sequence metadata by separate types

### DIFF
--- a/aim/cli/runs/commands.py
+++ b/aim/cli/runs/commands.py
@@ -7,6 +7,8 @@ import tqdm
 
 from aim.cli.runs.utils import make_zip_archive, match_runs, upload_repo_runs
 from aim.sdk.repo import Repo
+from aim.sdk.index_manager import RepoIndexManager
+from aim.sdk.sequences.sequence_type_map import SEQUENCE_TYPE_MAP
 from psutil import cpu_count
 
 
@@ -169,3 +171,43 @@ def close_runs(ctx, hashes, yes):
 
     for _ in tqdm.tqdm(pool.imap_unordered(repo._close_run, hashes), desc='Closing runs', total=len(hashes)):
         pass
+
+
+@runs.command(name='update-metrics')
+@click.pass_context
+@click.option('-y', '--yes', is_flag=True, help='Automatically confirm prompt')
+def update_metrics(ctx, yes):
+    """Separate Sequence metadata for optimal read."""
+    repo_path = ctx.obj['repo']
+    repo = Repo.from_path(repo_path)
+
+    click.secho(
+        f"This command will update Runs from Aim Repo '{repo_path}' to the latest data format to ensure better "
+        f"performance. Please make sure no Runs are active and Aim UI is not running."
+    )
+    if yes:
+        confirmed = True
+    else:
+        confirmed = click.confirm('Do you want to proceed?')
+    if not confirmed:
+        return
+
+    index_manager = RepoIndexManager.get_index_manager(repo)
+    hashes = repo.list_all_runs()
+    for run_hash in tqdm.tqdm(hashes, desc='Updating runs', total=len(hashes)):
+        meta_tree = repo.request_tree('meta', run_hash, read_only=False, from_union=False)
+        meta_run_tree = meta_tree.subtree(('meta', 'chunks', run_hash))
+        try:
+            # check if the Run has already been updated.
+            meta_run_tree.first_key('typed_traces')
+            click.secho(f"Run {run_hash} is uo-to-date. Skipping.")
+            continue
+        except KeyError:
+            for ctx_idx, run_ctx_dict in meta_run_tree.subtree('traces').items():
+                assert isinstance(ctx_idx, int)
+                for seq_name in run_ctx_dict.keys():
+                    assert isinstance(seq_name, str)
+                    dtype = run_ctx_dict[seq_name].get('dtype', 'float')
+                    seq_type = SEQUENCE_TYPE_MAP.get(dtype, 'sequence')
+                    meta_run_tree['typed_traces', seq_type, ctx_idx, seq_name] = 1
+            index_manager.index(run_hash)

--- a/aim/cli/runs/commands.py
+++ b/aim/cli/runs/commands.py
@@ -183,7 +183,7 @@ def update_metrics(ctx, yes):
 
     click.secho(
         f"This command will update Runs from Aim Repo '{repo_path}' to the latest data format to ensure better "
-        f"performance. Please make sure no Runs are active and Aim UI is not running."
+        f'performance. Please make sure no Runs are active and Aim UI is not running.'
     )
     if yes:
         confirmed = True
@@ -200,7 +200,7 @@ def update_metrics(ctx, yes):
         try:
             # check if the Run has already been updated.
             meta_run_tree.first_key('typed_traces')
-            click.secho(f"Run {run_hash} is uo-to-date. Skipping.")
+            click.secho(f'Run {run_hash} is uo-to-date. Skipping.')
             continue
         except KeyError:
             for ctx_idx, run_ctx_dict in meta_run_tree.subtree('traces').items():

--- a/aim/sdk/reporter/file_manager.py
+++ b/aim/sdk/reporter/file_manager.py
@@ -10,10 +10,12 @@ logger = logging.getLogger(__name__)
 
 class FileManager(object):
     @abstractmethod
-    def poll(self, pattern: str) -> Optional[str]: ...
+    def poll(self, pattern: str) -> Optional[str]:
+        ...
 
     @abstractmethod
-    def touch(self, filename: str, cleanup_file_pattern: Optional[str] = None): ...
+    def touch(self, filename: str, cleanup_file_pattern: Optional[str] = None):
+        ...
 
 
 class LocalFileManager(FileManager):

--- a/aim/sdk/run_status_watcher.py
+++ b/aim/sdk/run_status_watcher.py
@@ -83,13 +83,16 @@ class Notification:
         self.message = message
 
     @abstractmethod
-    def is_sent(self): ...
+    def is_sent(self):
+        ...
 
     @abstractmethod
-    def update_last_sent(self): ...
+    def update_last_sent(self):
+        ...
 
     @abstractmethod
-    def get_msg_details(self): ...
+    def get_msg_details(self):
+        ...
 
 
 class StatusNotification(Notification):

--- a/aim/sdk/sequences/sequence_type_map.py
+++ b/aim/sdk/sequences/sequence_type_map.py
@@ -10,5 +10,5 @@ SEQUENCE_TYPE_MAP = {
     'aim.text': 'texts',
     'list(aim.text)': 'texts',
     'aim.distribution': 'distributions',
-    'aim.figure': 'figures'
+    'aim.figure': 'figures',
 }

--- a/aim/sdk/sequences/sequence_type_map.py
+++ b/aim/sdk/sequences/sequence_type_map.py
@@ -1,0 +1,14 @@
+SEQUENCE_TYPE_MAP = {
+    'int': 'metric',
+    'float': 'metric',
+    'float64': 'metric',
+    'number': 'metric',
+    'aim.image': 'images',
+    'list(aim.image)': 'images',
+    'aim.audio': 'audios',
+    'list(aim.audio)': 'audios',
+    'aim.text': 'texts',
+    'list(aim.text)': 'texts',
+    'aim.distribution': 'distributions',
+    'aim.figure': 'figures'
+}

--- a/aim/sdk/tracker.py
+++ b/aim/sdk/tracker.py
@@ -15,6 +15,7 @@ from aim.storage.context import Context
 from aim.storage.hashing import hash_auto
 from aim.storage.object import CustomObject
 from aim.storage.types import AimObject
+from aim.sdk.sequences.sequence_type_map import SEQUENCE_TYPE_MAP
 
 
 if TYPE_CHECKING:
@@ -152,7 +153,7 @@ class RunTracker:
         try:
             seq_info.version = self.meta_run_tree['traces', ctx_id, name, 'version']
         except KeyError:
-            self.meta_run_tree['traces', ctx_id, name, 'version'] = seq_info.dtype = 1
+            self.meta_run_tree['traces', ctx_id, name, 'version'] = seq_info.version = 1
         try:
             seq_info.dtype = self.meta_run_tree['traces', ctx_id, name, 'dtype']
         except KeyError:
@@ -213,7 +214,9 @@ class RunTracker:
 
             def update_trace_dtype(old_dtype: str, new_dtype: str):
                 logger.warning(f"Updating sequence '{name}' data type from {old_dtype} to {new_dtype}.")
+                new_trace_type = SEQUENCE_TYPE_MAP.get(dtype, 'sequence')  # use mapping from value type to sequence type
                 self.meta_tree['traces_types', new_dtype, ctx_id, name] = 1
+                self.meta_run_tree['typed_traces', new_trace_type, ctx_id, name] = 1
                 self.meta_run_tree['traces', ctx_id, name, 'dtype'] = new_dtype
                 seq_info.dtype = new_dtype
 
@@ -222,11 +225,13 @@ class RunTracker:
                 raise ValueError(f"Cannot log value '{val}' on sequence '{name}'. Incompatible data types.")
 
         if seq_info.count == 0:
+            trace_type = SEQUENCE_TYPE_MAP.get(dtype, 'sequence')  # use mapping from value type to sequence type
             self.meta_tree['traces_types', dtype, ctx_id, name] = 1
             self.meta_run_tree['traces', ctx_id, name, 'dtype'] = dtype
             self.meta_run_tree['traces', ctx_id, name, 'version'] = seq_info.version
             self.meta_run_tree['traces', ctx_id, name, 'first'] = val
             self.meta_run_tree['traces', ctx_id, name, 'first_step'] = step
+            self.meta_run_tree['typed_traces', trace_type, ctx_id, name] = 1
             seq_info.dtype = dtype
 
         if step >= seq_info.count:

--- a/aim/sdk/tracker.py
+++ b/aim/sdk/tracker.py
@@ -214,7 +214,9 @@ class RunTracker:
 
             def update_trace_dtype(old_dtype: str, new_dtype: str):
                 logger.warning(f"Updating sequence '{name}' data type from {old_dtype} to {new_dtype}.")
-                new_trace_type = SEQUENCE_TYPE_MAP.get(dtype, 'sequence')  # use mapping from value type to sequence type
+                new_trace_type = SEQUENCE_TYPE_MAP.get(
+                    dtype, 'sequence'
+                )  # use mapping from value type to sequence type
                 self.meta_tree['traces_types', new_dtype, ctx_id, name] = 1
                 self.meta_run_tree['typed_traces', new_trace_type, ctx_id, name] = 1
                 self.meta_run_tree['traces', ctx_id, name, 'dtype'] = new_dtype


### PR DESCRIPTION
In order to skip sequences while iterating over them in query context, new mapping has been added. This will improve performance of metric queries in cases when there are many other types of sequences tracked/