### PR TITLE
[fix] Aim web ui integration in jupyter/colab

### DIFF
--- a/aim/cli/manager/manager.py
+++ b/aim/cli/manager/manager.py
@@ -34,17 +34,17 @@ def run_up(args):
 
         server_path = 'http://{}:{}{}'.format(args['--host'], args['--port'], args['--base-path'])
         status_api = f'{server_path}/api/projects/'
-        retry_count = 5
-        sleep_interval = 1
+        retry_count = 10
+        sleep_interval = 0.1
         for _ in range(retry_count):
+            time.sleep(sleep_interval)
+            sleep_interval *= 2
             try:
                 response = requests.get(status_api)
                 if response.status_code == 200:
                     return True
             except Exception:
                 pass
-            sleep_interval += 1
-            time.sleep(sleep_interval)
 
         return False
 

--- a/aim/cli/manager/manager.py
+++ b/aim/cli/manager/manager.py
@@ -33,7 +33,7 @@ def run_up(args):
         import requests
 
         server_path = 'http://{}:{}{}'.format(args['--host'], args['--port'], args['--base-path'])
-        status_api = f'{server_path}/api/projects/status'
+        status_api = f'{server_path}/api/projects/'
         retry_count = 5
         sleep_interval = 1
         for _ in range(retry_count):


### PR DESCRIPTION
The PR #2696 added more robust mechanism of initializing aim server, checking the health, and only then enabling the web ui. However, there's no endpoint /projects/status/ now as part of api, so currently aim web ui integration for jupyter always fails.

This PR:
- Relies on status code of /projects endpoint instead
- Removes unnecessary delay in case of failure (for loop always calling sleep even if no tries left)
- Implements delayed retries with exponential backoff, and lets it to wait longer, as some google colab machines are slow and take at least 10-15 seconds to start the aim server.

Possibly addresses #2672 and #3123

Tested on both local jupyter notebooks, and google colab
 