### PR TITLE
Fix: prevent IndexError in list_corrupted_runs for empty prefix

### DIFF
--- a/aim/sdk/repo.py
+++ b/aim/sdk/repo.py
@@ -397,10 +397,13 @@ class Repo:
         from aim.storage.encoding import decode_path
 
         def get_run_hash_from_prefix(prefix: bytes):
-            return decode_path(prefix)[-1]
+            path = decode_path(prefix)
+            if not path:
+                return None
+            return path[-1]
 
         container = RocksUnionContainer(os.path.join(self.path, 'meta'), read_only=True)
-        return list(map(get_run_hash_from_prefix, container.corrupted_dbs))
+        return [h for h in map(get_run_hash_from_prefix, container.corrupted_dbs) if h is not None]
 
     def _active_run_hashes(self) -> Set[str]:
         if self.is_remote_repo:


### PR DESCRIPTION
## Summary
Fixes a crash in `list_corrupted_runs()` when processing corrupted databases with empty prefixes.

## Bug
- **Issue**: #3390
- **Error**: `IndexError: list index out of range`
- **Cause**: `decode_path(prefix)` returns empty list `[]` when prefix is `b""`, and accessing `[-1]` on empty list crashes

## Fix
- Add check for empty path in `get_run_hash_from_prefix`
- Return `None` for empty paths and filter them out
- Prevents crash when corrupted DB has empty prefix entries

## Testing
This fix handles the edge case where corrupted_dbs contains entries with empty byte string prefixes.

<a href='https://ko-fi.com/J3J61X38VA' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>