### PR TITLE
fix: replace pkg_resources in system parameter logging

### DIFF
--- a/aim/ext/utils.py
+++ b/aim/ext/utils.py
@@ -1,5 +1,8 @@
 import logging
+import re
 import subprocess
+
+from functools import lru_cache
 
 from fastapi.responses import JSONResponse
 
@@ -7,12 +10,43 @@ from fastapi.responses import JSONResponse
 logger = logging.getLogger(__name__)
 
 
+def _get_installed_distributions():
+    try:
+        from importlib import metadata as metadata_module
+    except ImportError:
+        import importlib_metadata as metadata_module  # Python 3.7 support
+
+    return metadata_module.distributions()
+
+
+# Installed distributions normally do not change while the current Python process is running.
+@lru_cache(maxsize=1)
+def _collect_installed_package_versions():
+    installed_package_versions = {}
+
+    for installed_distribution in _get_installed_distributions():
+        distribution_metadata = installed_distribution.metadata
+        package_name = distribution_metadata.get('Name')
+        package_version = distribution_metadata.get('Version')
+
+        if not package_name or not package_version:
+            continue
+
+        # Preserve the normalized key format previously provided by pkg_resources.
+        normalized_package_name = re.sub(
+            r'[^A-Za-z0-9.]+',
+            '-',
+            package_name,
+        ).lower()
+
+        installed_package_versions.setdefault(normalized_package_name, package_version)
+
+    return installed_package_versions
+
+
 def get_installed_packages():
-    import pkg_resources
-
-    packages = {i.key: i.version for i in pkg_resources.working_set}
-
-    return packages
+    # Return a copy so callers cannot modify the cached package information.
+    return _collect_installed_package_versions().copy()
 
 
 def get_environment_variables():

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ REQUIRED = [
     'uvicorn<1,>=0.12.0',
     'Pillow>=8.0.0',
     'packaging>=15.0',
+    'importlib-metadata<6.8; python_version < "3.8"',
     'python-dateutil',
     'requests',
     'watchdog',

--- a/tests/ext/test_utils.py
+++ b/tests/ext/test_utils.py
@@ -1,0 +1,31 @@
+import unittest
+
+from types import SimpleNamespace
+from unittest import mock
+
+from aim.ext import utils
+
+
+class TestInstalledPackages(unittest.TestCase):
+    def setUp(self):
+        utils._collect_installed_package_versions.cache_clear()
+
+    def tearDown(self):
+        utils._collect_installed_package_versions.cache_clear()
+
+    @mock.patch('aim.ext.utils._get_installed_distributions')
+    def test_get_installed_packages(self, mock_installed_distributions):
+        mock_installed_distributions.return_value = [
+            SimpleNamespace(metadata={'Name': 'Example_Package', 'Version': '1.2.3'}),
+            SimpleNamespace(metadata={'Version': '2.0.0'}),
+            SimpleNamespace(metadata={'Name': 'missing-version'}),
+        ]
+
+        packages = utils.get_installed_packages()
+        packages['changed-by-caller'] = '1.0'
+
+        self.assertEqual(
+            {'example-package': '1.2.3'},
+            utils.get_installed_packages(),
+        )
+        mock_installed_distributions.assert_called_once_with()


### PR DESCRIPTION
## Summary

- replace `pkg_resources.working_set` with `importlib.metadata`
- use the `importlib-metadata` backport on Python 3.7
- preserve the previous normalized package-key format
- cache installed-package discovery and return independent copies
- add regression coverage for incomplete metadata and cached results

## Motivation

`get_installed_packages()` is used when `log_system_params=True`. Its current use of the deprecated `pkg_resources` module can fail when that module is not available.

## Testing

- `ruff check aim/ext/utils.py setup.py tests/ext/test_utils.py`
- `ruff format aim/ext/utils.py setup.py tests/ext/test_utils.py --check`
- `pytest tests/ext/test_utils.py tests/sdk/test_run_creation_checks.py -v`

Result: 3 tests passed. The reported SQLAlchemy warnings are pre-existing and unrelated to this change.