### PR TITLE
Add GCS artifact storage

### DIFF
--- a/aim/storage/artifacts/artifact_registry.py
+++ b/aim/storage/artifacts/artifact_registry.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Dict, Type
 from urllib.parse import urlparse
 
 from .filesystem_storage import FilesystemArtifactStorage
+from .gcs_storage import GCSArtifactStorage
 from .s3_storage import S3ArtifactStorage
 
 
@@ -30,4 +31,5 @@ class ArtifactStorageRegistry:
 
 registry = ArtifactStorageRegistry()
 registry.register('s3', S3ArtifactStorage)
+registry.register('gs', GCSArtifactStorage)
 registry.register('file', FilesystemArtifactStorage)

--- a/aim/storage/artifacts/gcs_storage.py
+++ b/aim/storage/artifacts/gcs_storage.py
@@ -5,6 +5,14 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_finish
 from typing import Optional
 from urllib.parse import urlparse
+try:
+    from google.cloud import storage
+except ImportError:
+    raise ImportError(
+        'google-cloud-storage is required for GCS artifact storage. '
+        'Install it with: pip install google-cloud-storage'
+    )
+
 
 from aim.ext.cleanup import AutoClean
 
@@ -73,14 +81,6 @@ class GCSArtifactStorage(AbstractArtifactStorage):
         self._futures.remove(future)
 
     def _get_gcs_client(self):
-        try:
-            from google.cloud import storage
-        except ImportError:
-            raise ImportError(
-                'google-cloud-storage is required for GCS artifact storage. '
-                'Install it with: pip install google-cloud-storage'
-            )
-
         client = storage.Client()
         return client
 
@@ -88,14 +88,6 @@ class GCSArtifactStorage(AbstractArtifactStorage):
 def GCSArtifactStorage_factory(**gcs_client_kwargs):
     class GCSArtifactStorageCustom(GCSArtifactStorage):
         def _get_gcs_client(self):
-            try:
-                from google.cloud import storage
-            except ImportError:
-                raise ImportError(
-                    'google-cloud-storage is required for GCS artifact storage. '
-                    'Install it with: pip install google-cloud-storage'
-                )
-
             client = storage.Client(**gcs_client_kwargs)
             return client
 

--- a/aim/storage/artifacts/gcs_storage.py
+++ b/aim/storage/artifacts/gcs_storage.py
@@ -1,0 +1,108 @@
+import pathlib
+import tempfile
+
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait as wait_for_finish
+from typing import Optional
+from urllib.parse import urlparse
+
+from aim.ext.cleanup import AutoClean
+
+from .artifact_storage import AbstractArtifactStorage
+
+
+class GCSArtifactsStorageAutoClean(AutoClean['GCSArtifactStorage']):
+    def __init__(self, instance: 'GCSArtifactStorage') -> None:
+        super().__init__(instance)
+        self._futures = instance._futures
+        self._thread_pool = instance._thread_pool
+
+    def _close(self) -> None:
+        wait_for_finish(self._futures)
+        self._thread_pool.shutdown()
+
+
+class GCSArtifactStorage(AbstractArtifactStorage):
+    def __init__(self, url: str):
+        super().__init__(url)
+        res = urlparse(self.url)
+        path = res.path
+        if path.startswith('/'):
+            path = path[1:]
+        self._bucket_name = res.netloc
+        self._prefix = path
+        self._client = self._get_gcs_client()
+        self._bucket = self._client.bucket(self._bucket_name)
+        self._thread_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix='gcs-upload')
+        self._futures = set()
+        self._resources = GCSArtifactsStorageAutoClean(self)
+
+    def upload_artifact(self, file_path: str, artifact_path: str, block: bool = False):
+        dest_path = pathlib.Path(self._prefix) / artifact_path
+        if block:
+            blob = self._bucket.blob(dest_path.as_posix())
+            blob.upload_from_filename(file_path)
+        else:
+            future = self._thread_pool.submit(self._upload_file, file_path, dest_path.as_posix())
+            future.add_done_callback(self._upload_complete)
+            self._futures.add(future)
+
+    def _upload_file(self, file_path: str, dest_path: str):
+        blob = self._bucket.blob(dest_path)
+        blob.upload_from_filename(file_path)
+
+    def download_artifact(self, artifact_path: str, dest_dir: Optional[str] = None) -> str:
+        if dest_dir is None:
+            dest_dir = pathlib.Path(tempfile.mkdtemp())
+        else:
+            dest_dir = pathlib.Path(dest_dir)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+        source_path = pathlib.Path(self._prefix) / artifact_path
+        dest_path = dest_dir / source_path.name
+        blob = self._bucket.blob(source_path.as_posix())
+        blob.download_to_filename(dest_path.as_posix())
+
+        return dest_path.as_posix()
+
+    def delete_artifact(self, artifact_path: str):
+        path = pathlib.Path(self._prefix) / artifact_path
+        blob = self._bucket.blob(path.as_posix())
+        blob.delete()
+
+    def _upload_complete(self, future):
+        self._futures.remove(future)
+
+    def _get_gcs_client(self):
+        try:
+            from google.cloud import storage
+        except ImportError:
+            raise ImportError(
+                'google-cloud-storage is required for GCS artifact storage. '
+                'Install it with: pip install google-cloud-storage'
+            )
+
+        client = storage.Client()
+        return client
+
+
+def GCSArtifactStorage_factory(**gcs_client_kwargs):
+    class GCSArtifactStorageCustom(GCSArtifactStorage):
+        def _get_gcs_client(self):
+            try:
+                from google.cloud import storage
+            except ImportError:
+                raise ImportError(
+                    'google-cloud-storage is required for GCS artifact storage. '
+                    'Install it with: pip install google-cloud-storage'
+                )
+
+            client = storage.Client(**gcs_client_kwargs)
+            return client
+
+    return GCSArtifactStorageCustom
+
+
+def GCSArtifactStorage_clientconfig(**gcs_client_kwargs):
+    from aim.storage.artifacts import registry
+
+    registry.registry['gs'] = GCSArtifactStorage_factory(**gcs_client_kwargs)

--- a/docs/source/using/artifacts.md
+++ b/docs/source/using/artifacts.md
@@ -18,6 +18,9 @@ run = aim.Run()
 # Use S3 as artifacts storage
 run.set_artifacts_uri('s3://aim/artifacts/')
 
+# Use Google Cloud Storage as artifacts storage
+run.set_artifacts_uri('gs://aim/artifacts/')
+
 # Use file-system as artifacts storage
 run.set_artifacts_uri('file:///home/user/aim/artifacts/')
 ```
@@ -43,6 +46,7 @@ stores, such as AWS S3, may be a better choice.
 When the artifacts URI is set, Aim will detect storage backend based on the URI scheme.
 Currently supported backends for artifacts storage are.
 - S3
+- Google Cloud Storage (GCS)
 - File System
 
 #### S3 Artifacts Storage Backend
@@ -60,6 +64,33 @@ S3ArtifactStorage_clientconfig(aws_access_key_id=..., aws_secret_access_key=...,
                                endpoint_url=..., config={'retries': {...}, },)
 run = aim.Run(...)
 run.set_artifacts_uri('s3://...')
+run.log_artifact(..., name=...)
+```
+
+#### GCS Artifacts Storage Backend
+
+Aim uses `google-cloud-storage` Python package for accessing Google Cloud Storage resources.
+
+Authentication is handled by the `google-cloud-storage` library. A typical way of supplying credentials is by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to a service account key file. Alternatively, if running on Google Cloud infrastructure (GCE, GKE, Cloud Run, etc.), the default service account credentials will be used automatically. More details on how authentication is configured for `google-cloud-storage` is available [here](https://cloud.google.com/docs/authentication/provide-credentials-adc).
+
+Basic usage:
+```python
+import aim
+
+run = aim.Run()
+run.set_artifacts_uri('gs://my-bucket/artifacts/')
+run.log_artifact('model.pt', name='model-checkpoint')
+```
+
+If you require direct control of how the GCS client is configured, you may use `aim.storage.artifacts.gcs_storage.GCSArtifactStorage_clientconfig(...)`. `GCSArtifactStorage_clientconfig` accepts any keyword-arguments that the `google.cloud.storage.Client` accepts, allowing you to specify custom project, credentials, or other configuration options.
+
+```python
+import aim
+from aim.storage.artifacts.gcs_storage import GCSArtifactStorage_clientconfig
+
+GCSArtifactStorage_clientconfig(project='my-project', credentials=...)
+run = aim.Run(...)
+run.set_artifacts_uri('gs://...')
 run.log_artifact(..., name=...)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ REQUIRED = [
     'watchdog',
     'websockets',
     'boto3',
+    'google-cloud-storage',
 ]
 
 if sys.version_info.minor < 9:

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -130,7 +130,7 @@ class TestGCSArtifactStorage(unittest.TestCase):
 
         self.assertTrue(result.endswith('artifact.txt'))
         # Should be in a temp directory
-        self.assertIn('tmp', result.lower()) or self.assertIn('temp', result.lower())
+        self.assertIn('tmp', result.lower()) is None or self.assertIn('temp', result.lower()) is None
 
     @patch('aim.storage.artifacts.gcs_storage.storage')
     def test_delete_artifact(self, mock_storage):
@@ -169,9 +169,8 @@ class TestGCSArtifactStorage(unittest.TestCase):
             from aim.storage.artifacts import gcs_storage
             import importlib
 
-            importlib.reload(gcs_storage)
-
             with self.assertRaises(ImportError) as context:
+                importlib.reload(gcs_storage)
                 gcs_storage.GCSArtifactStorage('gs://my-bucket/artifacts')
 
             self.assertIn('google-cloud-storage', str(context.exception))

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -1,0 +1,438 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+
+class TestGCSArtifactStorage(unittest.TestCase):
+    """Tests for GCS Artifact Storage backend."""
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_gcs_storage_initialization(self, mock_storage):
+        """Test GCS storage is properly initialized from URL."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        storage = GCSArtifactStorage('gs://my-bucket/path/to/artifacts')
+
+        self.assertEqual(storage._bucket_name, 'my-bucket')
+        self.assertEqual(storage._prefix, 'path/to/artifacts')
+        mock_storage.Client.assert_called_once()
+        mock_client.bucket.assert_called_once_with('my-bucket')
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_gcs_storage_initialization_no_prefix(self, mock_storage):
+        """Test GCS storage with no path prefix."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        storage = GCSArtifactStorage('gs://my-bucket/')
+
+        self.assertEqual(storage._bucket_name, 'my-bucket')
+        self.assertEqual(storage._prefix, '')
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_upload_artifact_blocking(self, mock_storage):
+        """Test blocking upload of artifact to GCS."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        storage = GCSArtifactStorage('gs://my-bucket/artifacts')
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b'test content')
+            temp_file = f.name
+
+        try:
+            storage.upload_artifact(temp_file, 'test/artifact.txt', block=True)
+
+            mock_bucket.blob.assert_called_with('artifacts/test/artifact.txt')
+            mock_blob.upload_from_filename.assert_called_once_with(temp_file)
+        finally:
+            os.unlink(temp_file)
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_upload_artifact_non_blocking(self, mock_storage):
+        """Test non-blocking upload submits to thread pool."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        storage = GCSArtifactStorage('gs://my-bucket/artifacts')
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b'test content')
+            temp_file = f.name
+
+        try:
+            storage.upload_artifact(temp_file, 'test/artifact.txt', block=False)
+            # Wait for thread pool to complete
+            storage._resources._close()
+
+            mock_bucket.blob.assert_called_with('artifacts/test/artifact.txt')
+            mock_blob.upload_from_filename.assert_called_once_with(temp_file)
+        finally:
+            os.unlink(temp_file)
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_download_artifact(self, mock_storage):
+        """Test downloading artifact from GCS."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        storage = GCSArtifactStorage('gs://my-bucket/artifacts')
+
+        with tempfile.TemporaryDirectory() as dest_dir:
+            result = storage.download_artifact('test/artifact.txt', dest_dir)
+
+            mock_bucket.blob.assert_called_with('artifacts/test/artifact.txt')
+            self.assertTrue(result.endswith('artifact.txt'))
+            mock_blob.download_to_filename.assert_called_once()
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_download_artifact_no_dest_dir(self, mock_storage):
+        """Test downloading artifact creates temp directory when dest_dir is None."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        storage = GCSArtifactStorage('gs://my-bucket/artifacts')
+
+        result = storage.download_artifact('test/artifact.txt')
+
+        self.assertTrue(result.endswith('artifact.txt'))
+        # Should be in a temp directory
+        self.assertIn('tmp', result.lower()) or self.assertIn('temp', result.lower())
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_delete_artifact(self, mock_storage):
+        """Test deleting artifact from GCS."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
+        storage = GCSArtifactStorage('gs://my-bucket/artifacts')
+        storage.delete_artifact('test/artifact.txt')
+
+        mock_bucket.blob.assert_called_with('artifacts/test/artifact.txt')
+        mock_blob.delete.assert_called_once()
+
+    def test_gcs_import_error(self):
+        """Test proper error message when google-cloud-storage is not installed."""
+        import sys
+
+        # Save reference to the actual module if it exists
+        saved_module = sys.modules.get('google.cloud.storage')
+        saved_google = sys.modules.get('google')
+        saved_google_cloud = sys.modules.get('google.cloud')
+
+        # Remove the modules to simulate not being installed
+        sys.modules['google.cloud.storage'] = None
+        sys.modules['google.cloud'] = None
+        sys.modules['google'] = None
+
+        try:
+            # Need to reimport the module to trigger the ImportError
+            from aim.storage.artifacts import gcs_storage
+            import importlib
+
+            importlib.reload(gcs_storage)
+
+            with self.assertRaises(ImportError) as context:
+                gcs_storage.GCSArtifactStorage('gs://my-bucket/artifacts')
+
+            self.assertIn('google-cloud-storage', str(context.exception))
+            self.assertIn('pip install', str(context.exception))
+        finally:
+            # Restore the modules
+            if saved_module is not None:
+                sys.modules['google.cloud.storage'] = saved_module
+            else:
+                sys.modules.pop('google.cloud.storage', None)
+            if saved_google_cloud is not None:
+                sys.modules['google.cloud'] = saved_google_cloud
+            else:
+                sys.modules.pop('google.cloud', None)
+            if saved_google is not None:
+                sys.modules['google'] = saved_google
+            else:
+                sys.modules.pop('google', None)
+
+
+class TestGCSArtifactStorageFactory(unittest.TestCase):
+    """Tests for GCS Artifact Storage factory functions."""
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_gcs_storage_factory(self, mock_storage):
+        """Test factory creates custom storage class with kwargs."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage_factory
+
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        CustomStorage = GCSArtifactStorage_factory(project='my-project', credentials='my-creds')
+        storage = CustomStorage('gs://my-bucket/artifacts')
+
+        mock_storage.Client.assert_called_once_with(project='my-project', credentials='my-creds')
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_gcs_storage_clientconfig(self, mock_storage):
+        """Test clientconfig registers custom storage in registry."""
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage_clientconfig
+        from aim.storage.artifacts import registry
+
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        # Store original
+        original_gs = registry.registry.get('gs')
+
+        try:
+            GCSArtifactStorage_clientconfig(project='custom-project')
+
+            # Verify the registry was updated
+            self.assertIn('gs', registry.registry)
+            self.assertNotEqual(registry.registry['gs'], original_gs)
+
+            # Create instance and verify kwargs are passed
+            custom_storage = registry.registry['gs']('gs://my-bucket/artifacts')
+            mock_storage.Client.assert_called_with(project='custom-project')
+        finally:
+            # Restore original
+            if original_gs is not None:
+                registry.registry['gs'] = original_gs
+
+
+class TestS3ArtifactStorage(unittest.TestCase):
+    """Tests for S3 Artifact Storage backend."""
+
+    @patch('boto3.client')
+    def test_s3_storage_initialization(self, mock_boto3_client):
+        """Test S3 storage is properly initialized from URL."""
+        from aim.storage.artifacts.s3_storage import S3ArtifactStorage
+
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        storage = S3ArtifactStorage('s3://my-bucket/path/to/artifacts')
+
+        self.assertEqual(storage._bucket, 'my-bucket')
+        self.assertEqual(storage._prefix, 'path/to/artifacts')
+        mock_boto3_client.assert_called_once_with('s3')
+
+    @patch('boto3.client')
+    def test_upload_artifact_blocking(self, mock_boto3_client):
+        """Test blocking upload of artifact to S3."""
+        from aim.storage.artifacts.s3_storage import S3ArtifactStorage
+
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        storage = S3ArtifactStorage('s3://my-bucket/artifacts')
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b'test content')
+            temp_file = f.name
+
+        try:
+            storage.upload_artifact(temp_file, 'test/artifact.txt', block=True)
+
+            mock_client.upload_file.assert_called_once_with(
+                Filename=temp_file, Bucket='my-bucket', Key='artifacts/test/artifact.txt'
+            )
+        finally:
+            os.unlink(temp_file)
+
+    @patch('boto3.client')
+    def test_download_artifact(self, mock_boto3_client):
+        """Test downloading artifact from S3."""
+        from aim.storage.artifacts.s3_storage import S3ArtifactStorage
+
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        storage = S3ArtifactStorage('s3://my-bucket/artifacts')
+
+        with tempfile.TemporaryDirectory() as dest_dir:
+            result = storage.download_artifact('test/artifact.txt', dest_dir)
+
+            self.assertTrue(result.endswith('artifact.txt'))
+            mock_client.download_file.assert_called_once()
+
+    @patch('boto3.client')
+    def test_delete_artifact(self, mock_boto3_client):
+        """Test deleting artifact from S3."""
+        from aim.storage.artifacts.s3_storage import S3ArtifactStorage
+
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        storage = S3ArtifactStorage('s3://my-bucket/artifacts')
+        storage.delete_artifact('test/artifact.txt')
+
+        mock_client.delete_object.assert_called_once_with(Bucket='my-bucket', Key='artifacts/test/artifact.txt')
+
+
+class TestFilesystemArtifactStorage(unittest.TestCase):
+    """Tests for Filesystem Artifact Storage backend."""
+
+    def test_filesystem_storage_initialization(self):
+        """Test filesystem storage is properly initialized from URL."""
+        from aim.storage.artifacts.filesystem_storage import FilesystemArtifactStorage
+
+        storage = FilesystemArtifactStorage('file:///tmp/artifacts')
+
+        self.assertEqual(storage._prefix, '/tmp/artifacts')
+
+    def test_upload_artifact(self):
+        """Test uploading artifact to filesystem."""
+        from aim.storage.artifacts.filesystem_storage import FilesystemArtifactStorage
+
+        with tempfile.TemporaryDirectory() as storage_dir:
+            storage = FilesystemArtifactStorage(f'file://{storage_dir}')
+
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                f.write(b'test content')
+                temp_file = f.name
+
+            try:
+                storage.upload_artifact(temp_file, 'test/artifact.txt')
+
+                dest_path = Path(storage_dir) / 'test' / 'artifact.txt'
+                self.assertTrue(dest_path.exists())
+                self.assertEqual(dest_path.read_bytes(), b'test content')
+            finally:
+                os.unlink(temp_file)
+
+    def test_download_artifact(self):
+        """Test downloading artifact from filesystem."""
+        from aim.storage.artifacts.filesystem_storage import FilesystemArtifactStorage
+
+        with tempfile.TemporaryDirectory() as storage_dir:
+            storage = FilesystemArtifactStorage(f'file://{storage_dir}')
+
+            # Create artifact in storage
+            artifact_dir = Path(storage_dir) / 'test'
+            artifact_dir.mkdir(parents=True)
+            artifact_path = artifact_dir / 'artifact.txt'
+            artifact_path.write_bytes(b'test content')
+
+            with tempfile.TemporaryDirectory() as dest_dir:
+                result = storage.download_artifact('test/artifact.txt', dest_dir)
+
+                self.assertTrue(result.endswith('artifact.txt'))
+                self.assertEqual(Path(result).read_bytes(), b'test content')
+
+    def test_delete_artifact(self):
+        """Test deleting artifact from filesystem."""
+        from aim.storage.artifacts.filesystem_storage import FilesystemArtifactStorage
+
+        with tempfile.TemporaryDirectory() as storage_dir:
+            storage = FilesystemArtifactStorage(f'file://{storage_dir}')
+
+            # Create artifact in storage
+            artifact_dir = Path(storage_dir) / 'test'
+            artifact_dir.mkdir(parents=True)
+            artifact_path = artifact_dir / 'artifact.txt'
+            artifact_path.write_bytes(b'test content')
+
+            storage.delete_artifact('test')
+
+            self.assertFalse(artifact_dir.exists())
+
+
+class TestArtifactStorageRegistry(unittest.TestCase):
+    """Tests for Artifact Storage Registry."""
+
+    def test_registry_has_expected_backends(self):
+        """Test registry contains all expected storage backends."""
+        from aim.storage.artifacts import registry
+
+        self.assertIn('s3', registry.registry)
+        self.assertIn('gs', registry.registry)
+        self.assertIn('file', registry.registry)
+
+    def test_get_storage_s3(self):
+        """Test getting S3 storage from registry."""
+        from aim.storage.artifacts import registry
+        from aim.storage.artifacts.s3_storage import S3ArtifactStorage
+
+        with patch('boto3.client'):
+            storage = registry.get_storage('s3://my-bucket/artifacts')
+            self.assertIsInstance(storage, S3ArtifactStorage)
+
+    @patch('aim.storage.artifacts.gcs_storage.storage')
+    def test_get_storage_gcs(self, mock_storage):
+        """Test getting GCS storage from registry."""
+        from aim.storage.artifacts import registry
+        from aim.storage.artifacts.gcs_storage import GCSArtifactStorage
+
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        # Clear the LRU cache to avoid cached values
+        registry.get_storage.cache_clear()
+
+        storage = registry.get_storage('gs://my-bucket/artifacts')
+        self.assertIsInstance(storage, GCSArtifactStorage)
+
+    def test_get_storage_file(self):
+        """Test getting filesystem storage from registry."""
+        from aim.storage.artifacts import registry
+        from aim.storage.artifacts.filesystem_storage import FilesystemArtifactStorage
+
+        # Clear the LRU cache to avoid cached values
+        registry.get_storage.cache_clear()
+
+        storage = registry.get_storage('file:///tmp/artifacts')
+        self.assertIsInstance(storage, FilesystemArtifactStorage)
+
+    def test_unsupported_scheme(self):
+        """Test error for unsupported storage scheme."""
+        from aim.storage.artifacts import registry
+
+        # Clear the LRU cache
+        registry.get_storage.cache_clear()
+
+        with self.assertRaises(ValueError) as context:
+            registry.get_storage('unsupported://bucket/path')
+
+        self.assertIn('unsupported', str(context.exception))
+        self.assertIn('not supported', str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add support for storing artifacts in Google Cloud Storage (GCS) buckets.

This works just fine for me. Disclaimer: the solution is vibe coded. It mostly replicates the already existing S3 solution.

What is different is that I `import google.cloud` on the top level. Mostly because I could not get the mock in the tests to work when importing it in the `GCSArtifactStore. _get_gcs_client` function. However, since `google-cloud-storage` is added to the top-level dependencies of the package - as is `boto3` - this shouldn't be a problem at this point (i.e. until `s3` and `gcs` are made into "extras").

Closes #3391 