### PR TITLE
[fix] Message stream parsing (#3297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements:
 - Skip metrics check when run is known to yield false result (alberttorosyan)
 - Correct indentation on query proxy object return statement (alberttorosyan)
+- Fix spurious assertion error in message stream parsing (qzed)
 
 ## 3.27.0 Dec 18, 2024
 

--- a/aim/ext/transport/message_utils.py
+++ b/aim/ext/transport/message_utils.py
@@ -46,22 +46,9 @@ def pack_stream(tree: Iterator[Tuple[bytes, bytes]]) -> bytes:
             yield struct.pack('I', len(key)) + key + struct.pack('?', True) + struct.pack('I', len(val)) + val
 
 
-def unpack_helper(msg: bytes) -> Tuple[bytes, bytes]:
-    (key_size,), tail = struct.unpack('I', msg[:4]), msg[4:]
-    key, tail = tail[:key_size], tail[key_size:]
-    (is_blob,), tail = struct.unpack('?', tail[:1]), tail[1:]
-    (value_size,), tail = struct.unpack('I', tail[:4]), tail[4:]
-    value, tail = tail[:value_size], tail[value_size:]
-    assert len(tail) == 0
-    if is_blob:
-        yield key, BLOB(data=value)
-    else:
-        yield key, value
-
-
 def unpack_stream(stream) -> Tuple[bytes, bytes]:
     for msg in stream:
-        yield from unpack_helper(msg)
+        yield from unpack_args(msg)
 
 
 def raise_exception(server_exception):


### PR DESCRIPTION
The chunks returned by `response.iter_content(chunk_size=None)` can contain multiple messages. However, message parsing currently assumes that these chunks represent individual messages, causing an assertion failure if this is not the case. Fix this by allowing multiple messages to be parsed from a single chunk.

Fixes #3297.

I noticed that `unpack_args()` already supports parsing multiple messages, so I just replaced `unpack_helper()` with that.

This all assumes that chunks contain complete messages and not message parts. I'm not sure if there is an actual guarantee for that, so message parsing may need to be robustified more. But the changes in this PR seem to work for me.

