### PR TITLE
[feat] PytorchLightning AimLogger custom contexts

### DIFF
--- a/aim/pytorch_lightning.py
+++ b/aim/pytorch_lightning.py
@@ -1,3 +1,2 @@
 # Alias to SDK PyTorch Lightning interface
 from aim.sdk.adapters.pytorch_lightning import AimLogger  # noqa F401
-from aim.sdk.adapters.pytorch_lightning import AimLoggerWithContext  # noqa F401

--- a/aim/pytorch_lightning.py
+++ b/aim/pytorch_lightning.py
@@ -1,2 +1,3 @@
 # Alias to SDK PyTorch Lightning interface
 from aim.sdk.adapters.pytorch_lightning import AimLogger  # noqa F401
+from aim.sdk.adapters.pytorch_lightning import AimLoggerWithContext  # noqa F401

--- a/aim/sdk/adapters/pytorch_lightning.py
+++ b/aim/sdk/adapters/pytorch_lightning.py
@@ -173,3 +173,65 @@ class AimLogger(Logger):
     @property
     def version(self) -> str:
         return self.experiment.hash
+
+
+class AimLoggerWithContext(AimLogger):
+    def __init__(
+        self,
+        repo: Optional[str] = None,
+        experiment: Optional[str] = None,
+        context_prefixes: Optional[Dict] = dict(subset={'train':'train_', 'val':'val_', 'test':'test_'}),
+        context_postfixes: Optional[Dict] = dict(),
+        system_tracking_interval: Optional[int] = DEFAULT_SYSTEM_TRACKING_INT,
+        log_system_params: Optional[bool] = True,
+        capture_terminal_logs: Optional[bool] = True,
+        run_name: Optional[str] = None,
+        run_hash: Optional[str] = None,
+    ):
+        super().__init__()
+        self._experiment_name = experiment
+        self._run_name = run_name
+        self._repo_path = repo
+
+        self._context_prefixes = context_prefixes
+        self._context_postfixes = context_postfixes
+        self._system_tracking_interval = system_tracking_interval
+        self._log_system_params = log_system_params
+        self._capture_terminal_logs = capture_terminal_logs
+
+        self._run = None
+        self._run_hash = run_hash
+
+    @rank_zero_only
+    def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None):
+        assert rank_zero_only.rank == 0, 'experiment tried to log from global_rank != 0'
+
+        metric_items: Dict[str:Any] = {k: v for k, v in metrics.items()}
+
+        if 'epoch' in metric_items:
+            epoch: int = metric_items.pop('epoch')
+        else:
+            epoch = None
+
+        for k, v in metric_items.items():
+            name, context = self.parse_context(k)
+            self.experiment.track(v, name=name, step=step, epoch=epoch, context=context)
+
+    def parse_context(self, name):
+        context = {}
+
+        for ctx, mappings in self._context_prefixes.items():
+            for category, prefix in mappings.items():
+                if name.startswith(prefix):
+                    name = name[len(prefix):]
+                    context[ctx] = category
+                    break  # avoid prefix rename cascade
+
+        for ctx, mappings in self._context_postfixes.items():
+            for category, postfix in mappings.items():
+                if name.endswith(postfix):
+                    name = name[:-len(postfix)]
+                    context[ctx] = category
+                    break  # avoid postfix rename cascade
+
+        return name, context

--- a/docs/source/quick_start/integrations.md
+++ b/docs/source/quick_start/integrations.md
@@ -83,20 +83,40 @@ Step 1. Create `AimLogger` object
 
 ```python
 # track experimental data by using Aim
-aim_logger = AimLogger(
-    experiment='aim_on_pt_lightning',
-    train_metric_prefix='train_',
-    val_metric_prefix='val_',
-)
+aim_logger = AimLogger(repo='path/to/aim/repo', experiment='aim_on_pt_lightning')
 ```
 
 Step 2. Pass the `aim_logger` object as the `logger` argument
-
 
 ```python
 # track experimental data by using Aim
 trainer = Trainer(gpus=1, progress_bar_refresh_rate=20, max_epochs=5, logger=aim_logger)
 ```
+
+#### Managing Aim Contexts
+Aim contexts can be automatically derived from your metric names by defining prefixes and postfixes with the `context_prefixes` and `context_postfixes` kwargs. By default, AimLogger recognizes `train_`, `val_`, and `test_` prefixes and assign metrics with those postfixes to the `subset` context. 
+
+For instance, calling `self.log("val_loss", loss_value)` in a pl.LightningModule instance will log `loss_value` to Aim in a metric called "loss" with the "val" context.
+
+Changing this default and adding new contexts is possible with the following usage:
+```python
+Aimlogger(...,
+    context_prefixes = dict(subset={'train': 'train_',    # the default behavior,
+                                    'val':   'val_',      # shown here as example
+                                    'test':  'test_'}),  
+    contest_postfixes = dict(custom_context={'weighted':'_weighted', # a new, user-defined 
+                                             'macro':   '_macro'},   # metric-averaging context
+)
+```
+
+To remove all default context mapping, do `AimLogger(..., context_prefixes={})`.
+
+If you need more than two contexts per metric, or have other context needs, you can always directly access Aim's tracking capabilities from a pl.LightningModule or pl.Trainer instance with:
+    `instance.logger.experiment.track(value, name=..., context=...)`
+
+For the Pytorch Lightning AimLogger, arguments `train_metric_prefix`, `val_metric_prefix`, `test_metric_prefix` are deprecated but functional. However, using them in conjuncture with `context_prefixes` will raise a ValueError. 
+
+
 Adapter source can be found [here](https://github.com/aimhubio/aim/blob/main/aim/sdk/adapters/pytorch_lightning.py).  
 Example using Pytorch Lightning can be found [here](https://github.com/aimhubio/aim/blob/main/examples/pytorch_lightning_track.py).
 

--- a/examples/pytorch_lightning_track.py
+++ b/examples/pytorch_lightning_track.py
@@ -76,9 +76,6 @@ test_loader = utils.data.DataLoader(test_dataset)
 # create AimLogger and call the fit to start the training
 aim_logger = AimLogger(
     experiment='example_experiment',
-    train_metric_prefix='train_',
-    test_metric_prefix='test_',
-    val_metric_prefix='val_',
 )
 
 


### PR DESCRIPTION
addresses #3259 "PytorchLightning AimLogger custom contexts"

There are two commits. First commit e0dc418 simply adds an AimLoggerWithContext subclass that uses the context configuring mechanism described in the associated Issue. Args `train_metric_prefix`, `val_metric_prefix`, `test_metric_prefix` ("SUBSET_metric_prefixes")  are removed.

The Second commit 15c9da5 is more extensive. It DOESN'T come with AimLoggerWithContext, instead refactoring the regular Lightning AimLogger to use the new context configuring mechanism. Care was taken make sure the changes are totally backwards compatible. SUBSET_metric_prefixes are present and functional but will raise a deprecation warning if input value is not default. 
I also went ahead and updated the documentation for the new schema. 

If the latter is too big a change, feel free to only integrate the first commit.