### PR TITLE
[feat] Set Aim user-agent on the S3 artifacts storage client

### DIFF
--- a/aim/storage/artifacts/s3_storage.py
+++ b/aim/storage/artifacts/s3_storage.py
@@ -11,6 +11,28 @@ from aim.ext.cleanup import AutoClean
 from .artifact_storage import AbstractArtifactStorage
 
 
+def _build_client_kwargs(boto3_client_kwargs):
+    """Append the Aim user-agent token to the S3 client's botocore config.
+
+    Any caller-provided endpoint_url, config, and user_agent_extra are kept; the
+    aim/<version> token is appended so the client works with any S3-compatible endpoint.
+    """
+    import botocore.config
+
+    from aim.__version__ import __version__
+
+    kwargs = dict(boto3_client_kwargs)
+    config = kwargs.get('config')
+    if isinstance(config, dict):
+        config = botocore.config.Config(**config)
+    aim_user_agent = f'aim/{__version__}'
+    if config is not None and config.user_agent_extra:
+        aim_user_agent = f'{config.user_agent_extra} {aim_user_agent}'
+    user_agent_config = botocore.config.Config(user_agent_extra=aim_user_agent)
+    kwargs['config'] = config.merge(user_agent_config) if config is not None else user_agent_config
+    return kwargs
+
+
 class S3ArtifactsStorageAutoClean(AutoClean['S3ArtifactStorage']):
     def __init__(self, instance: 'S3ArtifactStorage') -> None:
         super().__init__(instance)
@@ -69,21 +91,15 @@ class S3ArtifactStorage(AbstractArtifactStorage):
     def _get_s3_client(self):
         import boto3
 
-        client = boto3.client('s3')
-        return client
+        return boto3.client('s3', **_build_client_kwargs({}))
 
 
 def S3ArtifactStorage_factory(**boto3_client_kwargs):
     class S3ArtifactStorageCustom(S3ArtifactStorage):
         def _get_s3_client(self):
             import boto3
-            import botocore
 
-            if 'config' in boto3_client_kwargs and isinstance(boto3_client_kwargs['config'], dict):
-                config_kwargs = boto3_client_kwargs.pop('config')
-                boto3_client_kwargs['config'] = botocore.config.Config(**config_kwargs)
-            client = boto3.client('s3', **boto3_client_kwargs)
-            return client
+            return boto3.client('s3', **_build_client_kwargs(boto3_client_kwargs))
 
     return S3ArtifactStorageCustom
 

--- a/docs/source/using/artifacts.md
+++ b/docs/source/using/artifacts.md
@@ -63,6 +63,8 @@ run.set_artifacts_uri('s3://...')
 run.log_artifact(..., name=...)
 ```
 
+Because `endpoint_url` is passed straight through to `boto3`, the same backend works with any S3-compatible object store, such as Amazon S3, Backblaze B2, Cloudflare R2, or MinIO. Set `endpoint_url` to your provider's endpoint (for example `https://your-s3-endpoint.example.com`) and keep using the `s3://` URI scheme.
+
 #### File-system Artifacts Storage Backend
 
 Aim provides ability to use mounted FS as an artifact storage. Any kind of storage that provides a mounted FS


### PR DESCRIPTION
`S3ArtifactStorage._get_s3_client()` creates its boto3 client without any botocore config, so artifact traffic coming from Aim is indistinguishable from any other boto3 request on the storage side. This appends an `aim/<version>` token to the client's `user_agent_extra`, which makes Aim requests identifiable in server-side access logs. Nothing about request semantics changes.

The `S3ArtifactStorage_factory` path keeps its current behavior: a caller-supplied `endpoint_url` is still forwarded straight to boto3, a `config` passed as a dict is still turned into `botocore.config.Config`, and an existing `user_agent_extra` is preserved with the Aim token appended instead of overwritten. The kwargs dict is now copied before being modified, so repeated client creation no longer mutates the factory closure.

The second commit adds one line to `docs/source/using/artifacts.md` noting that, because `endpoint_url` is forwarded to boto3, the same backend works against any S3-compatible object store (Amazon S3, Backblaze B2, Cloudflare R2, MinIO). The example uses a placeholder endpoint.

There are no existing unit tests around the artifacts storage clients, so none are added here. Happy to add one asserting the resulting `user_agent_extra` if you would like coverage, and happy to open an issue first if you prefer to discuss the approach before review.
