### PR TITLE
Retry also on TimeoutError and WebSocketException in request_queue

### DIFF
--- a/aim/ext/transport/request_queue.py
+++ b/aim/ext/transport/request_queue.py
@@ -63,7 +63,7 @@ class RequestQueue(object):
 
     def _try_exec_task(self, task_f, *args):
         # temporary workaround for M1 build
-        from websockets.exceptions import ConnectionClosedError
+        from websockets.exceptions import WebSocketException
 
         retry = 0
         while retry < self.retry_count:
@@ -79,7 +79,7 @@ class RequestQueue(object):
             try:
                 task_f(*args)
                 return True
-            except (ConnectionClosedError, TimeoutError) as e:
+            except (WebSocketException, TimeoutError) as e:
                 self._needs_reconnect = True
 
                 retry += 1

--- a/aim/ext/transport/request_queue.py
+++ b/aim/ext/transport/request_queue.py
@@ -79,7 +79,7 @@ class RequestQueue(object):
             try:
                 task_f(*args)
                 return True
-            except ConnectionClosedError as e:
+            except (ConnectionClosedError, TimeoutError) as e:
                 self._needs_reconnect = True
 
                 retry += 1


### PR DESCRIPTION
Around 1% of our sessions of writing to our Aim server would fail with an unhandled TimeoutError or WebSocketException in the worker thread, when performing a WebSocket handshake.

This would cause the writing to Aim to hang forever.

This small change, of handling and retrying on TimeoutError and all subclasses of WebSocketException, solved that issue for us.