### PR TITLE
fix(ui): guard explorer selectors on slow networks

### DIFF
--- a/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/ImagesExplore/components/SelectForm/SelectForm.tsx
@@ -47,6 +47,10 @@ function SelectForm({
   const autocompleteRef: any = React.useRef<React.MutableRefObject<any>>(null);
   const advancedAutocompleteRef: any =
     React.useRef<React.MutableRefObject<any>>(null);
+
+  // Guard against the user opening the selector before options are loaded (slow network).
+  const isSelectDataReady = Array.isArray(selectFormData?.options);
+  const isImagesSelectorDisabled = isDisabled || !isSelectDataReady;
   React.useEffect(() => {
     return () => {
       searchMetricsRef.current?.abort();
@@ -115,6 +119,9 @@ function SelectForm({
   }
 
   function handleClick(event: React.ChangeEvent<any>) {
+    if (isImagesSelectorDisabled) {
+      return;
+    }
     setAnchorEl(event.currentTarget);
   }
 
@@ -167,7 +174,7 @@ function SelectForm({
                   <AutocompleteInput
                     advanced
                     refObject={advancedAutocompleteRef}
-                    context={selectFormData?.advancedSuggestions}
+                    context={selectFormData?.advancedSuggestions ?? {}}
                     value={selectedImagesData?.advancedQuery}
                     error={selectFormData?.advancedError}
                     onEnter={handleSearch}
@@ -177,16 +184,26 @@ function SelectForm({
               ) : (
                 <ErrorBoundary>
                   <Box display='flex' alignItems='center'>
-                    <Button
-                      variant='contained'
-                      color='primary'
-                      onClick={handleClick}
-                      aria-describedby={id}
-                      disabled={isDisabled}
+                    <Tooltip
+                      title={
+                        isImagesSelectorDisabled && !isDisabled
+                          ? 'Loading…'
+                          : ''
+                      }
                     >
-                      <Icon name='plus' style={{ marginRight: '0.5rem' }} />
-                      Images
-                    </Button>
+                      <div>
+                        <Button
+                          variant='contained'
+                          color='primary'
+                          onClick={handleClick}
+                          aria-describedby={id}
+                          disabled={isImagesSelectorDisabled}
+                        >
+                          <Icon name='plus' style={{ marginRight: '0.5rem' }} />
+                          Images
+                        </Button>
+                      </div>
+                    </Tooltip>
                     <Popper
                       id={id}
                       open={open}
@@ -304,7 +321,7 @@ function SelectForm({
               <div className='SelectForm__TextField'>
                 <AutocompleteInput
                   refObject={autocompleteRef}
-                  context={selectFormData?.suggestions}
+                  context={selectFormData?.suggestions ?? {}}
                   value={selectedImagesData?.query}
                   error={selectFormData?.error}
                   onEnter={handleSearch}

--- a/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/Metrics/components/SelectForm/SelectForm.tsx
@@ -46,6 +46,11 @@ function SelectForm({
   const autocompleteRef: any = React.useRef<React.MutableRefObject<any>>(null);
   const advancedAutocompleteRef: any =
     React.useRef<React.MutableRefObject<any>>(null);
+
+  // On slow networks it's possible for the user to click the selector before
+  // the explorer context/options are loaded. Guard against that state.
+  const isSelectDataReady = Array.isArray(selectFormData?.options);
+  const isMetricSelectorDisabled = isDisabled || !isSelectDataReady;
   React.useEffect(() => {
     return () => {
       searchRef.current?.abort();
@@ -106,6 +111,9 @@ function SelectForm({
   }
 
   function handleClick(event: React.ChangeEvent<any>) {
+    if (isMetricSelectorDisabled) {
+      return;
+    }
     setAnchorEl(event.currentTarget);
   }
 
@@ -156,9 +164,9 @@ function SelectForm({
               <div className='Metrics__SelectForm__textarea'>
                 <AutocompleteInput
                   advanced
-                  error={selectFormData.advancedError}
+                  error={selectFormData?.advancedError}
                   refObject={advancedAutocompleteRef}
-                  context={selectFormData?.advancedSuggestions}
+                  context={selectFormData?.advancedSuggestions ?? {}}
                   value={selectedMetricsData?.advancedQuery}
                   onEnter={handleMetricSearch}
                   disabled={isDisabled}
@@ -167,16 +175,24 @@ function SelectForm({
             ) : (
               <>
                 <Box display='flex' alignItems='center'>
-                  <Button
-                    variant='contained'
-                    color='primary'
-                    onClick={handleClick}
-                    aria-describedby={id}
-                    disabled={isDisabled}
+                  <Tooltip
+                    title={
+                      isMetricSelectorDisabled && !isDisabled ? 'Loading…' : ''
+                    }
                   >
-                    <Icon name='plus' style={{ marginRight: '0.5rem' }} />
-                    Metrics
-                  </Button>
+                    <div>
+                      <Button
+                        variant='contained'
+                        color='primary'
+                        onClick={handleClick}
+                        aria-describedby={id}
+                        disabled={isMetricSelectorDisabled}
+                      >
+                        <Icon name='plus' style={{ marginRight: '0.5rem' }} />
+                        Metrics
+                      </Button>
+                    </div>
+                  </Tooltip>
                   <Popper
                     id={id}
                     open={open}
@@ -292,9 +308,9 @@ function SelectForm({
             <div className='Metrics__SelectForm__TextField'>
               <AutocompleteInput
                 refObject={autocompleteRef}
-                error={selectFormData.error}
+                error={selectFormData?.error}
                 value={selectedMetricsData?.query}
-                context={selectFormData.suggestions}
+                context={selectFormData?.suggestions ?? {}}
                 onEnter={handleMetricSearch}
                 disabled={isDisabled}
               />

--- a/aim/web/ui/src/pages/Params/components/SelectForm/SelectForm.tsx
+++ b/aim/web/ui/src/pages/Params/components/SelectForm/SelectForm.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { Box, Checkbox, Divider, InputBase, Popper } from '@material-ui/core';
+import {
+  Box,
+  Checkbox,
+  Divider,
+  InputBase,
+  Popper,
+  Tooltip,
+} from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import {
   CheckBox as CheckBoxIcon,
@@ -34,6 +41,10 @@ function SelectForm({
   const [searchValue, setSearchValue] = React.useState<string>('');
   const searchRef = React.useRef<any>(null);
   const autocompleteRef: any = React.useRef<React.MutableRefObject<any>>(null);
+
+  // Guard against the user opening the selector before options are loaded (slow network).
+  const isSelectDataReady = Array.isArray(selectFormData?.options);
+  const isParamsSelectorDisabled = isDisabled || !isSelectDataReady;
   React.useEffect(() => {
     return () => {
       searchRef.current?.abort();
@@ -86,6 +97,9 @@ function SelectForm({
   }
 
   function handleClick(event: React.ChangeEvent<any>) {
+    if (isParamsSelectorDisabled) {
+      return;
+    }
     setAnchorEl(event.currentTarget);
   }
 
@@ -131,16 +145,24 @@ function SelectForm({
             >
               <ErrorBoundary>
                 <Box display='flex' alignItems='center'>
-                  <Button
-                    variant='contained'
-                    color='primary'
-                    onClick={handleClick}
-                    aria-describedby={id}
-                    disabled={isDisabled}
+                  <Tooltip
+                    title={
+                      isParamsSelectorDisabled && !isDisabled ? 'Loading…' : ''
+                    }
                   >
-                    <Icon name='plus' style={{ marginRight: '0.5rem' }} /> Run
-                    Params
-                  </Button>
+                    <div>
+                      <Button
+                        variant='contained'
+                        color='primary'
+                        onClick={handleClick}
+                        aria-describedby={id}
+                        disabled={isParamsSelectorDisabled}
+                      >
+                        <Icon name='plus' style={{ marginRight: '0.5rem' }} />
+                        Run Params
+                      </Button>
+                    </div>
+                  </Tooltip>
                   <Popper
                     id={id}
                     open={open}
@@ -278,7 +300,7 @@ function SelectForm({
           <div className='SelectForm__TextField'>
             <AutocompleteInput
               refObject={autocompleteRef}
-              context={selectFormData?.suggestions}
+              context={selectFormData?.suggestions ?? {}}
               error={selectFormData?.error}
               onEnter={handleParamsSearch}
               value={selectedParamsData?.query}


### PR DESCRIPTION
Fixes the issue where clicking explorer selector buttons (e.g. +Metrics/+Params/+Images) immediately after page load on a slow network can lead to an error state.

Changes:
- Guard selector button click until `selectFormData.options` is available.
- Disable the selector button and show a "Loading…" tooltip when options aren't ready.
- Use safe defaults for suggestions to avoid undefined access during initial load.

Tested:
- Local Aim UI (`aim up`) with artificial fetch latency and verified selectors remain stable.
- `npx eslint` on modified files.

Closes #1574.
